### PR TITLE
Allow all types of lammps 'atom_modify map ...'

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,7 @@ jobs:
     - name: Clone and build LAMMPS
       run: |
         source venv/bin/activate
-        git clone -b release https://github.com/lammps/lammps.git
+        git clone -b release --depth 1 https://github.com/lammps/lammps.git
         cd pair_symmetrix
         chmod +x install.sh
         ./install.sh ../lammps

--- a/pair_symmetrix/pair_symmetrix_mace.cpp
+++ b/pair_symmetrix/pair_symmetrix_mace.cpp
@@ -169,7 +169,7 @@ double PairSymmetrixMACE::init_one(int i, int j)
 
 void PairSymmetrixMACE::init_style()
 {
-  if (atom->map_user != atom->MAP_YES) error->all(FLERR, "symmetrix/mace requires \'atom_modify map yes\'");
+  if (atom->map_user == atom->MAP_NONE) error->all(FLERR, "symmetrix/mace requires \'atom_modify map [yes|array|hash]\'");
   if (force->newton_pair == 0) error->all(FLERR, "symmetrix/mace requires newton pair on");
 
   if (mode == "mpi_message_passing") {

--- a/symmetrix/test/test_lammpslib.py
+++ b/symmetrix/test/test_lammpslib.py
@@ -1,0 +1,101 @@
+import pytest
+
+import numpy as np
+
+from ase.atoms import Atoms
+
+try:
+    from symmetrix import Symmetrix
+except ModuleNotFoundError as exc:
+    if "No module named 'symmetrix.symmetrix'" in str(exc):
+        raise RuntimeError("Can't import symmetrix.symmetrix, probably need to run pytest in venv "
+                "and install version to be tested with "
+                "'(cd /path/to/repo && python3 -m pip install -e .)'") from exc
+    else:
+        raise
+
+try:
+    import lammps
+except ImportError:
+    pytest.skip("No lammps python package available", allow_module_level=True)
+from ase.calculators.lammpslib import LAMMPSlib
+
+
+def test_lammpslib_map(symmetrix_mace_mp0b3_1_8):
+    rng = np.random.default_rng(3)
+
+    calc_symmetrix = Symmetrix(symmetrix_mace_mp0b3_1_8)
+    species = ["H", "O"]
+
+    for map_type in [None, "yes", "array", "hash"]:
+        lammpslib_kwargs = dict(lmpcmds = [ "pair_style    symmetrix/mace",
+                                           f"pair_coeff    * * {symmetrix_mace_mp0b3_1_8}     " + " ".join(species)],
+                                   atom_types = {sp: sp_i+1 for sp_i, sp in enumerate(species)},
+                                   lammps_header = ['units metal', 'atom_style atomic', 'atom_modify sort 0 0'])
+        if map_type is None:
+            calc_lammpslib = LAMMPSlib(**lammpslib_kwargs)
+            atoms = Atoms('OH', cell=[4, 2, 2], positions=[[0, 0, 0], [2, 0, 0]], pbc=[True] * 3)
+            atoms.calc = calc_lammpslib
+            with pytest.raises(Exception):
+                _ = atoms.get_potential_energy()
+            continue
+
+        lammpslib_kwargs['lammps_header'].append("atom_modify map " + map_type)
+
+        compare_lammpslib_symmetrix(calc_symmetrix, lammpslib_kwargs)
+
+
+def test_lammpslib_default_header(symmetrix_mace_mp0b3_1_8):
+    rng = np.random.default_rng(3)
+
+    calc_symmetrix = Symmetrix(symmetrix_mace_mp0b3_1_8)
+    species = ["H", "O"]
+
+    # use default lammps_header, should do "atom_modify map array sort 0 0"
+    lammpslib_kwargs = dict(lmpcmds = [ "pair_style    symmetrix/mace",
+                                       f"pair_coeff    * * {symmetrix_mace_mp0b3_1_8}     " + " ".join(species)],
+                               atom_types = {sp: sp_i+1 for sp_i, sp in enumerate(species)})
+
+    compare_lammpslib_symmetrix(calc_symmetrix, lammpslib_kwargs)
+
+    # confirm that without "atom_modify sort 0 0" it fails
+    lammpslib_kwargs = dict(lmpcmds = [ "pair_style    symmetrix/mace",
+                                       f"pair_coeff    * * {symmetrix_mace_mp0b3_1_8}     " + " ".join(species)],
+                               atom_types = {sp: sp_i+1 for sp_i, sp in enumerate(species)},
+                               lammps_header = ['units metal', 'atom_style atomic', 'atom_modify map yes'])
+
+    with pytest.raises(AssertionError):
+        compare_lammpslib_symmetrix(calc_symmetrix, lammpslib_kwargs)
+
+
+def compare_lammpslib_symmetrix(calc_symmetrix, lammpslib_kwargs):
+        calc_lammpslib = LAMMPSlib(**lammpslib_kwargs)
+
+        atoms_list = []
+        for n1 in range(4, 2, -1): # when size gets smaller over different calls LAMMPSlib fails without 'sort 0 0'
+            for n2 in range(2, 4):
+                atoms = Atoms('OH', cell=[4, 2, 2], positions=[[0, 0, 0], [2, 0, 0]], pbc=[True] * 3)
+                atoms *= (1, n1 + 1, n2 + 1)
+                rng = np.random.default_rng(5)
+                atoms.rattle(rng=rng)
+
+                rng.shuffle(atoms.numbers)
+                atoms_list.append(atoms)
+
+        E_lammpslib = []
+        F_lammpslib = []
+        for atoms in atoms_list:
+            atoms.calc = calc_lammpslib
+            E_lammpslib.append(atoms.get_potential_energy())
+            F_lammpslib.append(atoms.get_forces())
+
+        E_symmetrix = []
+        F_symmetrix = []
+        for atoms in atoms_list:
+            atoms.calc = calc_symmetrix
+            E_symmetrix.append(atoms.get_potential_energy())
+            F_symmetrix.append(atoms.get_forces())
+
+        assert np.allclose(E_symmetrix, E_lammpslib)
+        for F_s, F_l in zip(F_symmetrix, F_lammpslib):
+            assert np.allclose(F_s, F_l, rtol=1e-2)


### PR DESCRIPTION
Allow `map array` and `map hash` as well as `map yes` (in particular for better compatibility with ASE `LAMMPSlib` default header).

Test that lammpslib results are correct with all such choices, including ASE default.

closes #47 