### PR TITLE
A few small fixes

### DIFF
--- a/pair_symmetrix/pair_symmetrix_mace_kokkos.cpp
+++ b/pair_symmetrix/pair_symmetrix_mace_kokkos.cpp
@@ -53,8 +53,8 @@ PairSymmetrixMACEKokkos<DeviceType>::PairSymmetrixMACEKokkos(LAMMPS *lmp)
   reverse_comm_device = 1;
   atomKK = (AtomKokkos *) atom;
   execution_space = ExecutionSpaceFromDevice<DeviceType>::space;
-  //datamask_read = EMPTY_MASK;
-  //datamask_modify = EMPTY_MASK;
+  datamask_read = EMPTY_MASK;
+  datamask_modify = F_MASK; // TODO: Add all the other masks here!
   //host_flag = (execution_space == Host);
 }
 
@@ -876,7 +876,7 @@ void PairSymmetrixMACEKokkos<DeviceType>::compute_no_mpi_message_passing(int efl
   const double r_cut_squared = mace->r_cut*mace->r_cut;
 
   // locate ghosts within r_cut of locals
-  auto is_local = Kokkos::Bitset(list->inum+list->gnum);
+  auto is_local = Kokkos::Bitset(atom->nlocal+atom->nghost);
   Kokkos::parallel_for("fill is_local",
     list->inum,
     KOKKOS_LAMBDA (const int ii) {
@@ -884,7 +884,7 @@ void PairSymmetrixMACEKokkos<DeviceType>::compute_no_mpi_message_passing(int efl
       is_local.set(i);
     });
   Kokkos::fence();
-  auto is_ghost = Kokkos::Bitset(list->inum+list->gnum);
+  auto is_ghost = Kokkos::Bitset(atom->nlocal+atom->nghost);
   Kokkos::parallel_for("fill is_ghost",
     Kokkos::TeamPolicy<>(list->inum, Kokkos::AUTO),
     KOKKOS_LAMBDA (Kokkos::TeamPolicy<>::member_type team_member) {

--- a/symmetrix/utilities/create_symmetrix_mace.py
+++ b/symmetrix/utilities/create_symmetrix_mace.py
@@ -46,7 +46,10 @@ output['L_max'] = L_max
 ### ----- ATOMIC NUMBERS AND ENERGIES -----
 
 atomic_numbers = sorted([int(i) for i in sys.argv[2:]])
-atomic_energies = [ 
+if model.atomic_energies_fn.atomic_energies.squeeze().ndim == 0:
+    atomic_energies = [model.atomic_energies_fn.atomic_energies.squeeze().item()]
+else:
+    atomic_energies = [ 
     model.atomic_energies_fn.atomic_energies.squeeze()[model.atomic_numbers.tolist().index(a)].item()
         + model.scale_shift.shift.item()
     for a in atomic_numbers]


### PR DESCRIPTION
This pull request collects small fixes targeted at three things:

- **pair_symmetrix_mace_kokkos.cpp** Adding a correct set of masks for datamask_modify such that an atomKK->sync(Host) call used elsewhere would work correctly.
- **pair_symmetrix_mace_kokkos.cpp** Small changes to bitmask length allocation. The bitmask entries correspond to `i` values rather than `ii` values and therefore should have length atom->nlocal + atom->nghost rather than list->inum + list->gnum
- **create_symmetrix_mace.py** Fixed bug which would cause error converting a single species MACE; `model.atomic_energies_fn.atomic_energies.squeeze()` would be reduced to a 0 dimensional tensor that could not be indexed.