### PR TITLE
Adding LAMMPS computes for MACE descriptors and descriptor gradients.

### DIFF
--- a/libsymmetrix/source/mace.cpp
+++ b/libsymmetrix/source/mace.cpp
@@ -1021,6 +1021,10 @@ void MACE::load_from_json(
     // Readouts
     // TODO! hardcoded 16
     readout_1_weights = file["readout_1_weights"].get<std::vector<double>>();
+    linear_up_l0_inv = file["linear_up_l0_inv"].get<std::vector<double>>();
+    if (static_cast<int>(linear_up_l0_inv.size()) != num_channels * num_channels) {
+        throw std::runtime_error("linear_up_l0_inv has wrong size");
+    }
     auto readout_2_weights_1 = file["readout_2_weights_1"].get<std::vector<double>>();
     auto readout_2_weights_2 = file["readout_2_weights_2"].get<std::vector<double>>();
     readout_2 = std::make_unique<MultilayerPerceptron>(

--- a/libsymmetrix/source/mace.hpp
+++ b/libsymmetrix/source/mace.hpp
@@ -1,3 +1,5 @@
+#ifndef MACE_HPP_INCLUDED
+#define MACE_HPP_INCLUDED
 #include <memory>
 #include <string>
 #include <vector>
@@ -167,3 +169,4 @@ void compute_readouts(const int num_nodes, std::span<const int> node_types);
 void load_from_json(std::string filename);
 
 };
+#endif

--- a/libsymmetrix/source/mace.hpp
+++ b/libsymmetrix/source/mace.hpp
@@ -162,6 +162,7 @@ void reverse_H2(const int num_nodes, std::span<const int> node_types, bool zero_
 
 // Readouts
 std::vector<double> readout_1_weights;
+std::vector<double> linear_up_l0_inv;
 std::unique_ptr<MultilayerPerceptron> readout_2;
 void compute_readouts(const int num_nodes, std::span<const int> node_types);
 

--- a/libsymmetrix/source/mace_kokkos.hpp
+++ b/libsymmetrix/source/mace_kokkos.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <memory>
 #include <string>
 #include <vector>

--- a/pair_symmetrix/compute_symmetrix_mace_atom.cpp
+++ b/pair_symmetrix/compute_symmetrix_mace_atom.cpp
@@ -1,0 +1,242 @@
+#include "compute_symmetrix_mace_atom.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "domain.h"
+#include "error.h"
+#include "memory.h"
+#include "neighbor.h"
+#include "neigh_list.h"
+#include "neigh_request.h"
+#include "update.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include "mace.hpp"
+
+using namespace LAMMPS_NS;
+
+ComputeSymmetrixMACEatom::ComputeSymmetrixMACEatom(LAMMPS *lmp, int narg, char **arg)
+  : Compute(lmp, narg, arg)
+{
+  if (narg < 4) error->all(FLERR, "Illegal compute symmetrix/mace/atom command");
+
+  // arg[3] = model.json, arg[4..] = element symbol per LAMMPS type
+  const std::string model_file = arg[3];
+  utils::logmesg(lmp, "Loading MACE model from \'{}\' ... ", arg[3]);
+  mace = std::make_unique<MACE>(model_file);
+
+  num_channels = mace->num_channels;
+  std::cout<<"num channels "<<num_channels<<std::endl;
+  num_LM = mace->num_LM;
+  std::cout<<"num LM "<<num_LM<<std::endl;
+  r_cut = mace->r_cut;
+
+  // compute outputs a per-atom ARRAY with num_channels columns (output is invariant features of final layer)
+  peratom_flag = 1;
+  size_peratom_cols = num_channels;
+
+  // only do forward comm of H1 for descriptors
+  comm_forward = num_LM * num_channels;
+  comm_reverse = 0;
+
+  // build mapping from LAMMPS types to MACE types
+  const int ntypes = atom->ntypes;
+  if (narg != 4 + ntypes)
+    error->all(FLERR, "compute symmetrix/mace/atom requires one element symbol per LAMMPS atom type");
+
+  mace_types.clear();
+  mace_types.reserve(ntypes);
+
+  for (int itype = 1; itype <= ntypes; ++itype) {
+    const char *elem = arg[3 + itype];
+
+    auto iter1 = std::find(periodic_table.begin(), periodic_table.end(), elem);
+    if (iter1 == periodic_table.end())
+      error->all(FLERR, "Element does not appear in periodic table");
+
+    const int atomic_number = static_cast<int>(std::distance(periodic_table.begin(), iter1)) + 1;
+
+    auto iter2 = std::find(mace->atomic_numbers.begin(), mace->atomic_numbers.end(), atomic_number);
+    if (iter2 == mace->atomic_numbers.end())
+      error->all(FLERR, "Problem matching LAMMPS types to MACE types");
+
+    const int mace_index = static_cast<int>(std::distance(mace->atomic_numbers.begin(), iter2));
+    mace_types.push_back(mace_index);
+  }
+}
+
+ComputeSymmetrixMACEatom::~ComputeSymmetrixMACEatom()
+{
+  if (array_atom) memory->destroy(array_atom);
+}
+
+void ComputeSymmetrixMACEatom::init()
+{
+  if (atom->map_user == atom->MAP_NONE)
+    error->all(FLERR, "symmetrix/mace/atom requires 'atom_modify map yes|array|hash'");
+
+  // same as the pair's mpi_message_passing mode: request full neighbor list
+  auto *req = neighbor->add_request(this, NeighConst::REQ_FULL | NeighConst::REQ_GHOST);
+  req->set_cutoff(r_cut);
+  std::cout<<"set cutoff to "<< r_cut <<std::endl;
+}
+
+void ComputeSymmetrixMACEatom::init_list(int /*id*/, NeighList *ptr)
+{
+  list = ptr;
+}
+
+int ComputeSymmetrixMACEatom::pack_forward_comm(int n, int *list_in, double *buf,
+                                              int /*pbc_flag*/, int * /*pbc*/)
+{
+  const int stride = num_LM * num_channels;
+  for (int ii = 0; ii < n; ++ii) {
+    const int i = list_in[ii];
+    const double *src = H1_comm.data() + i * stride;
+    double *dst = buf + ii * stride;
+    for (int k = 0; k < stride; ++k) dst[k] = src[k];
+  }
+  return n * stride;
+}
+
+void ComputeSymmetrixMACEatom::unpack_forward_comm(int n, int first, double *buf)
+{
+  const int stride = num_LM * num_channels;
+  for (int i = 0; i < n; ++i) {
+    double *dst = H1_comm.data() + (first + i) * stride;
+    const double *src = buf + i * stride;
+    for (int k = 0; k < stride; ++k) dst[k] = src[k];
+  }
+}
+
+void ComputeSymmetrixMACEatom::build_graph_from_neighlist(int &num_nodes, int &num_edges)
+{
+  const double r_cut_sq = r_cut * r_cut;
+
+  // count edges
+  num_edges = 0;
+  for (int ii = 0; ii < list->inum; ++ii) {
+    const int i = list->ilist[ii];
+    const double x_i = atom->x[i][0];
+    const double y_i = atom->x[i][1];
+    const double z_i = atom->x[i][2];
+    int *jlist = list->firstneigh[i];
+
+    for (int jj = 0; jj < list->numneigh[i]; ++jj) {
+      const int j = (jlist[jj] & NEIGHMASK);
+      const double dx = atom->x[j][0] - x_i;
+      const double dy = atom->x[j][1] - y_i;
+      const double dz = atom->x[j][2] - z_i;
+      const double rsq = dx*dx + dy*dy + dz*dz;
+      if (rsq < r_cut_sq) num_edges += 1;
+    }
+  }
+
+  // resize vectors
+  num_nodes = list->inum;
+  node_types.resize(num_nodes);
+  num_neigh.resize(num_nodes);
+  neigh_types.resize(num_edges);
+  xyz.resize(3 * num_edges);
+  r.resize(num_edges);
+  node_i.resize(num_nodes);
+  neigh_j.resize(num_edges);
+
+  // populate neighbor list variables
+  int ij = 0;
+  for (int ii = 0; ii < list->inum; ++ii) {
+    const int i = list->ilist[ii];
+    node_i[ii] = i;
+    node_types[ii] = mace_types[atom->type[i] - 1];
+
+    const double x_i = atom->x[i][0];
+    const double y_i = atom->x[i][1];
+    const double z_i = atom->x[i][2];
+
+    int *jlist = list->firstneigh[i];
+    num_neigh[ii] = 0;
+
+    for (int jj = 0; jj < list->numneigh[i]; ++jj) {
+      const int j = (jlist[jj] & NEIGHMASK);
+
+      const double dx = atom->x[j][0] - x_i;
+      const double dy = atom->x[j][1] - y_i;
+      const double dz = atom->x[j][2] - z_i;
+      const double rsq = dx*dx + dy*dy + dz*dz;
+
+      if (rsq < r_cut_sq) {
+        num_neigh[ii] += 1;
+        neigh_j[ij] = j;
+        neigh_types[ij] = mace_types[atom->type[j] - 1];
+        xyz[3*ij + 0] = dx;
+        xyz[3*ij + 1] = dy;
+        xyz[3*ij + 2] = dz;
+        r[ij] = std::sqrt(rsq);
+        ij += 1;
+      }
+    }
+  }
+}
+
+void ComputeSymmetrixMACEatom::compute_peratom()
+{
+  invoked_peratom = update->ntimestep;
+  if (!list) error->all(FLERR, "Neighbour list not initialised for compute symmetrix/mace/atom");
+
+  // allocate output: [nmax][num_channels]
+  if (atom->nmax > nmax) {
+    if (array_atom) memory->destroy(array_atom);
+    nmax = atom->nmax;
+    memory->create(array_atom, nmax, size_peratom_cols, "symmetrix/mace/atom:array_atom");
+  }
+
+  // initialise per-atom output to 0.0 for atoms not in group (LAMMPS convention)
+  for (int i = 0; i < atom->nlocal; ++i) {
+    for (int k = 0; k < num_channels; ++k) array_atom[i][k] = 0.0;
+  }
+
+  int num_nodes = 0, num_edges = 0;
+  build_graph_from_neighlist(num_nodes, num_edges);
+
+  // ---- begin MACE forward pass ----
+
+  mace->compute_Y(xyz);
+  mace->compute_R0(num_nodes, node_types, num_neigh, neigh_types, r);
+  mace->compute_A0(num_nodes, node_types, num_neigh, neigh_types);
+  mace->compute_A0_scaled(num_nodes, node_types, num_neigh, neigh_types, r);
+  mace->compute_M0(num_nodes, node_types);
+  mace->compute_H1(num_nodes);
+
+  const int stride = num_LM * num_channels;
+  H1_comm.assign((atom->nlocal + atom->nghost) * stride, 0.0);
+
+  for (int ii = 0; ii < num_nodes; ++ii) {
+    const int i = node_i[ii];
+    const double *src = mace->H1.data() + ii * stride;
+    double *dst = H1_comm.data() + i * stride;
+    for (int k = 0; k < stride; ++k) dst[k] = src[k];
+  }
+
+  comm->forward_comm(this);
+  mace->H1 = H1_comm;
+
+  mace->compute_R1(num_nodes, node_types, num_neigh, neigh_types, r);
+  mace->compute_Phi1(num_nodes, num_neigh, neigh_j);
+  mace->compute_A1(num_nodes);
+  mace->compute_A1_scaled(num_nodes, node_types, num_neigh, neigh_types, r);
+  mace->compute_M1(num_nodes, node_types);
+  mace->compute_H2(num_nodes, node_types);
+
+  // copy H2 (ii-indexed) to per-atom array (atom-indexed) for owned atoms in the compute group
+  for (int ii = 0; ii < num_nodes; ++ii) {
+    const int i = node_i[ii];
+    if (i < atom->nlocal && (atom->mask[i] & groupbit)) {
+      const double *src = mace->H2.data() + ii * num_channels;
+      for (int k = 0; k < num_channels; ++k){
+        array_atom[i][k] = src[k];
+      }
+    }
+  }
+}

--- a/pair_symmetrix/compute_symmetrix_mace_atom.cpp
+++ b/pair_symmetrix/compute_symmetrix_mace_atom.cpp
@@ -28,9 +28,7 @@ ComputeSymmetrixMACEatom::ComputeSymmetrixMACEatom(LAMMPS *lmp, int narg, char *
   mace = std::make_unique<MACE>(model_file);
 
   num_channels = mace->num_channels;
-  std::cout<<"num channels "<<num_channels<<std::endl;
   num_LM = mace->num_LM;
-  std::cout<<"num LM "<<num_LM<<std::endl;
   r_cut = mace->r_cut;
 
   // compute outputs a per-atom ARRAY with num_channels columns (output is invariant features of final layer)
@@ -80,7 +78,6 @@ void ComputeSymmetrixMACEatom::init()
   // same as the pair's mpi_message_passing mode: request full neighbor list
   auto *req = neighbor->add_request(this, NeighConst::REQ_FULL | NeighConst::REQ_GHOST);
   req->set_cutoff(r_cut);
-  std::cout<<"set cutoff to "<< r_cut <<std::endl;
 }
 
 void ComputeSymmetrixMACEatom::init_list(int /*id*/, NeighList *ptr)

--- a/pair_symmetrix/compute_symmetrix_mace_atom.h
+++ b/pair_symmetrix/compute_symmetrix_mace_atom.h
@@ -1,0 +1,71 @@
+#ifdef COMPUTE_CLASS
+// clang-format off
+ComputeStyle(symmetrix/mace/atom,ComputeSymmetrixMACEatom)
+// clang-format on
+#else
+
+#ifndef LMP_COMPUTE_SYMMETRIX_MACE_ATOM_H
+#define LMP_COMPUTE_SYMMETRIX_MACE_ATOM_H
+
+#include "compute.h"
+#include <unordered_map>
+#include "mace.hpp"
+
+class MACE;
+
+namespace LAMMPS_NS {
+
+class ComputeSymmetrixMACEatom : public Compute {
+ public:
+  ComputeSymmetrixMACEatom(class LAMMPS *, int, char **);
+  ~ComputeSymmetrixMACEatom() override;
+
+  void init() override;
+  void init_list(int, class NeighList *) override;
+  void compute_peratom() override;
+
+  int pack_forward_comm(int n, int *list, double *buf,
+                        int pbc_flag, int *pbc) override;
+  void unpack_forward_comm(int n, int first, double *buf) override;
+
+ private:
+  class NeighList *list = nullptr;
+
+  std::unique_ptr<MACE> mace;
+
+  std::vector<int> mace_types;
+
+  std::vector<int> node_types;
+  std::vector<int> num_neigh;
+  std::vector<int> neigh_types;
+  std::vector<int> node_i;      
+  std::vector<int> neigh_j;     
+  std::vector<double> xyz;     
+  std::vector<double> r;       
+
+  std::vector<double> H1_comm;
+
+  int num_channels = 0;
+  int num_LM = 0;
+  double r_cut = 0.0;
+  int nmax = 0;
+
+  void build_graph_from_neighlist(int &num_nodes, int &num_edges);
+
+  const std::array<std::string,118> periodic_table =
+    { "H", "He",
+        "Li", "Be",                                                              "B",  "C",  "N",  "O",  "F", "Ne",
+        "Na", "Mg",                                                             "Al", "Si",  "P",  "S", "Cl", "Ar",
+        "K",  "Ca", "Sc", "Ti",  "V", "Cr", "Mn", "Fe", "Co", "Ni", "Cu", "Zn", "Ga", "Ge", "As", "Se", "Br", "Kr",
+        "Rb", "Sr",  "Y", "Zr", "Nb", "Mo", "Tc", "Ru", "Rh", "Pd", "Ag", "Cd", "In", "Sn", "Sb", "Te",  "I", "Xe",
+        "Cs", "Ba", "La", "Ce", "Pr", "Nd", "Pm", "Sm", "Eu", "Gd", "Tb", "Dy", "Ho", "Er", "Tm", "Yb", "Lu",
+                        "Hf", "Ta",  "W", "Re", "Os", "Ir", "Pt", "Au", "Hg", "Tl", "Pb", "Bi", "Po", "At", "Rn",
+        "Fr", "Ra", "Ac", "Th", "Pa",  "U", "Np", "Pu", "Am", "Cm", "Bk", "Cf", "Es", "Fm", "Md", "No", "Lr",
+                        "Rf", "Db", "Sg", "Bh", "Hs", "Mt", "Ds", "Rg", "Cn", "Nh", "Fl", "Mc", "Lv", "Ts", "Og"};
+
+};
+
+}  // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/pair_symmetrix/compute_symmetrix_mace_atom_kokkos.cpp
+++ b/pair_symmetrix/compute_symmetrix_mace_atom_kokkos.cpp
@@ -42,7 +42,7 @@ ComputeSymmetrixMACEatomKokkos<DeviceType, Precision>::ComputeSymmetrixMACEatomK
   kokkosable = 1;
   atomKK = (AtomKokkos *) atom;
   execution_space = ExecutionSpaceFromDevice<DeviceType>::space;
-  datamask_read = X_MASK | TYPE_MASK | TAG_MASK;
+  datamask_read = X_MASK | TYPE_MASK | TAG_MASK | MASK_MASK;
   datamask_modify = EMPTY_MASK;
 
   const std::string model_file = arg[3];
@@ -233,8 +233,6 @@ void ComputeSymmetrixMACEatomKokkos<DeviceType, Precision>::compute_peratom()
   auto d_array_atom = k_array_atom.template view<DeviceType>();
   Kokkos::deep_copy(d_array_atom, 0.0);
 
-  // Assumes group "all" (matches every current caller in skmd/lammps_setup.py)
-  // -- unlike the CPU compute, no per-atom groupbit check is applied.
   if (mode == "no_domain_decomposition")
     compute_no_domain_decomposition(num_nodes);
   else
@@ -257,10 +255,11 @@ void ComputeSymmetrixMACEatomKokkos<DeviceType, Precision>::compute_no_domain_de
   auto d_neighbors = k_list->d_neighbors;
   auto d_ilist = k_list->d_ilist;
 
-  atomKK->sync(execution_space, X_MASK | TYPE_MASK | TAG_MASK);
+  atomKK->sync(execution_space, X_MASK | TYPE_MASK | TAG_MASK | MASK_MASK);
   auto x = atomKK->k_x.view<DeviceType>();
   auto tag = atomKK->k_tag.view<DeviceType>();
   auto type = atomKK->k_type.view<DeviceType>();
+  auto mask = atomKK->k_mask.view<DeviceType>();
 
   auto map_style = atom->map_style;
   auto k_map_array = atomKK->k_map_array;
@@ -374,10 +373,12 @@ void ComputeSymmetrixMACEatomKokkos<DeviceType, Precision>::compute_no_domain_de
   const auto mace_H1 = mace->H1;
   const auto mace_H2 = mace->H2;
   const auto num_channels = this->num_channels;
+  const auto groupbit = this->groupbit;
   Kokkos::parallel_for(
       "ComputeSymmetrixMACEatomKokkos::extract_descriptors", num_nodes,
       KOKKOS_LAMBDA(const int ii) {
         const int i = node_indices(ii);
+        if (!(mask(i) & groupbit)) return;
         for (int row = 0; row < num_channels; ++row) {
           double s = 0.0;
           for (int col = 0; col < num_channels; ++col)
@@ -401,9 +402,10 @@ void ComputeSymmetrixMACEatomKokkos<DeviceType, Precision>::compute_mpi_message_
   auto d_neighbors = k_list->d_neighbors;
   auto d_ilist = k_list->d_ilist;
 
-  atomKK->sync(execution_space, X_MASK | TYPE_MASK);
+  atomKK->sync(execution_space, X_MASK | TYPE_MASK | MASK_MASK);
   auto x = atomKK->k_x.view<DeviceType>();
   auto type = atomKK->k_type.view<DeviceType>();
+  auto mask = atomKK->k_mask.view<DeviceType>();
 
   if (node_indices.size() < num_nodes) Kokkos::realloc(node_indices, num_nodes);
   if (node_types.size() < num_nodes) Kokkos::realloc(node_types, num_nodes);
@@ -525,10 +527,12 @@ void ComputeSymmetrixMACEatomKokkos<DeviceType, Precision>::compute_mpi_message_
   const auto H1_atom_indexed = this->H1;
   const auto mace_H2 = mace->H2;
   const auto num_channels_out = this->num_channels;
+  const auto groupbit = this->groupbit;
   Kokkos::parallel_for(
       "ComputeSymmetrixMACEatomKokkos::extract_descriptors_mpi", num_nodes,
       KOKKOS_LAMBDA(const int ii) {
         const int i = node_indices(ii);
+        if (!(mask(i) & groupbit)) return;
         for (int row = 0; row < num_channels_out; ++row) {
           double s = 0.0;
           for (int col = 0; col < num_channels_out; ++col)

--- a/pair_symmetrix/compute_symmetrix_mace_atom_kokkos.cpp
+++ b/pair_symmetrix/compute_symmetrix_mace_atom_kokkos.cpp
@@ -1,0 +1,549 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "compute_symmetrix_mace_atom_kokkos.h"
+
+#include "atom_kokkos.h"
+#include "atom_masks.h"
+#include "comm.h"
+#include "error.h"
+#include "memory_kokkos.h"
+#include "neigh_list_kokkos.h"
+#include "neigh_request.h"
+#include "neighbor.h"
+#include "update.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include "mace.hpp"    // transient CPU MACE, only to read linear_up_l0_inv
+
+using namespace LAMMPS_NS;
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType, typename Precision>
+ComputeSymmetrixMACEatomKokkos<DeviceType, Precision>::ComputeSymmetrixMACEatomKokkos(
+    LAMMPS *lmp, int narg, char **arg) :
+  Compute(lmp, narg, arg)
+{
+  if (narg < 4) error->all(FLERR, "Illegal compute symmetrix/mace/atom/kk command");
+
+  kokkosable = 1;
+  atomKK = (AtomKokkos *) atom;
+  execution_space = ExecutionSpaceFromDevice<DeviceType>::space;
+  datamask_read = X_MASK | TYPE_MASK | TAG_MASK;
+  datamask_modify = EMPTY_MASK;
+
+  const std::string model_file = arg[3];
+  utils::logmesg(lmp, "Loading MACEKokkos model from '{}' ... ", model_file);
+  mace = std::make_unique<MACEKokkos<Precision>>(model_file);
+  utils::logmesg(lmp, "success\n");
+
+  num_channels = mace->num_channels;
+  num_LM = mace->num_LM;
+  r_cut = mace->r_cut;
+
+  // linear_up_l0_inv (the l=0 invariant "restoration" matrix) is baked
+  // into the model JSON but isn't exposed by MACEKokkos -- it's only
+  // needed for descriptors, not the energies/forces MACEKokkos was built
+  // for. Load it via a transient CPU MACE instance (the same dependency
+  // the plain CPU compute already uses) rather than a new direct JSON
+  // parsing path here.
+  {
+    MACE mace_cpu(model_file);
+    if (mace_cpu.num_channels != num_channels)
+      error->all(FLERR, "MACE/MACEKokkos num_channels mismatch loading '{}'", model_file);
+    linear_up_l0_inv = Kokkos::View<double **>(
+        "compute_symmetrix_mace_atom_kokkos:linear_up_l0_inv", num_channels, num_channels);
+    auto h_linear_up_l0_inv = Kokkos::create_mirror_view(linear_up_l0_inv);
+    for (int row = 0; row < num_channels; ++row)
+      for (int col = 0; col < num_channels; ++col)
+        h_linear_up_l0_inv(row, col) = mace_cpu.linear_up_l0_inv[row * num_channels + col];
+    Kokkos::deep_copy(linear_up_l0_inv, h_linear_up_l0_inv);
+  }
+
+  // compute outputs a per-atom ARRAY with num_channels columns (output is
+  // invariant features of final layer)
+  peratom_flag = 1;
+  size_peratom_cols = 2 * num_channels;
+
+  // Mirrors pair_symmetrix_mace_kokkos::settings(): forward-comm only
+  // matters (and is only correct) with more than one MPI rank -- with a
+  // single rank every neighbor (including periodic-image ghosts) maps
+  // straight back to its owning local atom via the atom map, so H1 never
+  // needs to leave the device at all. See compute_no_domain_decomposition.
+  mode = (comm->nprocs == 1) ? "no_domain_decomposition" : "mpi_message_passing";
+  comm_forward = (mode == "mpi_message_passing") ? num_LM * num_channels : 0;
+  comm_reverse = 0;
+
+  // build mapping from LAMMPS types to MACE types
+  const int ntypes = atom->ntypes;
+  if (narg != 4 + ntypes)
+    error->all(FLERR, "compute symmetrix/mace/atom/kk requires one element symbol per LAMMPS atom type");
+
+  mace_types = Kokkos::View<int *>("compute_symmetrix_mace_atom_kokkos:mace_types", ntypes);
+  auto h_mace_types = Kokkos::create_mirror_view(mace_types);
+  auto h_mace_atomic_numbers =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), mace->atomic_numbers);
+
+  for (int itype = 1; itype <= ntypes; ++itype) {
+    const char *elem = arg[3 + itype];
+
+    auto iter1 = std::find(periodic_table.begin(), periodic_table.end(), elem);
+    if (iter1 == periodic_table.end())
+      error->all(FLERR, "Element does not appear in periodic table");
+    const int atomic_number = static_cast<int>(std::distance(periodic_table.begin(), iter1)) + 1;
+
+    int mace_index = -1;
+    for (int j = 0; j < (int) mace->atomic_numbers.size(); ++j)
+      if (h_mace_atomic_numbers(j) == atomic_number) mace_index = j;
+    if (mace_index == -1)
+      error->all(FLERR, "Problem matching LAMMPS types to MACE types");
+
+    h_mace_types(itype - 1) = mace_index;
+  }
+  Kokkos::deep_copy(mace_types, h_mace_types);
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType, typename Precision>
+ComputeSymmetrixMACEatomKokkos<DeviceType, Precision>::~ComputeSymmetrixMACEatomKokkos()
+{
+  if (copymode) return;
+  memoryKK->destroy_kokkos(k_array_atom, array_atom);
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType, typename Precision>
+void ComputeSymmetrixMACEatomKokkos<DeviceType, Precision>::init()
+{
+  if (atom->map_user == atom->MAP_NONE)
+    error->all(FLERR, "symmetrix/mace/atom/kk requires 'atom_modify map yes|array|hash'");
+
+  auto request = neighbor->add_request(this, NeighConst::REQ_FULL);
+  request->set_cutoff(r_cut);
+  request->set_kokkos_host(std::is_same_v<DeviceType, LMPHostType> &&
+                            !std::is_same_v<DeviceType, LMPDeviceType>);
+  request->set_kokkos_device(std::is_same_v<DeviceType, LMPDeviceType>);
+}
+
+template<class DeviceType, typename Precision>
+void ComputeSymmetrixMACEatomKokkos<DeviceType, Precision>::init_list(int /*id*/, NeighList *ptr)
+{
+  list = ptr;
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType, typename Precision>
+int ComputeSymmetrixMACEatomKokkos<DeviceType, Precision>::pack_forward_comm(
+    int n, int *list_in, double *buf, int /*pbc_flag*/, int * /*pbc*/)
+{
+  auto h_H1 = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), H1);
+  for (int ii = 0; ii < n; ++ii) {
+    const int i = list_in[ii];
+    for (int LM = 0; LM < num_LM; ++LM)
+      for (int k = 0; k < num_channels; ++k)
+        buf[ii * num_LM * num_channels + LM * num_channels + k] = h_H1(i, LM, k);
+  }
+  return n * num_LM * num_channels;
+}
+
+template<class DeviceType, typename Precision>
+int ComputeSymmetrixMACEatomKokkos<DeviceType, Precision>::pack_forward_comm_kokkos(
+    int n, DAT::tdual_int_1d k_sendlist, DAT::tdual_double_1d &buf, int /*pbc_flag*/, int * /*pbc*/)
+{
+  const auto d_sendlist = k_sendlist.view<DeviceType>();
+  auto d_buf = buf.view<DeviceType>();
+  const auto H1 = this->H1;
+  const auto num_channels = this->num_channels;
+  const auto num_LM = this->num_LM;
+  Kokkos::parallel_for(
+      "ComputeSymmetrixMACEatomKokkos::pack_forward_comm_kokkos",
+      Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0, 0, 0}, {n, num_LM, num_channels}),
+      KOKKOS_LAMBDA(const int ii, const int LM, const int k) {
+        const int i = d_sendlist(ii);
+        d_buf(ii * num_LM * num_channels + LM * num_channels + k) = H1(i, LM, k);
+      });
+  Kokkos::fence();
+  return n * num_LM * num_channels;
+}
+
+template<class DeviceType, typename Precision>
+void ComputeSymmetrixMACEatomKokkos<DeviceType, Precision>::unpack_forward_comm(int n, int first,
+                                                                                 double *buf)
+{
+  auto h_H1 = Kokkos::create_mirror_view(H1);
+  for (int i = 0; i < n; ++i) {
+    for (int LM = 0; LM < num_LM; ++LM)
+      for (int k = 0; k < num_channels; ++k)
+        h_H1((first + i), LM, k) = buf[i * num_LM * num_channels + LM * num_channels + k];
+  }
+  Kokkos::deep_copy(H1, h_H1);
+}
+
+template<class DeviceType, typename Precision>
+void ComputeSymmetrixMACEatomKokkos<DeviceType, Precision>::unpack_forward_comm_kokkos(
+    int n, int first, DAT::tdual_double_1d &buf)
+{
+  auto H1 = this->H1;
+  const auto num_channels = this->num_channels;
+  const auto num_LM = this->num_LM;
+  const auto d_buf = buf.view<DeviceType>();
+  Kokkos::parallel_for(
+      "ComputeSymmetrixMACEatomKokkos::unpack_forward_comm_kokkos",
+      Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0, 0, 0}, {n, num_LM, num_channels}),
+      KOKKOS_LAMBDA(const int i, const int LM, const int k) {
+        H1((first + i), LM, k) = d_buf(i * num_LM * num_channels + LM * num_channels + k);
+      });
+  Kokkos::fence();
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType, typename Precision>
+void ComputeSymmetrixMACEatomKokkos<DeviceType, Precision>::compute_peratom()
+{
+  invoked_peratom = update->ntimestep;
+  if (!list) error->all(FLERR, "Neighbour list not initialised for compute symmetrix/mace/atom/kk");
+
+  if (atom->nmax > nmax) {
+    memoryKK->destroy_kokkos(k_array_atom, array_atom);
+    nmax = atom->nmax;
+    memoryKK->create_kokkos(k_array_atom, array_atom, nmax, size_peratom_cols,
+                             "symmetrix/mace/atom/kk:array_atom");
+  }
+
+  NeighListKokkos<DeviceType> *k_list = static_cast<NeighListKokkos<DeviceType> *>(list);
+  const int num_nodes = k_list->inum;
+
+  auto d_array_atom = k_array_atom.template view<DeviceType>();
+  Kokkos::deep_copy(d_array_atom, 0.0);
+
+  // Assumes group "all" (matches every current caller in skmd/lammps_setup.py)
+  // -- unlike the CPU compute, no per-atom groupbit check is applied.
+  if (mode == "no_domain_decomposition")
+    compute_no_domain_decomposition(num_nodes);
+  else
+    compute_mpi_message_passing(num_nodes);
+
+  k_array_atom.template modify<DeviceType>();
+  k_array_atom.sync_host();
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType, typename Precision>
+void ComputeSymmetrixMACEatomKokkos<DeviceType, Precision>::compute_no_domain_decomposition(
+    int num_nodes)
+{
+  const double r_cut_squared = r_cut * r_cut;
+
+  NeighListKokkos<DeviceType> *k_list = static_cast<NeighListKokkos<DeviceType> *>(list);
+  auto d_numneigh = k_list->d_numneigh;
+  auto d_neighbors = k_list->d_neighbors;
+  auto d_ilist = k_list->d_ilist;
+
+  atomKK->sync(execution_space, X_MASK | TYPE_MASK | TAG_MASK);
+  auto x = atomKK->k_x.view<DeviceType>();
+  auto tag = atomKK->k_tag.view<DeviceType>();
+  auto type = atomKK->k_type.view<DeviceType>();
+
+  auto map_style = atom->map_style;
+  auto k_map_array = atomKK->k_map_array;
+  auto k_map_hash = atomKK->k_map_hash;
+  k_map_array.template sync<DeviceType>();
+
+  if (node_indices.size() < num_nodes) Kokkos::realloc(node_indices, num_nodes);
+  if (node_types.size() < num_nodes) Kokkos::realloc(node_types, num_nodes);
+  if (num_neigh.size() < num_nodes) Kokkos::realloc(num_neigh, num_nodes);
+  Kokkos::deep_copy(num_neigh, 0);
+  auto node_indices = Kokkos::subview(this->node_indices, Kokkos::make_pair(0, num_nodes));
+  auto node_types = Kokkos::subview(this->node_types, Kokkos::make_pair(0, num_nodes));
+  auto num_neigh = Kokkos::subview(this->num_neigh, Kokkos::make_pair(0, num_nodes));
+  auto mace_types = this->mace_types;
+  Kokkos::parallel_for(
+      "ComputeSymmetrixMACEatomKokkos::set_node_based_views",
+      Kokkos::TeamPolicy<>(num_nodes, Kokkos::AUTO),
+      KOKKOS_LAMBDA(Kokkos::TeamPolicy<>::member_type team_member) {
+        const int ii = team_member.league_rank();
+        const int i = d_ilist(ii);
+        node_indices(ii) = i;
+        node_types(ii) = mace_types(type(i) - 1);
+        const double x_i = x(i, 0);
+        const double y_i = x(i, 1);
+        const double z_i = x(i, 2);
+        Kokkos::parallel_reduce(
+            Kokkos::TeamThreadRange(team_member, d_numneigh(i)),
+            [&](const int jj, int &num_neigh_ii) {
+              const int j = (d_neighbors(i, jj) & NEIGHMASK);
+              const double dx = x(j, 0) - x_i;
+              const double dy = x(j, 1) - y_i;
+              const double dz = x(j, 2) - z_i;
+              const double r_squared = dx * dx + dy * dy + dz * dz;
+              if (r_squared < r_cut_squared) num_neigh_ii += 1;
+            },
+            num_neigh(ii));
+      });
+
+  int num_edges;
+  Kokkos::parallel_reduce(
+      "ComputeSymmetrixMACEatomKokkos::count_edges", num_nodes,
+      KOKKOS_LAMBDA(const int ii, int &num_edges) { num_edges += num_neigh(ii); }, num_edges);
+
+  if (first_neigh.size() < num_nodes) Kokkos::realloc(first_neigh, num_nodes);
+  auto first_neigh = Kokkos::subview(this->first_neigh, Kokkos::make_pair(0, num_nodes));
+  Kokkos::parallel_scan(
+      "ComputeSymmetrixMACEatomKokkos::populate_first_neigh", num_nodes,
+      KOKKOS_LAMBDA(const int ii, int &first_neigh_ii, const bool final) {
+        if (final) first_neigh(ii) = first_neigh_ii;
+        first_neigh_ii += num_neigh(ii);
+      });
+
+  if (neigh_indices.size() < num_edges) Kokkos::realloc(neigh_indices, num_edges);
+  if (neigh_types.size() < num_edges) Kokkos::realloc(neigh_types, num_edges);
+  if (xyz.size() < 3 * num_edges) Kokkos::realloc(xyz, 3 * num_edges);
+  if (r.size() < num_edges) Kokkos::realloc(r, num_edges);
+  auto neigh_indices = Kokkos::subview(this->neigh_indices, Kokkos::make_pair(0, num_edges));
+  auto neigh_types = Kokkos::subview(this->neigh_types, Kokkos::make_pair(0, num_edges));
+  auto xyz = Kokkos::subview(this->xyz, Kokkos::make_pair(0, 3 * num_edges));
+  auto r = Kokkos::subview(this->r, Kokkos::make_pair(0, num_edges));
+  Kokkos::parallel_for(
+      "ComputeSymmetrixMACEatomKokkos::set_edge_based_views", num_nodes,
+      KOKKOS_LAMBDA(const int ii) {
+        const int i = d_ilist(ii);
+        const double x_i = x(i, 0);
+        const double y_i = x(i, 1);
+        const double z_i = x(i, 2);
+        int ij = first_neigh(ii);
+        for (int jj = 0; jj < d_numneigh(i); ++jj) {
+          const int j = (d_neighbors(i, jj) & NEIGHMASK);
+          // No forward-comm needed: with a single MPI rank, every
+          // neighbor (including periodic-image ghosts) maps straight
+          // back to its owning local atom's node index -- so H1/H2,
+          // stored per-node, are already directly indexable below.
+          const int j_local =
+              AtomKokkos::map_kokkos<DeviceType>(tag(j), map_style, k_map_array, k_map_hash);
+          const double dx = x(j, 0) - x_i;
+          const double dy = x(j, 1) - y_i;
+          const double dz = x(j, 2) - z_i;
+          const double r_squared = dx * dx + dy * dy + dz * dz;
+          if (r_squared < r_cut_squared) {
+            neigh_indices(ij) = j_local;
+            neigh_types(ij) = mace_types(type(j) - 1);
+            xyz(3 * ij) = dx;
+            xyz(3 * ij + 1) = dy;
+            xyz(3 * ij + 2) = dz;
+            r(ij) = std::sqrt(r_squared);
+            ij += 1;
+          }
+        }
+      });
+
+  mace->compute_Y(xyz);
+  mace->compute_R0(num_nodes, node_types, num_neigh, neigh_types, r);
+  mace->compute_A0(num_nodes, node_types, num_neigh, neigh_types);
+  mace->compute_A0_scaled(num_nodes, node_types, num_neigh, neigh_types, r);
+  mace->compute_M0(num_nodes, node_types);
+  mace->compute_H1(num_nodes);
+  mace->compute_R1(num_nodes, node_types, num_neigh, neigh_types, r);
+  mace->compute_Phi1(num_nodes, num_neigh, neigh_indices);
+  mace->compute_A1(num_nodes);
+  mace->compute_A1_scaled(num_nodes, node_types, num_neigh, neigh_types, r);
+  mace->compute_M1(num_nodes, node_types);
+  mace->compute_H2(num_nodes, node_types);
+
+  // Extract per-atom descriptor: h1_restored = linear_up_l0_inv^T @ H1(l=0)
+  // (matches the CPU compute's cblas_dgemv(CblasTrans, ...) call), plus
+  // the raw H2(l=0) invariants. H1/H2 are both node-indexed here (ii).
+  auto d_array_atom = k_array_atom.template view<DeviceType>();
+  const auto linear_up_l0_inv = this->linear_up_l0_inv;
+  const auto mace_H1 = mace->H1;
+  const auto mace_H2 = mace->H2;
+  const auto num_channels = this->num_channels;
+  Kokkos::parallel_for(
+      "ComputeSymmetrixMACEatomKokkos::extract_descriptors", num_nodes,
+      KOKKOS_LAMBDA(const int ii) {
+        const int i = node_indices(ii);
+        for (int row = 0; row < num_channels; ++row) {
+          double s = 0.0;
+          for (int col = 0; col < num_channels; ++col)
+            s += linear_up_l0_inv(col, row) * mace_H1(ii, 0, col);
+          d_array_atom(i, row) = s;
+          d_array_atom(i, num_channels + row) = mace_H2(ii, row);
+        }
+      });
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType, typename Precision>
+void ComputeSymmetrixMACEatomKokkos<DeviceType, Precision>::compute_mpi_message_passing(
+    int num_nodes)
+{
+  const double r_cut_squared = r_cut * r_cut;
+
+  NeighListKokkos<DeviceType> *k_list = static_cast<NeighListKokkos<DeviceType> *>(list);
+  auto d_numneigh = k_list->d_numneigh;
+  auto d_neighbors = k_list->d_neighbors;
+  auto d_ilist = k_list->d_ilist;
+
+  atomKK->sync(execution_space, X_MASK | TYPE_MASK);
+  auto x = atomKK->k_x.view<DeviceType>();
+  auto type = atomKK->k_type.view<DeviceType>();
+
+  if (node_indices.size() < num_nodes) Kokkos::realloc(node_indices, num_nodes);
+  if (node_types.size() < num_nodes) Kokkos::realloc(node_types, num_nodes);
+  if (num_neigh.size() < num_nodes) Kokkos::realloc(num_neigh, num_nodes);
+  Kokkos::deep_copy(num_neigh, 0);
+  auto node_indices = Kokkos::subview(this->node_indices, Kokkos::make_pair(0, num_nodes));
+  auto node_types = Kokkos::subview(this->node_types, Kokkos::make_pair(0, num_nodes));
+  auto num_neigh = Kokkos::subview(this->num_neigh, Kokkos::make_pair(0, num_nodes));
+  auto mace_types = this->mace_types;
+  Kokkos::parallel_for(
+      "ComputeSymmetrixMACEatomKokkos::set_node_based_views_mpi",
+      Kokkos::TeamPolicy<>(num_nodes, Kokkos::AUTO),
+      KOKKOS_LAMBDA(Kokkos::TeamPolicy<>::member_type team_member) {
+        const int ii = team_member.league_rank();
+        const int i = d_ilist(ii);
+        node_indices(ii) = i;
+        node_types(ii) = mace_types(type(i) - 1);
+        const double x_i = x(i, 0);
+        const double y_i = x(i, 1);
+        const double z_i = x(i, 2);
+        Kokkos::parallel_reduce(
+            Kokkos::TeamThreadRange(team_member, d_numneigh(i)),
+            [&](const int jj, int &num_neigh_ii) {
+              const int j = (d_neighbors(i, jj) & NEIGHMASK);
+              const double dx = x(j, 0) - x_i;
+              const double dy = x(j, 1) - y_i;
+              const double dz = x(j, 2) - z_i;
+              const double r_squared = dx * dx + dy * dy + dz * dz;
+              if (r_squared < r_cut_squared) num_neigh_ii += 1;
+            },
+            num_neigh(ii));
+      });
+
+  int num_edges;
+  Kokkos::parallel_reduce(
+      "ComputeSymmetrixMACEatomKokkos::count_edges_mpi", num_nodes,
+      KOKKOS_LAMBDA(const int ii, int &num_edges) { num_edges += num_neigh(ii); }, num_edges);
+
+  if (first_neigh.size() < num_nodes) Kokkos::realloc(first_neigh, num_nodes);
+  auto first_neigh = Kokkos::subview(this->first_neigh, Kokkos::make_pair(0, num_nodes));
+  Kokkos::parallel_scan(
+      "ComputeSymmetrixMACEatomKokkos::populate_first_neigh_mpi", num_nodes,
+      KOKKOS_LAMBDA(const int ii, int &first_neigh_ii, const bool final) {
+        if (final) first_neigh(ii) = first_neigh_ii;
+        first_neigh_ii += num_neigh(ii);
+      });
+
+  if (neigh_indices.size() < num_edges) Kokkos::realloc(neigh_indices, num_edges);
+  if (neigh_types.size() < num_edges) Kokkos::realloc(neigh_types, num_edges);
+  if (xyz.size() < 3 * num_edges) Kokkos::realloc(xyz, 3 * num_edges);
+  if (r.size() < num_edges) Kokkos::realloc(r, num_edges);
+  auto neigh_indices = Kokkos::subview(this->neigh_indices, Kokkos::make_pair(0, num_edges));
+  auto neigh_types = Kokkos::subview(this->neigh_types, Kokkos::make_pair(0, num_edges));
+  auto xyz = Kokkos::subview(this->xyz, Kokkos::make_pair(0, 3 * num_edges));
+  auto r = Kokkos::subview(this->r, Kokkos::make_pair(0, num_edges));
+  Kokkos::parallel_for(
+      "ComputeSymmetrixMACEatomKokkos::set_edge_based_views_mpi", num_nodes,
+      KOKKOS_LAMBDA(const int ii) {
+        const int i = d_ilist(ii);
+        const double x_i = x(i, 0);
+        const double y_i = x(i, 1);
+        const double z_i = x(i, 2);
+        int ij = first_neigh(ii);
+        for (int jj = 0; jj < d_numneigh(i); ++jj) {
+          const int j = (d_neighbors(i, jj) & NEIGHMASK);
+          const double dx = x(j, 0) - x_i;
+          const double dy = x(j, 1) - y_i;
+          const double dz = x(j, 2) - z_i;
+          const double r_squared = dx * dx + dy * dy + dz * dz;
+          if (r_squared < r_cut_squared) {
+            neigh_indices(ij) = j;
+            neigh_types(ij) = mace_types(type(j) - 1);
+            xyz(3 * ij) = dx;
+            xyz(3 * ij + 1) = dy;
+            xyz(3 * ij + 2) = dz;
+            r(ij) = std::sqrt(r_squared);
+            ij += 1;
+          }
+        }
+      });
+
+  mace->compute_Y(xyz);
+  mace->compute_R0(num_nodes, node_types, num_neigh, neigh_types, r);
+  mace->compute_A0(num_nodes, node_types, num_neigh, neigh_types);
+  mace->compute_A0_scaled(num_nodes, node_types, num_neigh, neigh_types, r);
+  mace->compute_M0(num_nodes, node_types);
+  mace->compute_H1(num_nodes);
+
+  // Sort H1 from node index ii to atom index i, forward-comm to ghosts,
+  // then hand the atom-indexed view back to mace for the second layer --
+  // exactly mirrors pair_symmetrix_mace_kokkos::compute_mpi_message_passing.
+  if (H1.extent(0) < k_list->inum + atom->nghost)
+    Kokkos::realloc(H1, k_list->inum + atom->nghost, num_LM, num_channels);
+  auto num_LM_local = num_LM;
+  auto num_channels_local = num_channels;
+  auto mace_H1 = mace->H1;
+  auto H1 = this->H1;
+  Kokkos::parallel_for(
+      "ComputeSymmetrixMACEatomKokkos::sort_H1",
+      Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0, 0, 0}, {num_nodes, num_LM_local, num_channels_local}),
+      KOKKOS_LAMBDA(const int ii, const int LM, const int k) {
+        const int i = d_ilist(ii);
+        H1(i, LM, k) = mace_H1(ii, LM, k);
+      });
+  Kokkos::fence();
+  comm->forward_comm(this);
+  Kokkos::fence();
+  mace->H1 = H1;
+
+  mace->compute_R1(num_nodes, node_types, num_neigh, neigh_types, r);
+  mace->compute_Phi1(num_nodes, num_neigh, neigh_indices);
+  mace->compute_A1(num_nodes);
+  mace->compute_A1_scaled(num_nodes, node_types, num_neigh, neigh_types, r);
+  mace->compute_M1(num_nodes, node_types);
+  mace->compute_H2(num_nodes, node_types);
+
+  auto d_array_atom = k_array_atom.template view<DeviceType>();
+  const auto linear_up_l0_inv = this->linear_up_l0_inv;
+  const auto H1_atom_indexed = this->H1;
+  const auto mace_H2 = mace->H2;
+  const auto num_channels_out = this->num_channels;
+  Kokkos::parallel_for(
+      "ComputeSymmetrixMACEatomKokkos::extract_descriptors_mpi", num_nodes,
+      KOKKOS_LAMBDA(const int ii) {
+        const int i = node_indices(ii);
+        for (int row = 0; row < num_channels_out; ++row) {
+          double s = 0.0;
+          for (int col = 0; col < num_channels_out; ++col)
+            s += linear_up_l0_inv(col, row) * H1_atom_indexed(i, 0, col);
+          d_array_atom(i, row) = s;
+          d_array_atom(i, num_channels_out + row) = mace_H2(ii, row);
+        }
+      });
+}
+
+/* ---------------------------------------------------------------------- */
+
+namespace LAMMPS_NS {
+template class ComputeSymmetrixMACEatomKokkos<LMPDeviceType, double>;
+#ifdef LMP_KOKKOS_GPU
+template class ComputeSymmetrixMACEatomKokkos<LMPHostType, double>;
+#endif
+}    // namespace LAMMPS_NS

--- a/pair_symmetrix/compute_symmetrix_mace_atom_kokkos.h
+++ b/pair_symmetrix/compute_symmetrix_mace_atom_kokkos.h
@@ -1,0 +1,115 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+// Device port of compute_symmetrix_mace_atom (the "macedesc" descriptor
+// compute): a full 2-layer MACE forward pass, run independently of the
+// pair style's own model instance (same architecture as the CPU version --
+// this compute owns its own MACEKokkos model and neighbor list). Mirrors
+// pair_symmetrix_mace_kokkos's two-mode dispatch: no_domain_decomposition
+// (single MPI rank -- neighbor indices resolve straight to their owning
+// local atom via the atom map, no ghost comm needed at all) or
+// mpi_message_passing (multiple ranks -- forward-comm's H1 to ghosts,
+// exactly like the pair style's pack/unpack_forward_comm_kokkos).
+
+#ifdef COMPUTE_CLASS
+// clang-format off
+ComputeStyle(symmetrix/mace/atom/kk,ComputeSymmetrixMACEatomKokkos<LMPDeviceType,double>);
+ComputeStyle(symmetrix/mace/atom/kk/device,ComputeSymmetrixMACEatomKokkos<LMPDeviceType,double>);
+ComputeStyle(symmetrix/mace/atom/kk/host,ComputeSymmetrixMACEatomKokkos<LMPHostType,double>);
+// clang-format on
+#else
+
+#ifndef LMP_COMPUTE_SYMMETRIX_MACE_ATOM_KOKKOS_H
+#define LMP_COMPUTE_SYMMETRIX_MACE_ATOM_KOKKOS_H
+
+#include "compute.h"
+#include "kokkos_base.h"
+#include "kokkos_type.h"
+
+#include <array>
+#include <memory>
+#include <string>
+
+#include "mace_kokkos.hpp"
+
+namespace LAMMPS_NS {
+
+template<class DeviceType, typename Precision = double>
+class ComputeSymmetrixMACEatomKokkos : public Compute, public KokkosBase {
+ public:
+  ComputeSymmetrixMACEatomKokkos(class LAMMPS *, int, char **);
+  ~ComputeSymmetrixMACEatomKokkos() override;
+
+  void init() override;
+  void init_list(int, class NeighList *) override;
+  void compute_peratom() override;
+
+  int pack_forward_comm(int, int *, double *, int, int *) override;
+  int pack_forward_comm_kokkos(int, DAT::tdual_int_1d, DAT::tdual_double_1d &, int, int *) override;
+  void unpack_forward_comm(int, int, double *) override;
+  void unpack_forward_comm_kokkos(int, int, DAT::tdual_double_1d &) override;
+
+ protected:
+  class NeighList *list = nullptr;
+
+  std::string mode;
+  std::unique_ptr<MACEKokkos<Precision>> mace;
+  Kokkos::View<int *> mace_types;
+
+  // atom-indexed [nlocal+nghost][num_LM][num_channels] -- only populated
+  // (and only meaningful) in mpi_message_passing mode, mirroring the pair
+  // style's H1 member exactly (same forward-comm pack/unpack pattern).
+  Kokkos::View<Precision ***, Kokkos::LayoutRight> H1;
+
+  // graph buffers, grown as needed (never shrunk) -- same pattern as
+  // pair_symmetrix_mace_kokkos's node/edge views.
+  Kokkos::View<int *> node_indices;
+  Kokkos::View<int *> node_types;
+  Kokkos::View<int *> num_neigh;
+  Kokkos::View<int *> first_neigh;
+  Kokkos::View<int *> neigh_indices;
+  Kokkos::View<int *> neigh_types;
+  Kokkos::View<double *> xyz;
+  Kokkos::View<double *> r;
+
+  // l=0 invariant "restoration" matrix -- baked into the model JSON, not
+  // exposed by MACEKokkos (which only needs it for energies/forces, not
+  // descriptors). [num_channels][num_channels], row-major.
+  Kokkos::View<double **> linear_up_l0_inv;
+
+  Kokkos::DualView<double **, DeviceType> k_array_atom;
+
+  int num_channels = 0;
+  int num_LM = 0;
+  double r_cut = 0.0;
+  int nmax = 0;
+
+  void compute_no_domain_decomposition(int num_nodes);
+  void compute_mpi_message_passing(int num_nodes);
+
+  const std::array<std::string, 118> periodic_table = {
+      "H",  "He", "Li", "Be", "B",  "C",  "N",  "O",  "F",  "Ne", "Na", "Mg", "Al", "Si",
+      "P",  "S",  "Cl", "Ar", "K",  "Ca", "Sc", "Ti", "V",  "Cr", "Mn", "Fe", "Co", "Ni",
+      "Cu", "Zn", "Ga", "Ge", "As", "Se", "Br", "Kr", "Rb", "Sr", "Y",  "Zr", "Nb", "Mo",
+      "Tc", "Ru", "Rh", "Pd", "Ag", "Cd", "In", "Sn", "Sb", "Te", "I",  "Xe", "Cs", "Ba",
+      "La", "Ce", "Pr", "Nd", "Pm", "Sm", "Eu", "Gd", "Tb", "Dy", "Ho", "Er", "Tm", "Yb",
+      "Lu", "Hf", "Ta", "W",  "Re", "Os", "Ir", "Pt", "Au", "Hg", "Tl", "Pb", "Bi", "Po",
+      "At", "Rn", "Fr", "Ra", "Ac", "Th", "Pa", "U",  "Np", "Pu", "Am", "Cm", "Bk", "Cf",
+      "Es", "Fm", "Md", "No", "Lr", "Rf", "Db", "Sg", "Bh", "Hs", "Mt", "Ds", "Rg", "Cn",
+      "Nh", "Fl", "Mc", "Lv", "Ts", "Og"};
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/pair_symmetrix/compute_symmetrix_mace_atom_kokkos.h
+++ b/pair_symmetrix/compute_symmetrix_mace_atom_kokkos.h
@@ -23,9 +23,19 @@
 
 #ifdef COMPUTE_CLASS
 // clang-format off
-ComputeStyle(symmetrix/mace/atom/kk,ComputeSymmetrixMACEatomKokkos<LMPDeviceType,double>);
-ComputeStyle(symmetrix/mace/atom/kk/device,ComputeSymmetrixMACEatomKokkos<LMPDeviceType,double>);
-ComputeStyle(symmetrix/mace/atom/kk/host,ComputeSymmetrixMACEatomKokkos<LMPHostType,double>);
+// The C preprocessor doesn't parse C++ templates -- a raw
+// Foo<LMPDeviceType,double> inside ComputeStyle(...) has its comma read as
+// an extra macro argument. Alias to a single token first, same trick
+// pair_symmetrix_mace_kokkos.h uses for PairStyle(...).
+#define ComputeSymmetrixMACEatomKokkosDeviceDouble ComputeSymmetrixMACEatomKokkos<LMPDeviceType,double>
+#define ComputeSymmetrixMACEatomKokkosHostDouble ComputeSymmetrixMACEatomKokkos<LMPHostType,double>
+
+ComputeStyle(symmetrix/mace/atom/kk,ComputeSymmetrixMACEatomKokkosDeviceDouble);
+ComputeStyle(symmetrix/mace/atom/kk/device,ComputeSymmetrixMACEatomKokkosDeviceDouble);
+ComputeStyle(symmetrix/mace/atom/kk/host,ComputeSymmetrixMACEatomKokkosHostDouble);
+
+#undef ComputeSymmetrixMACEatomKokkosDeviceDouble
+#undef ComputeSymmetrixMACEatomKokkosHostDouble
 // clang-format on
 #else
 
@@ -58,6 +68,12 @@ class ComputeSymmetrixMACEatomKokkos : public Compute, public KokkosBase {
   int pack_forward_comm_kokkos(int, DAT::tdual_int_1d, DAT::tdual_double_1d &, int, int *) override;
   void unpack_forward_comm(int, int, double *) override;
   void unpack_forward_comm_kokkos(int, int, DAT::tdual_double_1d &) override;
+
+  // Public (not protected) because each contains Kokkos device lambdas:
+  // nvcc requires the enclosing function of an extended __host__ __device__
+  // lambda to not be private/protected.
+  void compute_no_domain_decomposition(int num_nodes);
+  void compute_mpi_message_passing(int num_nodes);
 
  protected:
   class NeighList *list = nullptr;
@@ -93,9 +109,6 @@ class ComputeSymmetrixMACEatomKokkos : public Compute, public KokkosBase {
   int num_LM = 0;
   double r_cut = 0.0;
   int nmax = 0;
-
-  void compute_no_domain_decomposition(int num_nodes);
-  void compute_mpi_message_passing(int num_nodes);
 
   const std::array<std::string, 118> periodic_table = {
       "H",  "He", "Li", "Be", "B",  "C",  "N",  "O",  "F",  "Ne", "Na", "Mg", "Al", "Si",

--- a/pair_symmetrix/compute_symmetrix_mace_atom_kokkos.h
+++ b/pair_symmetrix/compute_symmetrix_mace_atom_kokkos.h
@@ -103,7 +103,12 @@ class ComputeSymmetrixMACEatomKokkos : public Compute, public KokkosBase {
   // descriptors). [num_channels][num_channels], row-major.
   Kokkos::View<double **> linear_up_l0_inv;
 
-  Kokkos::DualView<double **, DeviceType> k_array_atom;
+  // LayoutRight is required by memoryKK::create_kokkos/destroy_kokkos to
+  // alias with the legacy double** array_atom (see memory_kokkos.h's
+  // static_assert) -- the DualView's default layout for a 2D array
+  // depends on the execution space (LayoutLeft on CUDA), so it must be
+  // named explicitly rather than left to the DeviceType default.
+  Kokkos::DualView<double **, Kokkos::LayoutRight, DeviceType> k_array_atom;
 
   int num_channels = 0;
   int num_LM = 0;

--- a/pair_symmetrix/compute_symmetrix_maced_atom.cpp
+++ b/pair_symmetrix/compute_symmetrix_maced_atom.cpp
@@ -1,0 +1,450 @@
+#include "compute_symmetrix_maced_atom.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "domain.h"
+#include "error.h"
+#include "memory.h"
+#include "modify.h"
+#include "neighbor.h"
+#include "neigh_list.h"
+#include "neigh_request.h"
+#include "update.h"
+#include "utils.h"
+
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "mace.hpp"
+
+using namespace LAMMPS_NS;
+
+ComputeSymmetrixMACEdatom::ComputeSymmetrixMACEdatom(LAMMPS *lmp, int narg, char **arg)
+  : Compute(lmp, narg, arg)
+{
+  if (narg < 4) error->all(FLERR, "Illegal compute symmetrix/maced/atom command");
+
+  // compute ID group symmetrix/maced/atom model.json H C N O [vjp c_seed]
+
+  // arg[3] = model.json, arg[4..] = element symbol per LAMMPS type
+  // optional: "vjp" <compute-id-or-c_id>  (global vector length num_channels)
+
+  const std::string model_file = arg[3];
+  utils::logmesg(lmp, "Loading MACE model from '{}' ... ", model_file);
+  mace = std::make_unique<MACE>(model_file);
+  utils::logmesg(lmp, "success\n");
+
+  num_channels = mace->num_channels;
+  num_LM = mace->num_LM;
+  r_cut = mace->r_cut;
+
+  // Output: per-atom ARRAY with either 3 columns (VJP) or 3C columns per atom.
+  peratom_flag = 1;
+  if (use_vjp) size_peratom_cols = 3;
+  else         size_peratom_cols = 3 * num_channels;
+
+  comm_forward = num_LM * num_channels;
+  comm_reverse = num_LM * num_channels;
+
+  // Parse optional args
+  const int ntypes = atom->ntypes;
+  const int base = 4 + ntypes;
+  use_vjp = false;
+  vjp_compute = nullptr;
+
+  if (narg < base)
+    error->all(FLERR, "compute symmetrix/maced/atom requires one element symbol per LAMMPS atom type");
+
+  if (narg > base) {
+    if (narg != base + 2)
+      error->all(FLERR, "Illegal compute symmetrix/maced/atom optional args; expected: [vjp c_ID]");
+    if (std::string(arg[base]) != "vjp")
+      error->all(FLERR, "Illegal compute symmetrix/maced/atom optional args; expected keyword 'vjp'");
+    vjp_id = arg[base + 1];
+    use_vjp = true;
+  }
+
+  // Build mapping from LAMMPS types -> MACE types
+  mace_types.clear();
+  mace_types.reserve(ntypes);
+
+  for (int itype = 1; itype <= ntypes; ++itype) {
+    const char *elem = arg[3 + itype];
+
+    auto iter1 = std::find(periodic_table.begin(), periodic_table.end(), elem);
+    if (iter1 == periodic_table.end())
+      error->all(FLERR, "Element does not appear in periodic table");
+
+    const int atomic_number = static_cast<int>(std::distance(periodic_table.begin(), iter1)) + 1;
+
+    auto iter2 = std::find(mace->atomic_numbers.begin(), mace->atomic_numbers.end(), atomic_number);
+    if (iter2 == mace->atomic_numbers.end())
+      error->all(FLERR, "Problem matching LAMMPS types to MACE types");
+
+    const int mace_index = static_cast<int>(std::distance(mace->atomic_numbers.begin(), iter2));
+    mace_types.push_back(mace_index);
+  }
+}
+
+ComputeSymmetrixMACEdatom::~ComputeSymmetrixMACEdatom()
+{
+  if (array_atom) memory->destroy(array_atom);
+}
+
+void ComputeSymmetrixMACEdatom::init()
+{
+  if (atom->map_user == atom->MAP_NONE)
+    error->all(FLERR, "symmetrix/maced/atom requires 'atom_modify map yes|array|hash'");
+
+  // request full neighbor list + ghosts (like pair mpi_message_passing mode needs ghost comm)
+  auto *req = neighbor->add_request(this, NeighConst::REQ_FULL | NeighConst::REQ_GHOST);
+  req->set_cutoff(r_cut);
+
+  if (use_vjp) {
+    vjp_compute = modify->get_compute_by_id(vjp_id);
+
+    if (!vjp_compute)
+      error->all(FLERR, "Compute ID {} does not exist", vjp_id);
+
+    if (!vjp_compute->vector_flag)
+      error->all(FLERR, "VJP compute '{}' must provide a global vector", vjp_id);
+
+    if (vjp_compute->size_vector != num_channels)
+      error->all(FLERR, "VJP compute '{}' vector length {} != num_channels {}",
+                 vjp_id, vjp_compute->size_vector, num_channels);
+  }
+}
+
+void ComputeSymmetrixMACEdatom::init_list(int /*id*/, NeighList *ptr)
+{
+  list = ptr;
+}
+
+/* ---------------- forward comm (H1) ---------------- */
+
+int ComputeSymmetrixMACEdatom::pack_forward_comm(int n, int *list_in, double *buf,
+                                                int /*pbc_flag*/, int * /*pbc*/)
+{
+  const int stride = num_LM * num_channels;
+  for (int ii = 0; ii < n; ++ii) {
+    const int i = list_in[ii];
+    const double *src = H1_comm.data() + i * stride;
+    double *dst = buf + ii * stride;
+    for (int k = 0; k < stride; ++k) dst[k] = src[k];
+  }
+  return n * stride;
+}
+
+void ComputeSymmetrixMACEdatom::unpack_forward_comm(int n, int first, double *buf)
+{
+  const int stride = num_LM * num_channels;
+  for (int i = 0; i < n; ++i) {
+    double *dst = H1_comm.data() + (first + i) * stride;
+    const double *src = buf + i * stride;
+    for (int k = 0; k < stride; ++k) dst[k] = src[k];
+  }
+}
+
+/* ---------------- reverse comm (H1_adj) ---------------- */
+
+int ComputeSymmetrixMACEdatom::pack_reverse_comm(int n, int first, double *buf)
+{
+  const int stride = num_LM * num_channels;
+  for (int i = 0; i < n; ++i) {
+    const double *src = H1_adj_comm.data() + (first + i) * stride;
+    double *dst = buf + i * stride;
+    for (int k = 0; k < stride; ++k) dst[k] = src[k];
+  }
+  return n * stride;
+}
+
+void ComputeSymmetrixMACEdatom::unpack_reverse_comm(int n, int *list_in, double *buf)
+{
+  const int stride = num_LM * num_channels;
+  for (int ii = 0; ii < n; ++ii) {
+    const int i = list_in[ii];
+    double *dst = H1_adj_comm.data() + i * stride;
+    const double *src = buf + ii * stride;
+    for (int k = 0; k < stride; ++k) dst[k] += src[k];
+  }
+}
+
+void ComputeSymmetrixMACEdatom::build_graph_from_neighlist(int &num_nodes, int &num_edges)
+{
+  const double r_cut_sq = r_cut * r_cut;
+
+  // count edges
+  num_edges = 0;
+  for (int ii = 0; ii < list->inum; ++ii) {
+    const int i = list->ilist[ii];
+    const double x_i = atom->x[i][0];
+    const double y_i = atom->x[i][1];
+    const double z_i = atom->x[i][2];
+    int *jlist = list->firstneigh[i];
+
+    for (int jj = 0; jj < list->numneigh[i]; ++jj) {
+      const int j = (jlist[jj] & NEIGHMASK);
+      const double dx = atom->x[j][0] - x_i;
+      const double dy = atom->x[j][1] - y_i;
+      const double dz = atom->x[j][2] - z_i;
+      const double rsq = dx*dx + dy*dy + dz*dz;
+      if (rsq < r_cut_sq) num_edges += 1;
+    }
+  }
+
+  // resize
+  num_nodes = list->inum;
+  node_types.resize(num_nodes);
+  num_neigh.resize(num_nodes);
+  neigh_types.resize(num_edges);
+  xyz.resize(3 * num_edges);
+  r.resize(num_edges);
+  node_i.resize(num_nodes);
+  neigh_j.resize(num_edges);
+
+  // populate
+  int ij = 0;
+  for (int ii = 0; ii < list->inum; ++ii) {
+    const int i = list->ilist[ii];
+    node_i[ii] = i;
+    node_types[ii] = mace_types[atom->type[i] - 1];
+
+    const double x_i = atom->x[i][0];
+    const double y_i = atom->x[i][1];
+    const double z_i = atom->x[i][2];
+
+    int *jlist = list->firstneigh[i];
+    num_neigh[ii] = 0;
+
+    for (int jj = 0; jj < list->numneigh[i]; ++jj) {
+      const int j = (jlist[jj] & NEIGHMASK);
+
+      const double dx = atom->x[j][0] - x_i;
+      const double dy = atom->x[j][1] - y_i;
+      const double dz = atom->x[j][2] - z_i;
+      const double rsq = dx*dx + dy*dy + dz*dz;
+
+      if (rsq < r_cut_sq) {
+        num_neigh[ii] += 1;
+
+        neigh_j[ij] = j;
+        neigh_types[ij] = mace_types[atom->type[j] - 1];
+
+        xyz[3*ij + 0] = dx;
+        xyz[3*ij + 1] = dy;
+        xyz[3*ij + 2] = dz;
+        r[ij] = std::sqrt(rsq);
+
+        ij += 1;
+      }
+    }
+  }
+}
+
+/* ---------------- main compute ---------------- */
+
+void ComputeSymmetrixMACEdatom::compute_peratom()
+{
+  invoked_peratom = update->ntimestep;
+  if (!list) error->all(FLERR, "Neighbour list not initialised for compute symmetrix/maced/atom");
+
+  // allocate output: [nmax * size_peratom_cols]
+  if (atom->nmax > nmax) {
+    if (array_atom) memory->destroy(array_atom);
+    nmax = atom->nmax;
+    memory->create(array_atom, nmax, size_peratom_cols, "symmetrix/maced/atom:array_atom");
+  }
+
+  // init output to 0 (LAMMPS convention)
+  for (int i = 0; i < atom->nlocal; ++i) {
+    for (int c = 0; c < size_peratom_cols; ++c) array_atom[i][c] = 0.0;
+  }
+
+  int num_nodes = 0, num_edges = 0;
+  build_graph_from_neighlist(num_nodes, num_edges);
+
+  // ----- forward pass (mirror pair mpi_message_passing, without readouts) -----
+
+  mace->compute_Y(xyz);
+
+  mace->compute_R0(num_nodes, node_types, num_neigh, neigh_types, r);
+  mace->compute_A0(num_nodes, node_types, num_neigh, neigh_types);
+  mace->compute_A0_scaled(num_nodes, node_types, num_neigh, neigh_types, r);
+  mace->compute_M0(num_nodes, node_types);
+  mace->compute_H1(num_nodes);
+
+  // sort local H1 by atom index and forward-communicate to ghosts (exactly like pair)
+  const int stride = num_LM * num_channels;
+  H1_comm.assign((atom->nlocal + atom->nghost) * stride, 0.0);
+
+  for (int ii = 0; ii < num_nodes; ++ii) {
+    const int i = node_i[ii];
+    const double *src = mace->H1.data() + ii * stride;
+    double *dst = H1_comm.data() + i * stride;
+    for (int k = 0; k < stride; ++k) dst[k] = src[k];
+  }
+
+  comm->forward_comm(this);
+  mace->H1 = H1_comm;
+
+  mace->compute_R1(num_nodes, node_types, num_neigh, neigh_types, r);
+  mace->compute_Phi1(num_nodes, num_neigh, neigh_j);
+  mace->compute_A1(num_nodes);
+  mace->compute_A1_scaled(num_nodes, node_types, num_neigh, neigh_types, r);
+  mace->compute_M1(num_nodes, node_types);
+  mace->compute_H2(num_nodes, node_types);
+
+  // ----- end forward -----
+
+  if (use_vjp) {
+
+    // ----- VJP mode: single backward pass seeded by compute vector -----
+
+    if (!(vjp_compute->invoked_flag & Compute::INVOKED_VECTOR)) {
+      vjp_compute->compute_vector();
+      vjp_compute->invoked_flag |= Compute::INVOKED_VECTOR;
+    }
+    const double *v = vjp_compute->vector;
+
+    // set all channels for each atom in H2_adj to the vjp input vector
+    // We will propagate this backwards via backprop. 
+    mace->H2_adj.resize(num_nodes * num_channels);
+    for (int ii = 0; ii < num_nodes; ++ii) {
+      double *adj = mace->H2_adj.data() + ii * num_channels;
+      for (int k = 0; k < num_channels; ++k) adj[k] = v[k];
+    }
+
+    mace->node_forces.resize(xyz.size());
+    std::fill(mace->node_forces.begin(), mace->node_forces.end(), 0.0);
+
+    mace->reverse_H2(num_nodes, node_types, false);
+    mace->reverse_M1(num_nodes, node_types);
+    mace->reverse_A1_scaled(num_nodes, node_types, num_neigh, neigh_types, xyz, r, false);
+    mace->reverse_A1(num_nodes);
+    mace->reverse_Phi1(num_nodes, num_neigh, neigh_j, xyz, r, false, false);
+
+    // reverse-comm H1_adj (exactly like pair)
+    H1_adj_comm.assign((atom->nlocal + atom->nghost) * stride, 0.0);
+    {
+      const int nall = (atom->nlocal + atom->nghost) * stride;
+      const double *src = mace->H1_adj.data();
+      double *dst = H1_adj_comm.data();
+      for (int k = 0; k < nall; ++k) dst[k] = src[k];
+    }
+
+    comm->reverse_comm(this);
+    mace->H1_adj = H1_adj_comm;
+
+    mace->reverse_H1(num_nodes);
+    mace->reverse_M0(num_nodes, node_types);
+    mace->reverse_A0_scaled(num_nodes, node_types, num_neigh, neigh_types, xyz, r);
+    mace->reverse_A0(num_nodes, node_types, num_neigh, neigh_types, xyz, r);
+
+    // scatter edge forces to per-atom gradient (3 columns)
+    int ij = 0;
+    for (int ii = 0; ii < num_nodes; ++ii) {
+      const int i = node_i[ii];
+      for (int jj = 0; jj < num_neigh[ii]; ++jj) {
+        const int j = neigh_j[ij];
+
+        const double fx = mace->node_forces[3*ij + 0];
+        const double fy = mace->node_forces[3*ij + 1];
+        const double fz = mace->node_forces[3*ij + 2];
+        
+        // flip signs as we want to output positive gradient 
+        // not negative as is standard for the node forces.
+        if (i < atom->nlocal) {
+          array_atom[i][0] += fx;
+          array_atom[i][1] += fy;
+          array_atom[i][2] += fz;
+        }
+        if (j < atom->nlocal) {
+          array_atom[j][0] -= fx;
+          array_atom[j][1] -= fy;
+          array_atom[j][2] -= fz;
+        }
+
+        ij += 1;
+      }
+    }
+
+  } else {
+
+    // ----- SLOW FULL JACOBIAN MODE: C backward passes -----
+    // Output layout: array_atom[i][{0,1,2}*num_channels + kc] = d q_k / d{x,y,z}_i
+    // matches snad/atom output layout.
+    
+    mace->H2_adj.resize(num_nodes * num_channels);
+
+    for (int kc = 0; kc < num_channels; ++kc) {
+
+      // Seed: d/dH2_{i,kc} = 1 for all i (q_k = sum_i H2_{i,k})
+      for (int ii = 0; ii < num_nodes; ++ii) {
+        double *adj = mace->H2_adj.data() + ii * num_channels;
+        for (int k = 0; k < num_channels; ++k) adj[k] = 0.0;
+        adj[kc] = 1.0;
+      }
+
+      // Zero edge-force accumulator for this pass
+      mace->node_forces.resize(xyz.size());
+      std::fill(mace->node_forces.begin(), mace->node_forces.end(), 0.0);
+
+      // Reverse pass (same sequence as pair)
+      mace->reverse_H2(num_nodes, node_types, true);
+      mace->reverse_M1(num_nodes, node_types);
+      mace->reverse_A1_scaled(num_nodes, node_types, num_neigh, neigh_types, xyz, r, false);
+      mace->reverse_A1(num_nodes);
+      mace->reverse_Phi1(num_nodes, num_neigh, neigh_j, xyz, r, false, false);
+
+      // reverse-comm H1_adj (same as pair)
+      H1_adj_comm.assign((atom->nlocal + atom->nghost) * stride, 0.0);
+      {
+        const int nall = (atom->nlocal + atom->nghost) * stride;
+        const double *src = mace->H1_adj.data();
+        double *dst = H1_adj_comm.data();
+        for (int k = 0; k < nall; ++k) dst[k] = src[k];
+      }
+
+      comm->reverse_comm(this);
+      mace->H1_adj = H1_adj_comm;
+
+      mace->reverse_H1(num_nodes);
+      mace->reverse_M0(num_nodes, node_types);
+      mace->reverse_A0_scaled(num_nodes, node_types, num_neigh, neigh_types, xyz, r);
+      mace->reverse_A0(num_nodes, node_types, num_neigh, neigh_types, xyz, r);
+
+      // Layout matches snad/atom: [ x-subblock | y-subblock | z-subblock ], each subblock has K=num_channels cols
+
+      int ij = 0;
+      for (int ii = 0; ii < num_nodes; ++ii) {
+        const int i = node_i[ii];
+        for (int jj = 0; jj < num_neigh[ii]; ++jj) {
+          const int j = neigh_j[ij];
+
+          const double fx = mace->node_forces[3*ij + 0];
+          const double fy = mace->node_forces[3*ij + 1];
+          const double fz = mace->node_forces[3*ij + 2];
+
+          // slow Jacobian pass writes only channel kc
+          // flip signs as we want to output positive gradient 
+          // not negative as is standard for the node forces.
+          if (i < atom->nlocal) {
+            array_atom[i][0*num_channels + kc] += fx;  // d q_kc / d x_i
+            array_atom[i][1*num_channels + kc] += fy;  // d q_kc / d y_i
+            array_atom[i][2*num_channels + kc] += fz;  // d q_kc / d z_i
+          }
+          if (j < atom->nlocal) {
+            array_atom[j][0*num_channels + kc] -= fx;  // d q_kc / d x_j
+            array_atom[j][1*num_channels + kc] -= fy;  // d q_kc / d y_j
+            array_atom[j][2*num_channels + kc] -= fz;  // d q_kc / d z_j
+          }
+
+          ++ij;
+        }
+      }
+    } // end channel loop
+  }
+}

--- a/pair_symmetrix/compute_symmetrix_maced_atom.cpp
+++ b/pair_symmetrix/compute_symmetrix_maced_atom.cpp
@@ -41,15 +41,8 @@ ComputeSymmetrixMACEdatom::ComputeSymmetrixMACEdatom(LAMMPS *lmp, int narg, char
   num_LM = mace->num_LM;
   r_cut = mace->r_cut;
 
-  // Output: per-atom ARRAY with either 3 columns (VJP) or 3C columns per atom.
-  peratom_flag = 1;
-  if (use_vjp) size_peratom_cols = 3;
-  else         size_peratom_cols = 3 * (2 * num_channels);
-
-  comm_forward = num_LM * num_channels;
-  comm_reverse = num_LM * num_channels;
-
-  // Parse optional args
+  // Parse optional args -- must run before the "Output" sizing block below,
+  // since size_peratom_cols depends on use_vjp.
   const int ntypes = atom->ntypes;
   const int base = 4 + ntypes;
   use_vjp = false;
@@ -66,6 +59,14 @@ ComputeSymmetrixMACEdatom::ComputeSymmetrixMACEdatom(LAMMPS *lmp, int narg, char
     vjp_id = arg[base + 1];
     use_vjp = true;
   }
+
+  // Output: per-atom ARRAY with either 3 columns (VJP) or 3C columns per atom.
+  peratom_flag = 1;
+  if (use_vjp) size_peratom_cols = 3;
+  else         size_peratom_cols = 3 * (2 * num_channels);
+
+  comm_forward = num_LM * num_channels;
+  comm_reverse = num_LM * num_channels;
 
   // Build mapping from LAMMPS types -> MACE types
   mace_types.clear();

--- a/pair_symmetrix/compute_symmetrix_maced_atom.h
+++ b/pair_symmetrix/compute_symmetrix_maced_atom.h
@@ -1,0 +1,90 @@
+#ifdef COMPUTE_CLASS
+// clang-format off
+ComputeStyle(symmetrix/maced/atom,ComputeSymmetrixMACEdatom)
+// clang-format on
+#else
+
+#ifndef LMP_COMPUTE_SYMMETRIX_MACED_ATOM_H
+#define LMP_COMPUTE_SYMMETRIX_MACED_ATOM_H
+
+#include "compute.h"
+
+#include <array>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "mace.hpp"
+
+class MACE;
+
+namespace LAMMPS_NS {
+
+class ComputeSymmetrixMACEdatom : public Compute {
+ public:
+  ComputeSymmetrixMACEdatom(class LAMMPS *, int, char **);
+  ~ComputeSymmetrixMACEdatom() override;
+
+  void init() override;
+  void init_list(int, class NeighList *) override;
+  void compute_peratom() override;
+
+  int pack_forward_comm(int n, int *list, double *buf,
+                        int pbc_flag, int *pbc) override;
+  void unpack_forward_comm(int n, int first, double *buf) override;
+
+  // Needed for VJP / gradient path (reverse comm of H1_adj)
+  int pack_reverse_comm(int n, int first, double *buf) override;
+  void unpack_reverse_comm(int n, int *list, double *buf) override;
+
+ private:
+  class NeighList *list = nullptr;
+
+  std::unique_ptr<MACE> mace;
+
+  std::vector<int> mace_types;
+
+  // Graph buffers
+  std::vector<int> node_types;
+  std::vector<int> num_neigh;
+  std::vector<int> neigh_types;
+  std::vector<int> node_i;
+  std::vector<int> neigh_j;
+  std::vector<double> xyz;
+  std::vector<double> r;
+
+  // Forward-comm buffer for H1 (atom-indexed, size (nlocal+nghost)*stride)
+  std::vector<double> H1_comm;
+
+  // Reverse-comm buffer for H1_adj (atom-indexed, size (nlocal+nghost)*stride)
+  std::vector<double> H1_adj_comm;
+
+  // Optional VJP seed compute (global vector length num_channels)
+  bool use_vjp = false;
+  std::string vjp_id;
+  class Compute *vjp_compute = nullptr;
+
+  int num_channels = 0;
+  int num_LM = 0;
+  double r_cut = 0.0;
+  int nmax = 0;
+
+  void build_graph_from_neighlist(int &num_nodes, int &num_edges);
+
+  const std::array<std::string,118> periodic_table =
+    { "H", "He",
+        "Li", "Be",                                                              "B",  "C",  "N",  "O",  "F", "Ne",
+        "Na", "Mg",                                                             "Al", "Si",  "P",  "S", "Cl", "Ar",
+        "K",  "Ca", "Sc", "Ti",  "V", "Cr", "Mn", "Fe", "Co", "Ni", "Cu", "Zn", "Ga", "Ge", "As", "Se", "Br", "Kr",
+        "Rb", "Sr",  "Y", "Zr", "Nb", "Mo", "Tc", "Ru", "Rh", "Pd", "Ag", "Cd", "In", "Sn", "Sb", "Te",  "I", "Xe",
+        "Cs", "Ba", "La", "Ce", "Pr", "Nd", "Pm", "Sm", "Eu", "Gd", "Tb", "Dy", "Ho", "Er", "Tm", "Yb", "Lu",
+                        "Hf", "Ta",  "W", "Re", "Os", "Ir", "Pt", "Au", "Hg", "Tl", "Pb", "Bi", "Po", "At", "Rn",
+        "Fr", "Ra", "Ac", "Th", "Pa",  "U", "Np", "Pu", "Am", "Cm", "Bk", "Cf", "Es", "Fm", "Md", "No", "Lr",
+                        "Rf", "Db", "Sg", "Bh", "Hs", "Mt", "Ds", "Rg", "Cn", "Nh", "Fl", "Mc", "Lv", "Ts", "Og"};
+};
+
+}  // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/pair_symmetrix/compute_symmetrix_maced_atom_kokkos.cpp
+++ b/pair_symmetrix/compute_symmetrix_maced_atom_kokkos.cpp
@@ -1,0 +1,732 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "compute_symmetrix_maced_atom_kokkos.h"
+
+#include "atom_kokkos.h"
+#include "atom_masks.h"
+#include "comm.h"
+#include "error.h"
+#include "memory_kokkos.h"
+#include "neigh_list_kokkos.h"
+#include "neigh_request.h"
+#include "neighbor.h"
+#include "update.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include "mace.hpp"    // transient CPU MACE, only to read linear_up_l0_inv
+
+using namespace LAMMPS_NS;
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType, typename Precision>
+ComputeSymmetrixMACEdatomKokkos<DeviceType, Precision>::ComputeSymmetrixMACEdatomKokkos(
+    LAMMPS *lmp, int narg, char **arg) :
+  Compute(lmp, narg, arg)
+{
+  if (narg < 4) error->all(FLERR, "Illegal compute symmetrix/maced/atom/kk command");
+
+  kokkosable = 1;
+  atomKK = (AtomKokkos *) atom;
+  execution_space = ExecutionSpaceFromDevice<DeviceType>::space;
+  datamask_read = X_MASK | TYPE_MASK | TAG_MASK;
+  datamask_modify = EMPTY_MASK;
+
+  const std::string model_file = arg[3];
+  utils::logmesg(lmp, "Loading MACEKokkos model from '{}' ... ", model_file);
+  mace = std::make_unique<MACEKokkos<Precision>>(model_file);
+  utils::logmesg(lmp, "success\n");
+
+  num_channels = mace->num_channels;
+  num_LM = mace->num_LM;
+  r_cut = mace->r_cut;
+
+  {
+    MACE mace_cpu(model_file);
+    if (mace_cpu.num_channels != num_channels)
+      error->all(FLERR, "MACE/MACEKokkos num_channels mismatch loading '{}'", model_file);
+    linear_up_l0_inv = Kokkos::View<double **>(
+        "compute_symmetrix_maced_atom_kokkos:linear_up_l0_inv", num_channels, num_channels);
+    auto h_linear_up_l0_inv = Kokkos::create_mirror_view(linear_up_l0_inv);
+    for (int row = 0; row < num_channels; ++row)
+      for (int col = 0; col < num_channels; ++col)
+        h_linear_up_l0_inv(row, col) = mace_cpu.linear_up_l0_inv[row * num_channels + col];
+    Kokkos::deep_copy(linear_up_l0_inv, h_linear_up_l0_inv);
+  }
+
+  // Full-Jacobian mode only -- the VJP (single directional derivative)
+  // mode isn't ported: fix_skmd always needs the complete Jacobian.
+  const int ntypes = atom->ntypes;
+  const int base = 4 + ntypes;
+  if (narg != base)
+    error->all(FLERR,
+               "compute symmetrix/maced/atom/kk requires exactly one element symbol per "
+               "LAMMPS atom type (VJP mode is not supported by this Kokkos port)");
+
+  // Output: per-atom ARRAY, [x|y|z] subblocks of 2*num_channels cols each
+  // -- H1-restored gradient columns [0,C), H2 gradient columns [C,2C).
+  peratom_flag = 1;
+  size_peratom_cols = 3 * (2 * num_channels);
+
+  mode = (comm->nprocs == 1) ? "no_domain_decomposition" : "mpi_message_passing";
+  comm_forward = (mode == "mpi_message_passing") ? num_LM * num_channels : 0;
+  comm_reverse = (mode == "mpi_message_passing") ? num_LM * num_channels : 0;
+
+  mace_types = Kokkos::View<int *>("compute_symmetrix_maced_atom_kokkos:mace_types", ntypes);
+  auto h_mace_types = Kokkos::create_mirror_view(mace_types);
+  auto h_mace_atomic_numbers =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), mace->atomic_numbers);
+
+  for (int itype = 1; itype <= ntypes; ++itype) {
+    const char *elem = arg[3 + itype];
+
+    auto iter1 = std::find(periodic_table.begin(), periodic_table.end(), elem);
+    if (iter1 == periodic_table.end())
+      error->all(FLERR, "Element does not appear in periodic table");
+    const int atomic_number = static_cast<int>(std::distance(periodic_table.begin(), iter1)) + 1;
+
+    int mace_index = -1;
+    for (int j = 0; j < (int) mace->atomic_numbers.size(); ++j)
+      if (h_mace_atomic_numbers(j) == atomic_number) mace_index = j;
+    if (mace_index == -1)
+      error->all(FLERR, "Problem matching LAMMPS types to MACE types");
+
+    h_mace_types(itype - 1) = mace_index;
+  }
+  Kokkos::deep_copy(mace_types, h_mace_types);
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType, typename Precision>
+ComputeSymmetrixMACEdatomKokkos<DeviceType, Precision>::~ComputeSymmetrixMACEdatomKokkos()
+{
+  if (copymode) return;
+  memoryKK->destroy_kokkos(k_array_atom, array_atom);
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType, typename Precision>
+void ComputeSymmetrixMACEdatomKokkos<DeviceType, Precision>::init()
+{
+  if (atom->map_user == atom->MAP_NONE)
+    error->all(FLERR, "symmetrix/maced/atom/kk requires 'atom_modify map yes|array|hash'");
+
+  auto request = neighbor->add_request(this, NeighConst::REQ_FULL);
+  request->set_cutoff(r_cut);
+  request->set_kokkos_host(std::is_same_v<DeviceType, LMPHostType> &&
+                            !std::is_same_v<DeviceType, LMPDeviceType>);
+  request->set_kokkos_device(std::is_same_v<DeviceType, LMPDeviceType>);
+}
+
+template<class DeviceType, typename Precision>
+void ComputeSymmetrixMACEdatomKokkos<DeviceType, Precision>::init_list(int /*id*/, NeighList *ptr)
+{
+  list = ptr;
+}
+
+/* ---------------------------------------------------------------------- */
+/* forward comm (H1), identical pattern to compute_symmetrix_mace_atom_kokkos */
+
+template<class DeviceType, typename Precision>
+int ComputeSymmetrixMACEdatomKokkos<DeviceType, Precision>::pack_forward_comm(
+    int n, int *list_in, double *buf, int /*pbc_flag*/, int * /*pbc*/)
+{
+  auto h_H1 = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), H1);
+  for (int ii = 0; ii < n; ++ii) {
+    const int i = list_in[ii];
+    for (int LM = 0; LM < num_LM; ++LM)
+      for (int k = 0; k < num_channels; ++k)
+        buf[ii * num_LM * num_channels + LM * num_channels + k] = h_H1(i, LM, k);
+  }
+  return n * num_LM * num_channels;
+}
+
+template<class DeviceType, typename Precision>
+int ComputeSymmetrixMACEdatomKokkos<DeviceType, Precision>::pack_forward_comm_kokkos(
+    int n, DAT::tdual_int_1d k_sendlist, DAT::tdual_double_1d &buf, int /*pbc_flag*/, int * /*pbc*/)
+{
+  const auto d_sendlist = k_sendlist.view<DeviceType>();
+  auto d_buf = buf.view<DeviceType>();
+  const auto H1 = this->H1;
+  const auto num_channels = this->num_channels;
+  const auto num_LM = this->num_LM;
+  Kokkos::parallel_for(
+      "ComputeSymmetrixMACEdatomKokkos::pack_forward_comm_kokkos",
+      Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0, 0, 0}, {n, num_LM, num_channels}),
+      KOKKOS_LAMBDA(const int ii, const int LM, const int k) {
+        const int i = d_sendlist(ii);
+        d_buf(ii * num_LM * num_channels + LM * num_channels + k) = H1(i, LM, k);
+      });
+  Kokkos::fence();
+  return n * num_LM * num_channels;
+}
+
+template<class DeviceType, typename Precision>
+void ComputeSymmetrixMACEdatomKokkos<DeviceType, Precision>::unpack_forward_comm(int n, int first,
+                                                                                  double *buf)
+{
+  auto h_H1 = Kokkos::create_mirror_view(H1);
+  for (int i = 0; i < n; ++i) {
+    for (int LM = 0; LM < num_LM; ++LM)
+      for (int k = 0; k < num_channels; ++k)
+        h_H1((first + i), LM, k) = buf[i * num_LM * num_channels + LM * num_channels + k];
+  }
+  Kokkos::deep_copy(H1, h_H1);
+}
+
+template<class DeviceType, typename Precision>
+void ComputeSymmetrixMACEdatomKokkos<DeviceType, Precision>::unpack_forward_comm_kokkos(
+    int n, int first, DAT::tdual_double_1d &buf)
+{
+  auto H1 = this->H1;
+  const auto num_channels = this->num_channels;
+  const auto num_LM = this->num_LM;
+  const auto d_buf = buf.view<DeviceType>();
+  Kokkos::parallel_for(
+      "ComputeSymmetrixMACEdatomKokkos::unpack_forward_comm_kokkos",
+      Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0, 0, 0}, {n, num_LM, num_channels}),
+      KOKKOS_LAMBDA(const int i, const int LM, const int k) {
+        H1((first + i), LM, k) = d_buf(i * num_LM * num_channels + LM * num_channels + k);
+      });
+  Kokkos::fence();
+}
+
+/* ---------------------------------------------------------------------- */
+/* reverse comm (H1_adj), same pattern as pair_symmetrix_mace_kokkos */
+
+template<class DeviceType, typename Precision>
+int ComputeSymmetrixMACEdatomKokkos<DeviceType, Precision>::pack_reverse_comm(int n, int first,
+                                                                               double *buf)
+{
+  auto h_H1_adj = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), H1_adj);
+  for (int i = 0; i < n; ++i) {
+    for (int LM = 0; LM < num_LM; ++LM)
+      for (int k = 0; k < num_channels; ++k)
+        buf[i * num_LM * num_channels + LM * num_channels + k] = h_H1_adj((first + i), LM, k);
+  }
+  return n * num_LM * num_channels;
+}
+
+template<class DeviceType, typename Precision>
+int ComputeSymmetrixMACEdatomKokkos<DeviceType, Precision>::pack_reverse_comm_kokkos(
+    int n, int first, DAT::tdual_double_1d &buf)
+{
+  auto d_buf = buf.view<DeviceType>();
+  const auto H1_adj = this->H1_adj;
+  const auto num_channels = this->num_channels;
+  const auto num_LM = this->num_LM;
+  Kokkos::parallel_for(
+      "ComputeSymmetrixMACEdatomKokkos::pack_reverse_comm_kokkos",
+      Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0, 0, 0}, {n, num_LM, num_channels}),
+      KOKKOS_LAMBDA(const int i, const int LM, const int k) {
+        d_buf(i * num_LM * num_channels + LM * num_channels + k) = H1_adj((first + i), LM, k);
+      });
+  Kokkos::fence();
+  return n * num_LM * num_channels;
+}
+
+template<class DeviceType, typename Precision>
+void ComputeSymmetrixMACEdatomKokkos<DeviceType, Precision>::unpack_reverse_comm(int n,
+                                                                                  int *list_in,
+                                                                                  double *buf)
+{
+  auto h_H1_adj = Kokkos::create_mirror_view(H1_adj);
+  for (int ii = 0; ii < n; ++ii) {
+    const int i = list_in[ii];
+    for (int LM = 0; LM < num_LM; ++LM)
+      for (int k = 0; k < num_channels; ++k)
+        h_H1_adj(i, LM, k) += buf[ii * num_LM * num_channels + LM * num_channels + k];
+  }
+  Kokkos::deep_copy(H1_adj, h_H1_adj);
+}
+
+template<class DeviceType, typename Precision>
+void ComputeSymmetrixMACEdatomKokkos<DeviceType, Precision>::unpack_reverse_comm_kokkos(
+    int n, DAT::tdual_int_1d k_sendlist, DAT::tdual_double_1d &buf)
+{
+  const auto d_sendlist = k_sendlist.view<DeviceType>();
+  const auto d_buf = buf.view<DeviceType>();
+  auto H1_adj = this->H1_adj;
+  const auto num_LM = this->num_LM;
+  const auto num_channels = this->num_channels;
+  Kokkos::parallel_for(
+      "ComputeSymmetrixMACEdatomKokkos::unpack_reverse_comm_kokkos",
+      Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0, 0, 0}, {n, num_LM, num_channels}),
+      KOKKOS_LAMBDA(const int ii, const int LM, const int k) {
+        const int i = d_sendlist(ii);
+        Kokkos::atomic_add(&H1_adj(i, LM, k), d_buf(ii * num_LM * num_channels + LM * num_channels + k));
+      });
+  Kokkos::fence();
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType, typename Precision>
+void ComputeSymmetrixMACEdatomKokkos<DeviceType, Precision>::compute_peratom()
+{
+  invoked_peratom = update->ntimestep;
+  if (!list) error->all(FLERR, "Neighbour list not initialised for compute symmetrix/maced/atom/kk");
+
+  if (atom->nmax > nmax) {
+    memoryKK->destroy_kokkos(k_array_atom, array_atom);
+    nmax = atom->nmax;
+    memoryKK->create_kokkos(k_array_atom, array_atom, nmax, size_peratom_cols,
+                             "symmetrix/maced/atom/kk:array_atom");
+  }
+
+  NeighListKokkos<DeviceType> *k_list = static_cast<NeighListKokkos<DeviceType> *>(list);
+  const int num_nodes = k_list->inum;
+
+  auto d_array_atom = k_array_atom.template view<DeviceType>();
+  Kokkos::deep_copy(d_array_atom, 0.0);
+
+  // Assumes group "all", matching every current caller.
+  if (mode == "no_domain_decomposition")
+    compute_no_domain_decomposition(num_nodes);
+  else
+    compute_mpi_message_passing(num_nodes);
+
+  k_array_atom.template modify<DeviceType>();
+  k_array_atom.sync_host();
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType, typename Precision>
+void ComputeSymmetrixMACEdatomKokkos<DeviceType, Precision>::compute_no_domain_decomposition(
+    int num_nodes)
+{
+  const double r_cut_squared = r_cut * r_cut;
+
+  NeighListKokkos<DeviceType> *k_list = static_cast<NeighListKokkos<DeviceType> *>(list);
+  auto d_numneigh = k_list->d_numneigh;
+  auto d_neighbors = k_list->d_neighbors;
+  auto d_ilist = k_list->d_ilist;
+
+  atomKK->sync(execution_space, X_MASK | TYPE_MASK | TAG_MASK);
+  auto x = atomKK->k_x.view<DeviceType>();
+  auto tag = atomKK->k_tag.view<DeviceType>();
+  auto type = atomKK->k_type.view<DeviceType>();
+
+  auto map_style = atom->map_style;
+  auto k_map_array = atomKK->k_map_array;
+  auto k_map_hash = atomKK->k_map_hash;
+  k_map_array.template sync<DeviceType>();
+
+  if (node_indices.size() < num_nodes) Kokkos::realloc(node_indices, num_nodes);
+  if (node_types.size() < num_nodes) Kokkos::realloc(node_types, num_nodes);
+  if (num_neigh.size() < num_nodes) Kokkos::realloc(num_neigh, num_nodes);
+  Kokkos::deep_copy(num_neigh, 0);
+  auto node_indices = Kokkos::subview(this->node_indices, Kokkos::make_pair(0, num_nodes));
+  auto node_types = Kokkos::subview(this->node_types, Kokkos::make_pair(0, num_nodes));
+  auto num_neigh = Kokkos::subview(this->num_neigh, Kokkos::make_pair(0, num_nodes));
+  auto mace_types = this->mace_types;
+  Kokkos::parallel_for(
+      "ComputeSymmetrixMACEdatomKokkos::set_node_based_views",
+      Kokkos::TeamPolicy<>(num_nodes, Kokkos::AUTO),
+      KOKKOS_LAMBDA(Kokkos::TeamPolicy<>::member_type team_member) {
+        const int ii = team_member.league_rank();
+        const int i = d_ilist(ii);
+        node_indices(ii) = i;
+        node_types(ii) = mace_types(type(i) - 1);
+        const double x_i = x(i, 0);
+        const double y_i = x(i, 1);
+        const double z_i = x(i, 2);
+        Kokkos::parallel_reduce(
+            Kokkos::TeamThreadRange(team_member, d_numneigh(i)),
+            [&](const int jj, int &num_neigh_ii) {
+              const int j = (d_neighbors(i, jj) & NEIGHMASK);
+              const double dx = x(j, 0) - x_i;
+              const double dy = x(j, 1) - y_i;
+              const double dz = x(j, 2) - z_i;
+              const double r_squared = dx * dx + dy * dy + dz * dz;
+              if (r_squared < r_cut_squared) num_neigh_ii += 1;
+            },
+            num_neigh(ii));
+      });
+
+  int num_edges;
+  Kokkos::parallel_reduce(
+      "ComputeSymmetrixMACEdatomKokkos::count_edges", num_nodes,
+      KOKKOS_LAMBDA(const int ii, int &num_edges) { num_edges += num_neigh(ii); }, num_edges);
+
+  if (first_neigh.size() < num_nodes) Kokkos::realloc(first_neigh, num_nodes);
+  auto first_neigh = Kokkos::subview(this->first_neigh, Kokkos::make_pair(0, num_nodes));
+  Kokkos::parallel_scan(
+      "ComputeSymmetrixMACEdatomKokkos::populate_first_neigh", num_nodes,
+      KOKKOS_LAMBDA(const int ii, int &first_neigh_ii, const bool final) {
+        if (final) first_neigh(ii) = first_neigh_ii;
+        first_neigh_ii += num_neigh(ii);
+      });
+
+  if (neigh_indices.size() < num_edges) Kokkos::realloc(neigh_indices, num_edges);
+  if (neigh_types.size() < num_edges) Kokkos::realloc(neigh_types, num_edges);
+  if (xyz.size() < 3 * num_edges) Kokkos::realloc(xyz, 3 * num_edges);
+  if (r.size() < num_edges) Kokkos::realloc(r, num_edges);
+  auto neigh_indices = Kokkos::subview(this->neigh_indices, Kokkos::make_pair(0, num_edges));
+  auto neigh_types = Kokkos::subview(this->neigh_types, Kokkos::make_pair(0, num_edges));
+  auto xyz = Kokkos::subview(this->xyz, Kokkos::make_pair(0, 3 * num_edges));
+  auto r = Kokkos::subview(this->r, Kokkos::make_pair(0, num_edges));
+  Kokkos::parallel_for(
+      "ComputeSymmetrixMACEdatomKokkos::set_edge_based_views", num_nodes,
+      KOKKOS_LAMBDA(const int ii) {
+        const int i = d_ilist(ii);
+        const double x_i = x(i, 0);
+        const double y_i = x(i, 1);
+        const double z_i = x(i, 2);
+        int ij = first_neigh(ii);
+        for (int jj = 0; jj < d_numneigh(i); ++jj) {
+          const int j = (d_neighbors(i, jj) & NEIGHMASK);
+          const int j_local =
+              AtomKokkos::map_kokkos<DeviceType>(tag(j), map_style, k_map_array, k_map_hash);
+          const double dx = x(j, 0) - x_i;
+          const double dy = x(j, 1) - y_i;
+          const double dz = x(j, 2) - z_i;
+          const double r_squared = dx * dx + dy * dy + dz * dz;
+          if (r_squared < r_cut_squared) {
+            neigh_indices(ij) = j_local;
+            neigh_types(ij) = mace_types(type(j) - 1);
+            xyz(3 * ij) = dx;
+            xyz(3 * ij + 1) = dy;
+            xyz(3 * ij + 2) = dz;
+            r(ij) = std::sqrt(r_squared);
+            ij += 1;
+          }
+        }
+      });
+
+  mace->compute_Y(xyz);
+  mace->compute_R0(num_nodes, node_types, num_neigh, neigh_types, r);
+  mace->compute_A0(num_nodes, node_types, num_neigh, neigh_types);
+  mace->compute_A0_scaled(num_nodes, node_types, num_neigh, neigh_types, r);
+  mace->compute_M0(num_nodes, node_types);
+  mace->compute_H1(num_nodes);
+  mace->compute_R1(num_nodes, node_types, num_neigh, neigh_types, r);
+  mace->compute_Phi1(num_nodes, num_neigh, neigh_indices);
+  mace->compute_A1(num_nodes);
+  mace->compute_A1_scaled(num_nodes, node_types, num_neigh, neigh_types, r);
+  mace->compute_M1(num_nodes, node_types);
+  mace->compute_H2(num_nodes, node_types);
+
+  run_channel_loop(num_nodes, num_edges, /*use_comm=*/false);
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType, typename Precision>
+void ComputeSymmetrixMACEdatomKokkos<DeviceType, Precision>::compute_mpi_message_passing(
+    int num_nodes)
+{
+  const double r_cut_squared = r_cut * r_cut;
+
+  NeighListKokkos<DeviceType> *k_list = static_cast<NeighListKokkos<DeviceType> *>(list);
+  auto d_numneigh = k_list->d_numneigh;
+  auto d_neighbors = k_list->d_neighbors;
+  auto d_ilist = k_list->d_ilist;
+
+  atomKK->sync(execution_space, X_MASK | TYPE_MASK);
+  auto x = atomKK->k_x.view<DeviceType>();
+  auto type = atomKK->k_type.view<DeviceType>();
+
+  if (node_indices.size() < num_nodes) Kokkos::realloc(node_indices, num_nodes);
+  if (node_types.size() < num_nodes) Kokkos::realloc(node_types, num_nodes);
+  if (num_neigh.size() < num_nodes) Kokkos::realloc(num_neigh, num_nodes);
+  Kokkos::deep_copy(num_neigh, 0);
+  auto node_indices = Kokkos::subview(this->node_indices, Kokkos::make_pair(0, num_nodes));
+  auto node_types = Kokkos::subview(this->node_types, Kokkos::make_pair(0, num_nodes));
+  auto num_neigh = Kokkos::subview(this->num_neigh, Kokkos::make_pair(0, num_nodes));
+  auto mace_types = this->mace_types;
+  Kokkos::parallel_for(
+      "ComputeSymmetrixMACEdatomKokkos::set_node_based_views_mpi",
+      Kokkos::TeamPolicy<>(num_nodes, Kokkos::AUTO),
+      KOKKOS_LAMBDA(Kokkos::TeamPolicy<>::member_type team_member) {
+        const int ii = team_member.league_rank();
+        const int i = d_ilist(ii);
+        node_indices(ii) = i;
+        node_types(ii) = mace_types(type(i) - 1);
+        const double x_i = x(i, 0);
+        const double y_i = x(i, 1);
+        const double z_i = x(i, 2);
+        Kokkos::parallel_reduce(
+            Kokkos::TeamThreadRange(team_member, d_numneigh(i)),
+            [&](const int jj, int &num_neigh_ii) {
+              const int j = (d_neighbors(i, jj) & NEIGHMASK);
+              const double dx = x(j, 0) - x_i;
+              const double dy = x(j, 1) - y_i;
+              const double dz = x(j, 2) - z_i;
+              const double r_squared = dx * dx + dy * dy + dz * dz;
+              if (r_squared < r_cut_squared) num_neigh_ii += 1;
+            },
+            num_neigh(ii));
+      });
+
+  int num_edges;
+  Kokkos::parallel_reduce(
+      "ComputeSymmetrixMACEdatomKokkos::count_edges_mpi", num_nodes,
+      KOKKOS_LAMBDA(const int ii, int &num_edges) { num_edges += num_neigh(ii); }, num_edges);
+
+  if (first_neigh.size() < num_nodes) Kokkos::realloc(first_neigh, num_nodes);
+  auto first_neigh = Kokkos::subview(this->first_neigh, Kokkos::make_pair(0, num_nodes));
+  Kokkos::parallel_scan(
+      "ComputeSymmetrixMACEdatomKokkos::populate_first_neigh_mpi", num_nodes,
+      KOKKOS_LAMBDA(const int ii, int &first_neigh_ii, const bool final) {
+        if (final) first_neigh(ii) = first_neigh_ii;
+        first_neigh_ii += num_neigh(ii);
+      });
+
+  if (neigh_indices.size() < num_edges) Kokkos::realloc(neigh_indices, num_edges);
+  if (neigh_types.size() < num_edges) Kokkos::realloc(neigh_types, num_edges);
+  if (xyz.size() < 3 * num_edges) Kokkos::realloc(xyz, 3 * num_edges);
+  if (r.size() < num_edges) Kokkos::realloc(r, num_edges);
+  auto neigh_indices = Kokkos::subview(this->neigh_indices, Kokkos::make_pair(0, num_edges));
+  auto neigh_types = Kokkos::subview(this->neigh_types, Kokkos::make_pair(0, num_edges));
+  auto xyz = Kokkos::subview(this->xyz, Kokkos::make_pair(0, 3 * num_edges));
+  auto r = Kokkos::subview(this->r, Kokkos::make_pair(0, num_edges));
+  Kokkos::parallel_for(
+      "ComputeSymmetrixMACEdatomKokkos::set_edge_based_views_mpi", num_nodes,
+      KOKKOS_LAMBDA(const int ii) {
+        const int i = d_ilist(ii);
+        const double x_i = x(i, 0);
+        const double y_i = x(i, 1);
+        const double z_i = x(i, 2);
+        int ij = first_neigh(ii);
+        for (int jj = 0; jj < d_numneigh(i); ++jj) {
+          const int j = (d_neighbors(i, jj) & NEIGHMASK);
+          const double dx = x(j, 0) - x_i;
+          const double dy = x(j, 1) - y_i;
+          const double dz = x(j, 2) - z_i;
+          const double r_squared = dx * dx + dy * dy + dz * dz;
+          if (r_squared < r_cut_squared) {
+            neigh_indices(ij) = j;
+            neigh_types(ij) = mace_types(type(j) - 1);
+            xyz(3 * ij) = dx;
+            xyz(3 * ij + 1) = dy;
+            xyz(3 * ij + 2) = dz;
+            r(ij) = std::sqrt(r_squared);
+            ij += 1;
+          }
+        }
+      });
+
+  mace->compute_Y(xyz);
+  mace->compute_R0(num_nodes, node_types, num_neigh, neigh_types, r);
+  mace->compute_A0(num_nodes, node_types, num_neigh, neigh_types);
+  mace->compute_A0_scaled(num_nodes, node_types, num_neigh, neigh_types, r);
+  mace->compute_M0(num_nodes, node_types);
+  mace->compute_H1(num_nodes);
+
+  if (H1.extent(0) < k_list->inum + atom->nghost)
+    Kokkos::realloc(H1, k_list->inum + atom->nghost, num_LM, num_channels);
+  auto num_LM_local = num_LM;
+  auto num_channels_local = num_channels;
+  auto mace_H1 = mace->H1;
+  auto H1 = this->H1;
+  Kokkos::parallel_for(
+      "ComputeSymmetrixMACEdatomKokkos::sort_H1",
+      Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0, 0, 0}, {num_nodes, num_LM_local, num_channels_local}),
+      KOKKOS_LAMBDA(const int ii, const int LM, const int k) {
+        const int i = d_ilist(ii);
+        H1(i, LM, k) = mace_H1(ii, LM, k);
+      });
+  Kokkos::fence();
+  comm->forward_comm(this);
+  Kokkos::fence();
+  mace->H1 = H1;
+
+  mace->compute_R1(num_nodes, node_types, num_neigh, neigh_types, r);
+  mace->compute_Phi1(num_nodes, num_neigh, neigh_indices);
+  mace->compute_A1(num_nodes);
+  mace->compute_A1_scaled(num_nodes, node_types, num_neigh, neigh_types, r);
+  mace->compute_M1(num_nodes, node_types);
+  mace->compute_H2(num_nodes, node_types);
+
+  run_channel_loop(num_nodes, num_edges, /*use_comm=*/true);
+}
+
+/* ---------------------------------------------------------------------- */
+/* The 2*num_channels reverse-pass channel loop, shared by both modes.
+   H1-block (columns [0,C)): reverse_H1 -> reverse_M0 -> reverse_A0_scaled
+   -> reverse_A0, seeded directly on H1_adj (no message passing involved,
+   so never needs comm regardless of mode -- see the CPU compute, which
+   doesn't call comm->reverse_comm in this loop either).
+   H2-block (columns [C,2C)): reverse_H2 -> reverse_M1 -> reverse_A1_scaled
+   -> reverse_A1 -> reverse_Phi1 (this is what actually populates H1_adj,
+   potentially with ghost-atom contributions -- reverse-comm here in
+   mpi_message_passing mode) -> reverse_H1 -> reverse_M0 ->
+   reverse_A0_scaled -> reverse_A0. */
+
+template<class DeviceType, typename Precision>
+void ComputeSymmetrixMACEdatomKokkos<DeviceType, Precision>::run_channel_loop(int num_nodes,
+                                                                               int num_edges,
+                                                                               bool use_comm)
+{
+  NeighListKokkos<DeviceType> *k_list = static_cast<NeighListKokkos<DeviceType> *>(list);
+  auto node_indices = Kokkos::subview(this->node_indices, Kokkos::make_pair(0, num_nodes));
+  auto node_types = Kokkos::subview(this->node_types, Kokkos::make_pair(0, num_nodes));
+  auto num_neigh = Kokkos::subview(this->num_neigh, Kokkos::make_pair(0, num_nodes));
+  auto first_neigh = Kokkos::subview(this->first_neigh, Kokkos::make_pair(0, num_nodes));
+  auto neigh_indices = Kokkos::subview(this->neigh_indices, Kokkos::make_pair(0, num_edges));
+  auto neigh_types = Kokkos::subview(this->neigh_types, Kokkos::make_pair(0, num_edges));
+  auto xyz = Kokkos::subview(this->xyz, Kokkos::make_pair(0, 3 * num_edges));
+  auto r = Kokkos::subview(this->r, Kokkos::make_pair(0, num_edges));
+
+  const int C = num_channels;
+  const int nlocal = atom->nlocal;
+  const int twoC = 2 * C;
+
+  const int H1_adj_extent = use_comm ? (k_list->inum + atom->nghost) : num_nodes;
+  if (H1_adj.extent(0) < H1_adj_extent) Kokkos::realloc(H1_adj, H1_adj_extent, num_LM, C);
+  if ((int) mace->H2_adj.extent(0) < num_nodes || (int) mace->H2_adj.extent(1) < C)
+    Kokkos::realloc(mace->H2_adj, num_nodes, C);
+  if ((int) mace->node_forces.size() < 3 * num_edges) Kokkos::realloc(mace->node_forces, 3 * num_edges);
+
+  auto d_array_atom = k_array_atom.template view<DeviceType>();
+  const auto linear_up_l0_inv = this->linear_up_l0_inv;
+
+  // ---- H1 block: output columns [0, C) ----
+  for (int kc = 0; kc < C; ++kc) {
+    Kokkos::deep_copy(mace->node_forces, 0.0);
+    Kokkos::deep_copy(H1_adj, 0.0);
+
+    auto H1_adj_local = this->H1_adj;
+    Kokkos::parallel_for(
+        "ComputeSymmetrixMACEdatomKokkos::seed_H1_adj", num_nodes,
+        KOKKOS_LAMBDA(const int ii) {
+          const int i = node_indices(ii);
+          for (int row = 0; row < C; ++row) H1_adj_local(i, 0, row) += linear_up_l0_inv(row, kc);
+        });
+    mace->H1_adj = H1_adj_local;
+
+    mace->reverse_H1(num_nodes);
+    mace->reverse_M0(num_nodes, node_types);
+    mace->reverse_A0_scaled(num_nodes, node_types, num_neigh, neigh_types, xyz, r);
+    mace->reverse_A0(num_nodes, node_types, num_neigh, neigh_types, xyz, r);
+
+    const auto mace_node_forces = mace->node_forces;
+    const int col = kc;
+    Kokkos::parallel_for(
+        "ComputeSymmetrixMACEdatomKokkos::scatter_H1_block",
+        Kokkos::TeamPolicy<>(num_nodes, Kokkos::AUTO),
+        KOKKOS_LAMBDA(Kokkos::TeamPolicy<>::member_type team_member) {
+          const int ii = team_member.league_rank();
+          const int i = node_indices(ii);
+          double f_x, f_y, f_z;
+          Kokkos::parallel_reduce(
+              Kokkos::TeamThreadRange(team_member, num_neigh(ii)),
+              [&](const int jj, double &f_x, double &f_y, double &f_z) {
+                const int ij = first_neigh(ii) + jj;
+                const int j = neigh_indices(ij);
+                const double fx = mace_node_forces(3 * ij);
+                const double fy = mace_node_forces(3 * ij + 1);
+                const double fz = mace_node_forces(3 * ij + 2);
+                f_x += fx;
+                f_y += fy;
+                f_z += fz;
+                if (j < nlocal) {
+                  Kokkos::atomic_add(&d_array_atom(j, 0 * twoC + col), -fx);
+                  Kokkos::atomic_add(&d_array_atom(j, 1 * twoC + col), -fy);
+                  Kokkos::atomic_add(&d_array_atom(j, 2 * twoC + col), -fz);
+                }
+              },
+              f_x, f_y, f_z);
+          Kokkos::single(Kokkos::PerTeam(team_member), [&]() {
+            if (i < nlocal) {
+              Kokkos::atomic_add(&d_array_atom(i, 0 * twoC + col), f_x);
+              Kokkos::atomic_add(&d_array_atom(i, 1 * twoC + col), f_y);
+              Kokkos::atomic_add(&d_array_atom(i, 2 * twoC + col), f_z);
+            }
+          });
+        });
+  }
+
+  // ---- H2 block: output columns [C, 2C) ----
+  for (int kc = 0; kc < C; ++kc) {
+    Kokkos::deep_copy(mace->node_forces, 0.0);
+
+    auto H2_adj_local = mace->H2_adj;
+    Kokkos::parallel_for(
+        "ComputeSymmetrixMACEdatomKokkos::seed_H2_adj", num_nodes,
+        KOKKOS_LAMBDA(const int ii) {
+          for (int k = 0; k < C; ++k) H2_adj_local(ii, k) = (k == kc) ? 1.0 : 0.0;
+        });
+
+    mace->reverse_H2(num_nodes, node_types, true);
+    mace->reverse_M1(num_nodes, node_types);
+    mace->reverse_A1_scaled(num_nodes, node_types, num_neigh, neigh_types, xyz, r);
+    mace->reverse_A1(num_nodes);
+    mace->reverse_Phi1(num_nodes, num_neigh, neigh_indices, xyz, r, false, false);
+
+    if (use_comm) {
+      H1_adj = mace->H1_adj;
+      Kokkos::fence();
+      comm->reverse_comm(this);
+      Kokkos::fence();
+      mace->H1_adj = H1_adj;
+    }
+
+    mace->reverse_H1(num_nodes);
+    mace->reverse_M0(num_nodes, node_types);
+    mace->reverse_A0_scaled(num_nodes, node_types, num_neigh, neigh_types, xyz, r);
+    mace->reverse_A0(num_nodes, node_types, num_neigh, neigh_types, xyz, r);
+
+    const auto mace_node_forces = mace->node_forces;
+    const int col = C + kc;
+    Kokkos::parallel_for(
+        "ComputeSymmetrixMACEdatomKokkos::scatter_H2_block",
+        Kokkos::TeamPolicy<>(num_nodes, Kokkos::AUTO),
+        KOKKOS_LAMBDA(Kokkos::TeamPolicy<>::member_type team_member) {
+          const int ii = team_member.league_rank();
+          const int i = node_indices(ii);
+          double f_x, f_y, f_z;
+          Kokkos::parallel_reduce(
+              Kokkos::TeamThreadRange(team_member, num_neigh(ii)),
+              [&](const int jj, double &f_x, double &f_y, double &f_z) {
+                const int ij = first_neigh(ii) + jj;
+                const int j = neigh_indices(ij);
+                const double fx = mace_node_forces(3 * ij);
+                const double fy = mace_node_forces(3 * ij + 1);
+                const double fz = mace_node_forces(3 * ij + 2);
+                f_x += fx;
+                f_y += fy;
+                f_z += fz;
+                if (j < nlocal) {
+                  Kokkos::atomic_add(&d_array_atom(j, 0 * twoC + col), -fx);
+                  Kokkos::atomic_add(&d_array_atom(j, 1 * twoC + col), -fy);
+                  Kokkos::atomic_add(&d_array_atom(j, 2 * twoC + col), -fz);
+                }
+              },
+              f_x, f_y, f_z);
+          Kokkos::single(Kokkos::PerTeam(team_member), [&]() {
+            if (i < nlocal) {
+              Kokkos::atomic_add(&d_array_atom(i, 0 * twoC + col), f_x);
+              Kokkos::atomic_add(&d_array_atom(i, 1 * twoC + col), f_y);
+              Kokkos::atomic_add(&d_array_atom(i, 2 * twoC + col), f_z);
+            }
+          });
+        });
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+namespace LAMMPS_NS {
+template class ComputeSymmetrixMACEdatomKokkos<LMPDeviceType, double>;
+#ifdef LMP_KOKKOS_GPU
+template class ComputeSymmetrixMACEdatomKokkos<LMPHostType, double>;
+#endif
+}    // namespace LAMMPS_NS

--- a/pair_symmetrix/compute_symmetrix_maced_atom_kokkos.cpp
+++ b/pair_symmetrix/compute_symmetrix_maced_atom_kokkos.cpp
@@ -18,6 +18,7 @@
 #include "comm.h"
 #include "error.h"
 #include "memory_kokkos.h"
+#include "modify.h"
 #include "neigh_list_kokkos.h"
 #include "neigh_request.h"
 #include "neighbor.h"
@@ -67,19 +68,34 @@ ComputeSymmetrixMACEdatomKokkos<DeviceType, Precision>::ComputeSymmetrixMACEdato
     Kokkos::deep_copy(linear_up_l0_inv, h_linear_up_l0_inv);
   }
 
-  // Full-Jacobian mode only -- the VJP (single directional derivative)
-  // mode isn't ported by this Kokkos compute.
+  // arg[3] = model.json, arg[4..] = element symbol per LAMMPS type,
+  // optional trailing: "vjp" <compute-id> -- mirrors
+  // compute_symmetrix_maced_atom.cpp's parsing exactly.
   const int ntypes = atom->ntypes;
   const int base = 4 + ntypes;
-  if (narg != base)
+  if (narg < base)
     error->all(FLERR,
-               "compute symmetrix/maced/atom/kk requires exactly one element symbol per "
-               "LAMMPS atom type (VJP mode is not supported by this Kokkos port)");
+               "compute symmetrix/maced/atom/kk requires one element symbol per LAMMPS atom type");
 
-  // Output: per-atom ARRAY, [x|y|z] subblocks of 2*num_channels cols each
-  // -- H1-restored gradient columns [0,C), H2 gradient columns [C,2C).
+  use_vjp = false;
+  vjp_compute = nullptr;
+  if (narg > base) {
+    if (narg != base + 2)
+      error->all(FLERR,
+                 "Illegal compute symmetrix/maced/atom/kk optional args; expected: [vjp c_ID]");
+    if (std::string(arg[base]) != "vjp")
+      error->all(FLERR,
+                 "Illegal compute symmetrix/maced/atom/kk optional args; expected keyword 'vjp'");
+    vjp_id = arg[base + 1];
+    use_vjp = true;
+  }
+
+  // Output: per-atom ARRAY -- either 3 columns (VJP: d(v.q)/dr, [x|y|z])
+  // or [x|y|z] subblocks of 2*num_channels cols each (full Jacobian:
+  // H1-restored gradient columns [0,C), H2 gradient columns [C,2C)).
   peratom_flag = 1;
-  size_peratom_cols = 3 * (2 * num_channels);
+  if (use_vjp) size_peratom_cols = 3;
+  else         size_peratom_cols = 3 * (2 * num_channels);
 
   mode = (comm->nprocs == 1) ? "no_domain_decomposition" : "mpi_message_passing";
   comm_forward = (mode == "mpi_message_passing") ? num_LM * num_channels : 0;
@@ -131,6 +147,19 @@ void ComputeSymmetrixMACEdatomKokkos<DeviceType, Precision>::init()
   request->set_kokkos_host(std::is_same_v<DeviceType, LMPHostType> &&
                             !std::is_same_v<DeviceType, LMPDeviceType>);
   request->set_kokkos_device(std::is_same_v<DeviceType, LMPDeviceType>);
+
+  if (use_vjp) {
+    vjp_compute = modify->get_compute_by_id(vjp_id);
+
+    if (!vjp_compute) error->all(FLERR, "Compute ID {} does not exist", vjp_id);
+
+    if (!vjp_compute->vector_flag)
+      error->all(FLERR, "VJP compute '{}' must provide a global vector", vjp_id);
+
+    if (vjp_compute->size_vector != 2 * num_channels)
+      error->all(FLERR, "VJP compute '{}' vector length {} != 2*num_channels {}", vjp_id,
+                 vjp_compute->size_vector, 2 * num_channels);
+  }
 }
 
 template<class DeviceType, typename Precision>
@@ -423,7 +452,8 @@ void ComputeSymmetrixMACEdatomKokkos<DeviceType, Precision>::compute_no_domain_d
   mace->compute_M1(num_nodes, node_types);
   mace->compute_H2(num_nodes, node_types);
 
-  run_channel_loop(num_nodes, num_edges, /*use_comm=*/false);
+  if (use_vjp) run_vjp(num_nodes, num_edges, /*use_comm=*/false);
+  else         run_channel_loop(num_nodes, num_edges, /*use_comm=*/false);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -555,7 +585,8 @@ void ComputeSymmetrixMACEdatomKokkos<DeviceType, Precision>::compute_mpi_message
   mace->compute_M1(num_nodes, node_types);
   mace->compute_H2(num_nodes, node_types);
 
-  run_channel_loop(num_nodes, num_edges, /*use_comm=*/true);
+  if (use_vjp) run_vjp(num_nodes, num_edges, /*use_comm=*/true);
+  else         run_channel_loop(num_nodes, num_edges, /*use_comm=*/true);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -720,6 +751,141 @@ void ComputeSymmetrixMACEdatomKokkos<DeviceType, Precision>::run_channel_loop(in
           });
         });
   }
+}
+
+/* ---------------------------------------------------------------------- */
+/* VJP mode: a single combined reverse pass seeded by an external global
+   vector v = [v1 | v2] (length 2*num_channels), producing
+   d(v1.h1_restored + v2.H2)/dr per atom (3 columns) instead of the full
+   2*num_channels x 3N Jacobian. Mirrors compute_symmetrix_maced_atom.cpp's
+   VJP branch exactly: v2 seeds H2_adj (broadcast to every node) and is
+   propagated back through the second layer (reverse_H2 -> reverse_M1 ->
+   reverse_A1_scaled -> reverse_A1 -> reverse_Phi1) into H1_adj; v1 is
+   separately contracted through linear_up_l0_inv into a l=0-block seed
+   that's added onto that SAME H1_adj (not a separate pass) -- so the
+   final reverse_H1 -> reverse_M0 -> reverse_A0_scaled -> reverse_A0 call
+   backpropagates both contributions together in one pass. */
+
+template<class DeviceType, typename Precision>
+void ComputeSymmetrixMACEdatomKokkos<DeviceType, Precision>::run_vjp(int num_nodes, int num_edges,
+                                                                       bool use_comm)
+{
+  NeighListKokkos<DeviceType> *k_list = static_cast<NeighListKokkos<DeviceType> *>(list);
+  auto node_indices = Kokkos::subview(this->node_indices, Kokkos::make_pair(0, num_nodes));
+  auto node_types = Kokkos::subview(this->node_types, Kokkos::make_pair(0, num_nodes));
+  auto num_neigh = Kokkos::subview(this->num_neigh, Kokkos::make_pair(0, num_nodes));
+  auto first_neigh = Kokkos::subview(this->first_neigh, Kokkos::make_pair(0, num_nodes));
+  auto neigh_indices = Kokkos::subview(this->neigh_indices, Kokkos::make_pair(0, num_edges));
+  auto neigh_types = Kokkos::subview(this->neigh_types, Kokkos::make_pair(0, num_edges));
+  auto xyz = Kokkos::subview(this->xyz, Kokkos::make_pair(0, 3 * num_edges));
+  auto r = Kokkos::subview(this->r, Kokkos::make_pair(0, num_edges));
+
+  const int C = num_channels;
+  const int nlocal = atom->nlocal;
+
+  // Pull the seed vector off vjp_compute's host-side global vector and
+  // stage it on device -- refreshed every call since the seed compute's
+  // output can change step to step.
+  if (!(vjp_compute->invoked_flag & Compute::INVOKED_VECTOR)) {
+    vjp_compute->compute_vector();
+    vjp_compute->invoked_flag |= Compute::INVOKED_VECTOR;
+  }
+  if ((int) vjp_seed.extent(0) < 2 * C) Kokkos::realloc(vjp_seed, 2 * C);
+  auto h_vjp_seed = Kokkos::create_mirror_view(vjp_seed);
+  for (int k = 0; k < 2 * C; ++k) h_vjp_seed(k) = vjp_compute->vector[k];
+  Kokkos::deep_copy(vjp_seed, h_vjp_seed);
+  const auto vjp_seed = this->vjp_seed;
+
+  const int H1_adj_extent = use_comm ? (k_list->inum + atom->nghost) : num_nodes;
+  if (H1_adj.extent(0) < H1_adj_extent) Kokkos::realloc(H1_adj, H1_adj_extent, num_LM, C);
+  if ((int) mace->H2_adj.extent(0) < num_nodes || (int) mace->H2_adj.extent(1) < C)
+    Kokkos::realloc(mace->H2_adj, num_nodes, C);
+  if ((int) mace->node_forces.size() < 3 * num_edges) Kokkos::realloc(mace->node_forces, 3 * num_edges);
+
+  Kokkos::deep_copy(mace->node_forces, 0.0);
+
+  // ---- H2-path: seed H2_adj with v2 = vjp_seed[C, 2C), broadcast to
+  // every node, and propagate back through the second layer into H1_adj.
+  auto H2_adj_local = mace->H2_adj;
+  Kokkos::parallel_for(
+      "ComputeSymmetrixMACEdatomKokkos::vjp_seed_H2_adj", num_nodes,
+      KOKKOS_LAMBDA(const int ii) {
+        for (int k = 0; k < C; ++k) H2_adj_local(ii, k) = vjp_seed(C + k);
+      });
+
+  mace->reverse_H2(num_nodes, node_types, /*zero_H1_adj=*/true);
+  mace->reverse_M1(num_nodes, node_types);
+  mace->reverse_A1_scaled(num_nodes, node_types, num_neigh, neigh_types, xyz, r);
+  mace->reverse_A1(num_nodes);
+  mace->reverse_Phi1(num_nodes, num_neigh, neigh_indices, xyz, r,
+                      /*zero_dxyz=*/false, /*zero_H1_adj=*/false);
+
+  // ---- H1-direct path: add the v1 = vjp_seed[0, C)-weighted l=0
+  // restoration seed onto the SAME H1_adj the H2-path just populated
+  // (accumulate, not overwrite) -- see compute_symmetrix_mace_atom_kokkos's
+  // extract_descriptors kernel for why linear_up_l0_inv(row, col) is the
+  // right orientation here (same matrix, same convention).
+  auto H1_adj_mace = mace->H1_adj;
+  const auto linear_up_l0_inv = this->linear_up_l0_inv;
+  Kokkos::parallel_for(
+      "ComputeSymmetrixMACEdatomKokkos::vjp_seed_H1_adj", num_nodes,
+      KOKKOS_LAMBDA(const int ii) {
+        const int i = node_indices(ii);
+        for (int row = 0; row < C; ++row) {
+          double s = 0.0;
+          for (int kc = 0; kc < C; ++kc) s += linear_up_l0_inv(row, kc) * vjp_seed(kc);
+          H1_adj_mace(i, 0, row) += s;
+        }
+      });
+
+  if (use_comm) {
+    H1_adj = mace->H1_adj;
+    Kokkos::fence();
+    comm->reverse_comm(this);
+    Kokkos::fence();
+    mace->H1_adj = H1_adj;
+  }
+
+  mace->reverse_H1(num_nodes);
+  mace->reverse_M0(num_nodes, node_types);
+  mace->reverse_A0_scaled(num_nodes, node_types, num_neigh, neigh_types, xyz, r);
+  mace->reverse_A0(num_nodes, node_types, num_neigh, neigh_types, xyz, r);
+
+  auto d_array_atom = k_array_atom.template view<DeviceType>();
+  const auto mace_node_forces = mace->node_forces;
+  Kokkos::parallel_for(
+      "ComputeSymmetrixMACEdatomKokkos::vjp_scatter",
+      Kokkos::TeamPolicy<>(num_nodes, Kokkos::AUTO),
+      KOKKOS_LAMBDA(Kokkos::TeamPolicy<>::member_type team_member) {
+        const int ii = team_member.league_rank();
+        const int i = node_indices(ii);
+        double f_x, f_y, f_z;
+        Kokkos::parallel_reduce(
+            Kokkos::TeamThreadRange(team_member, num_neigh(ii)),
+            [&](const int jj, double &f_x, double &f_y, double &f_z) {
+              const int ij = first_neigh(ii) + jj;
+              const int j = neigh_indices(ij);
+              const double fx = mace_node_forces(3 * ij);
+              const double fy = mace_node_forces(3 * ij + 1);
+              const double fz = mace_node_forces(3 * ij + 2);
+              f_x += fx;
+              f_y += fy;
+              f_z += fz;
+              if (j < nlocal) {
+                Kokkos::atomic_add(&d_array_atom(j, 0), -fx);
+                Kokkos::atomic_add(&d_array_atom(j, 1), -fy);
+                Kokkos::atomic_add(&d_array_atom(j, 2), -fz);
+              }
+            },
+            f_x, f_y, f_z);
+        Kokkos::single(Kokkos::PerTeam(team_member), [&]() {
+          if (i < nlocal) {
+            Kokkos::atomic_add(&d_array_atom(i, 0), f_x);
+            Kokkos::atomic_add(&d_array_atom(i, 1), f_y);
+            Kokkos::atomic_add(&d_array_atom(i, 2), f_z);
+          }
+        });
+      });
 }
 
 /* ---------------------------------------------------------------------- */

--- a/pair_symmetrix/compute_symmetrix_maced_atom_kokkos.cpp
+++ b/pair_symmetrix/compute_symmetrix_maced_atom_kokkos.cpp
@@ -68,7 +68,7 @@ ComputeSymmetrixMACEdatomKokkos<DeviceType, Precision>::ComputeSymmetrixMACEdato
   }
 
   // Full-Jacobian mode only -- the VJP (single directional derivative)
-  // mode isn't ported: fix_skmd always needs the complete Jacobian.
+  // mode isn't ported by this Kokkos compute.
   const int ntypes = atom->ntypes;
   const int base = 4 + ntypes;
   if (narg != base)

--- a/pair_symmetrix/compute_symmetrix_maced_atom_kokkos.h
+++ b/pair_symmetrix/compute_symmetrix_maced_atom_kokkos.h
@@ -12,18 +12,19 @@
 ------------------------------------------------------------------------- */
 
 // Device port of compute_symmetrix_maced_atom (the full per-atom Jacobian
-// compute) -- the "SLOW FULL JACOBIAN MODE" only (the
-// VJP/single-directional-derivative mode isn't ported by this Kokkos
-// compute). Shares its graph-build
-// and forward-pass structure, and its two-mode
+// compute), including both of its output modes: the "SLOW FULL JACOBIAN
+// MODE" (run_channel_loop, one reverse pass per channel) and the VJP/
+// single-directional-derivative mode (run_vjp, one combined reverse pass
+// seeded by an external global-vector compute's output). Shares its
+// graph-build and forward-pass structure, and its two-mode
 // (no_domain_decomposition / mpi_message_passing) dispatch, with
 // compute_symmetrix_mace_atom_kokkos -- see that file's header comment
-// for the mode-selection rationale. The 2*num_channels reverse-pass
-// channel loop reuses MACEKokkos's existing reverse_H1/M0/A0_scaled/A0
-// (first layer) and reverse_H2/M1/A1_scaled/A1/Phi1 (second layer, plus
-// reverse-comm of H1_adj in mpi_message_passing mode) device methods --
-// no new backward-pass numerics, only device-resident orchestration of
-// what the CPU compute already does with plain C++ loops.
+// for the mode-selection rationale. Both run_channel_loop and run_vjp
+// reuse MACEKokkos's existing reverse_H1/M0/A0_scaled/A0 (first layer) and
+// reverse_H2/M1/A1_scaled/A1/Phi1 (second layer, plus reverse-comm of
+// H1_adj in mpi_message_passing mode) device methods -- no new
+// backward-pass numerics, only device-resident orchestration of what the
+// CPU compute already does with plain C++ loops.
 
 #ifdef COMPUTE_CLASS
 // clang-format off
@@ -80,6 +81,7 @@ class ComputeSymmetrixMACEdatomKokkos : public Compute, public KokkosBase {
   void compute_no_domain_decomposition(int num_nodes);
   void compute_mpi_message_passing(int num_nodes);
   void run_channel_loop(int num_nodes, int num_edges, bool use_comm);
+  void run_vjp(int num_nodes, int num_edges, bool use_comm);
 
  protected:
   class NeighList *list = nullptr;
@@ -87,6 +89,16 @@ class ComputeSymmetrixMACEdatomKokkos : public Compute, public KokkosBase {
   std::string mode;
   std::unique_ptr<MACEKokkos<Precision>> mace;
   Kokkos::View<int *> mace_types;
+
+  // Optional VJP seed compute (global vector length 2*num_channels) --
+  // mirrors compute_symmetrix_maced_atom.h's use_vjp/vjp_id/vjp_compute.
+  bool use_vjp = false;
+  std::string vjp_id;
+  class Compute *vjp_compute = nullptr;
+  // Device staging buffer for vjp_compute->vector (host), refreshed each
+  // compute_peratom() call -- length 2*num_channels, [0,C) = v1 (seeds the
+  // H1-restored/l=0 block), [C,2C) = v2 (seeds the H2 block).
+  Kokkos::View<double *> vjp_seed;
 
   // atom-indexed [nlocal+nghost][num_LM][num_channels] -- only populated
   // (and only meaningful) in mpi_message_passing mode. H1 mirrors the

--- a/pair_symmetrix/compute_symmetrix_maced_atom_kokkos.h
+++ b/pair_symmetrix/compute_symmetrix_maced_atom_kokkos.h
@@ -1,0 +1,135 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+// Device port of compute_symmetrix_maced_atom (the "macedescgrad" full
+// per-atom Jacobian compute) -- the "SLOW FULL JACOBIAN MODE" only (the
+// VJP/single-directional-derivative mode isn't ported: fix_skmd always
+// needs the complete Jacobian and never uses VJP). Shares its graph-build
+// and forward-pass structure, and its two-mode
+// (no_domain_decomposition / mpi_message_passing) dispatch, with
+// compute_symmetrix_mace_atom_kokkos -- see that file's header comment
+// for the mode-selection rationale. The 2*num_channels reverse-pass
+// channel loop reuses MACEKokkos's existing reverse_H1/M0/A0_scaled/A0
+// (first layer) and reverse_H2/M1/A1_scaled/A1/Phi1 (second layer, plus
+// reverse-comm of H1_adj in mpi_message_passing mode) device methods --
+// no new backward-pass numerics, only device-resident orchestration of
+// what the CPU compute already does with plain C++ loops.
+
+#ifdef COMPUTE_CLASS
+// clang-format off
+#define ComputeSymmetrixMACEdatomKokkosDeviceDouble ComputeSymmetrixMACEdatomKokkos<LMPDeviceType,double>
+#define ComputeSymmetrixMACEdatomKokkosHostDouble ComputeSymmetrixMACEdatomKokkos<LMPHostType,double>
+
+ComputeStyle(symmetrix/maced/atom/kk,ComputeSymmetrixMACEdatomKokkosDeviceDouble);
+ComputeStyle(symmetrix/maced/atom/kk/device,ComputeSymmetrixMACEdatomKokkosDeviceDouble);
+ComputeStyle(symmetrix/maced/atom/kk/host,ComputeSymmetrixMACEdatomKokkosHostDouble);
+
+#undef ComputeSymmetrixMACEdatomKokkosDeviceDouble
+#undef ComputeSymmetrixMACEdatomKokkosHostDouble
+// clang-format on
+#else
+
+#ifndef LMP_COMPUTE_SYMMETRIX_MACED_ATOM_KOKKOS_H
+#define LMP_COMPUTE_SYMMETRIX_MACED_ATOM_KOKKOS_H
+
+#include "compute.h"
+#include "kokkos_base.h"
+#include "kokkos_type.h"
+
+#include <array>
+#include <memory>
+#include <string>
+
+#include "mace_kokkos.hpp"
+
+namespace LAMMPS_NS {
+
+template<class DeviceType, typename Precision = double>
+class ComputeSymmetrixMACEdatomKokkos : public Compute, public KokkosBase {
+ public:
+  ComputeSymmetrixMACEdatomKokkos(class LAMMPS *, int, char **);
+  ~ComputeSymmetrixMACEdatomKokkos() override;
+
+  void init() override;
+  void init_list(int, class NeighList *) override;
+  void compute_peratom() override;
+
+  int pack_forward_comm(int, int *, double *, int, int *) override;
+  int pack_forward_comm_kokkos(int, DAT::tdual_int_1d, DAT::tdual_double_1d &, int, int *) override;
+  void unpack_forward_comm(int, int, double *) override;
+  void unpack_forward_comm_kokkos(int, int, DAT::tdual_double_1d &) override;
+
+  int pack_reverse_comm(int, int, double *) override;
+  int pack_reverse_comm_kokkos(int, int, DAT::tdual_double_1d &) override;
+  void unpack_reverse_comm(int, int *, double *) override;
+  void unpack_reverse_comm_kokkos(int, DAT::tdual_int_1d, DAT::tdual_double_1d &) override;
+
+  // Public (not protected): each contains Kokkos device lambdas, and nvcc
+  // requires the enclosing function of an extended __host__ __device__
+  // lambda to not be private/protected.
+  void compute_no_domain_decomposition(int num_nodes);
+  void compute_mpi_message_passing(int num_nodes);
+  void run_channel_loop(int num_nodes, int num_edges, bool use_comm);
+
+ protected:
+  class NeighList *list = nullptr;
+
+  std::string mode;
+  std::unique_ptr<MACEKokkos<Precision>> mace;
+  Kokkos::View<int *> mace_types;
+
+  // atom-indexed [nlocal+nghost][num_LM][num_channels] -- only populated
+  // (and only meaningful) in mpi_message_passing mode. H1 mirrors the
+  // pair style's own member; H1_adj is this compute's adjoint
+  // counterpart, reverse-summed back from ghosts via
+  // pack/unpack_reverse_comm_kokkos exactly like the pair style's H1_adj.
+  Kokkos::View<Precision ***, Kokkos::LayoutRight> H1, H1_adj;
+
+  // graph buffers, grown as needed (never shrunk)
+  Kokkos::View<int *> node_indices;
+  Kokkos::View<int *> node_types;
+  Kokkos::View<int *> num_neigh;
+  Kokkos::View<int *> first_neigh;
+  Kokkos::View<int *> neigh_indices;
+  Kokkos::View<int *> neigh_types;
+  Kokkos::View<double *> xyz;
+  Kokkos::View<double *> r;
+
+  // l=0 invariant "restoration" matrix -- see compute_symmetrix_mace_atom_kokkos.h.
+  Kokkos::View<double **> linear_up_l0_inv;
+
+  // Output: [nmax][3 * 2*num_channels], layout matches the CPU compute --
+  // x/y/z subblocks of 2*num_channels columns each (H1-restored then H2).
+  Kokkos::DualView<double **, Kokkos::LayoutRight, DeviceType> k_array_atom;
+
+  int num_channels = 0;
+  int num_LM = 0;
+  double r_cut = 0.0;
+  int nmax = 0;
+
+  const std::array<std::string, 118> periodic_table = {
+      "H",  "He", "Li", "Be", "B",  "C",  "N",  "O",  "F",  "Ne", "Na", "Mg", "Al", "Si",
+      "P",  "S",  "Cl", "Ar", "K",  "Ca", "Sc", "Ti", "V",  "Cr", "Mn", "Fe", "Co", "Ni",
+      "Cu", "Zn", "Ga", "Ge", "As", "Se", "Br", "Kr", "Rb", "Sr", "Y",  "Zr", "Nb", "Mo",
+      "Tc", "Ru", "Rh", "Pd", "Ag", "Cd", "In", "Sn", "Sb", "Te", "I",  "Xe", "Cs", "Ba",
+      "La", "Ce", "Pr", "Nd", "Pm", "Sm", "Eu", "Gd", "Tb", "Dy", "Ho", "Er", "Tm", "Yb",
+      "Lu", "Hf", "Ta", "W",  "Re", "Os", "Ir", "Pt", "Au", "Hg", "Tl", "Pb", "Bi", "Po",
+      "At", "Rn", "Fr", "Ra", "Ac", "Th", "Pa", "U",  "Np", "Pu", "Am", "Cm", "Bk", "Cf",
+      "Es", "Fm", "Md", "No", "Lr", "Rf", "Db", "Sg", "Bh", "Hs", "Mt", "Ds", "Rg", "Cn",
+      "Nh", "Fl", "Mc", "Lv", "Ts", "Og"};
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/pair_symmetrix/compute_symmetrix_maced_atom_kokkos.h
+++ b/pair_symmetrix/compute_symmetrix_maced_atom_kokkos.h
@@ -11,10 +11,10 @@
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
 
-// Device port of compute_symmetrix_maced_atom (the "macedescgrad" full
-// per-atom Jacobian compute) -- the "SLOW FULL JACOBIAN MODE" only (the
-// VJP/single-directional-derivative mode isn't ported: fix_skmd always
-// needs the complete Jacobian and never uses VJP). Shares its graph-build
+// Device port of compute_symmetrix_maced_atom (the full per-atom Jacobian
+// compute) -- the "SLOW FULL JACOBIAN MODE" only (the
+// VJP/single-directional-derivative mode isn't ported by this Kokkos
+// compute). Shares its graph-build
 // and forward-pass structure, and its two-mode
 // (no_domain_decomposition / mpi_message_passing) dispatch, with
 // compute_symmetrix_mace_atom_kokkos -- see that file's header comment

--- a/pair_symmetrix/install.sh
+++ b/pair_symmetrix/install.sh
@@ -18,6 +18,8 @@ ln -sf $(pwd)/pair_symmetrix_mace_kokkos.h ${lammps}/src/KOKKOS/pair_symmetrix_m
 ln -sf $(pwd)/pair_symmetrix_mace_kokkos.cpp ${lammps}/src/KOKKOS/pair_symmetrix_mace_kokkos.cpp
 ln -sf $(pwd)/compute_symmetrix_mace_atom.h ${lammps}/src/compute_symmetrix_mace_atom.h
 ln -sf $(pwd)/compute_symmetrix_mace_atom.cpp ${lammps}/src/compute_symmetrix_mace_atom.cpp
+ln -sf $(pwd)/compute_symmetrix_maced_atom.h ${lammps}/src/compute_symmetrix_maced_atom.h
+ln -sf $(pwd)/compute_symmetrix_maced_atom.cpp ${lammps}/src/compute_symmetrix_maced_atom.cpp
 
 # update lammps build instructions
 echo "

--- a/pair_symmetrix/install.sh
+++ b/pair_symmetrix/install.sh
@@ -16,6 +16,8 @@ ln -sf $(pwd)/pair_symmetrix_mace.h ${lammps}/src/pair_symmetrix_mace.h
 ln -sf $(pwd)/pair_symmetrix_mace.cpp ${lammps}/src/pair_symmetrix_mace.cpp
 ln -sf $(pwd)/pair_symmetrix_mace_kokkos.h ${lammps}/src/KOKKOS/pair_symmetrix_mace_kokkos.h
 ln -sf $(pwd)/pair_symmetrix_mace_kokkos.cpp ${lammps}/src/KOKKOS/pair_symmetrix_mace_kokkos.cpp
+ln -sf $(pwd)/compute_symmetrix_mace_atom.h ${lammps}/src/compute_symmetrix_mace_atom.h
+ln -sf $(pwd)/compute_symmetrix_mace_atom.cpp ${lammps}/src/compute_symmetrix_mace_atom.cpp
 
 # update lammps build instructions
 echo "

--- a/pair_symmetrix/install.sh
+++ b/pair_symmetrix/install.sh
@@ -18,6 +18,8 @@ ln -sf $(pwd)/pair_symmetrix_mace_kokkos.h ${lammps}/src/KOKKOS/pair_symmetrix_m
 ln -sf $(pwd)/pair_symmetrix_mace_kokkos.cpp ${lammps}/src/KOKKOS/pair_symmetrix_mace_kokkos.cpp
 ln -sf $(pwd)/compute_symmetrix_mace_atom.h ${lammps}/src/compute_symmetrix_mace_atom.h
 ln -sf $(pwd)/compute_symmetrix_mace_atom.cpp ${lammps}/src/compute_symmetrix_mace_atom.cpp
+ln -sf $(pwd)/compute_symmetrix_mace_atom_kokkos.h ${lammps}/src/KOKKOS/compute_symmetrix_mace_atom_kokkos.h
+ln -sf $(pwd)/compute_symmetrix_mace_atom_kokkos.cpp ${lammps}/src/KOKKOS/compute_symmetrix_mace_atom_kokkos.cpp
 ln -sf $(pwd)/compute_symmetrix_maced_atom.h ${lammps}/src/compute_symmetrix_maced_atom.h
 ln -sf $(pwd)/compute_symmetrix_maced_atom.cpp ${lammps}/src/compute_symmetrix_maced_atom.cpp
 

--- a/pair_symmetrix/install.sh
+++ b/pair_symmetrix/install.sh
@@ -22,6 +22,8 @@ ln -sf $(pwd)/compute_symmetrix_mace_atom_kokkos.h ${lammps}/src/KOKKOS/compute_
 ln -sf $(pwd)/compute_symmetrix_mace_atom_kokkos.cpp ${lammps}/src/KOKKOS/compute_symmetrix_mace_atom_kokkos.cpp
 ln -sf $(pwd)/compute_symmetrix_maced_atom.h ${lammps}/src/compute_symmetrix_maced_atom.h
 ln -sf $(pwd)/compute_symmetrix_maced_atom.cpp ${lammps}/src/compute_symmetrix_maced_atom.cpp
+ln -sf $(pwd)/compute_symmetrix_maced_atom_kokkos.h ${lammps}/src/KOKKOS/compute_symmetrix_maced_atom_kokkos.h
+ln -sf $(pwd)/compute_symmetrix_maced_atom_kokkos.cpp ${lammps}/src/KOKKOS/compute_symmetrix_maced_atom_kokkos.cpp
 
 # update lammps build instructions
 echo "

--- a/pair_symmetrix/test/test_compute_symmetrix_mace.py
+++ b/pair_symmetrix/test/test_compute_symmetrix_mace.py
@@ -6,17 +6,19 @@ the same pattern test_mace.py in symmetrix/test/ uses for the raw
 forward/reverse layer values, just carried through to the final
 [h1_restored | H2] descriptor these computes expose.
 
-Parametrized over cmdargs exactly like test_pair_symmetrix_mace.py: plain
-CPU vs `-k on -sf kk` (Kokkos/GPU). This is what actually exercises
-compute_symmetrix_mace_atom_kokkos / compute_symmetrix_maced_atom_kokkos --
-under -sf kk, `compute ... symmetrix/mace(d)/atom ...` auto-resolves to
-the /kk variant if one's registered.
+Parametrized over cmdargs: plain CPU vs `-k on g 1 -sf kk -pk kokkos
+newton on neigh half` (Kokkos/GPU, matching skmd.lammps_setup.make_lammps's
+cmdargs). This is what actually exercises compute_symmetrix_mace_atom_kokkos
+/ compute_symmetrix_maced_atom_kokkos -- under -sf kk, `compute ...
+symmetrix/mace(d)/atom ...` auto-resolves to the /kk variant if one's
+registered. The explicit `g 1` is required: on a LAMMPS build compiled
+with a GPU-enabled Kokkos backend, `-k on` alone errors with "Kokkos has
+been compiled with GPU-enabled backend but no GPUs are requested" --
+unlike test_pair_symmetrix_mace.py's bare `-k on -sf kk`, which only
+works on a host/serial-only Kokkos build.
 
 Not wired into CI -- run manually, e.g.:
     pytest test_compute_symmetrix_mace.py -v
-On a machine without a GPU, the "-k on -sf kk" cases will run Kokkos in
-whatever host/serial backend the LAMMPS build was configured with (still
-exercises the /kk code path, just not on-device).
 """
 
 import json
@@ -131,7 +133,11 @@ def build_lammps(cmdargs):
 
 CMDARGS = [
     pytest.param(["-screen", "none"], id="cpu"),
-    pytest.param(["-screen", "none", "-k", "on", "-sf", "kk"], id="kokkos"),
+    pytest.param(
+        ["-screen", "none", "-k", "on", "g", "1", "-sf", "kk",
+         "-pk", "kokkos", "newton", "on", "neigh", "half"],
+        id="kokkos",
+    ),
 ]
 
 

--- a/pair_symmetrix/test/test_compute_symmetrix_mace.py
+++ b/pair_symmetrix/test/test_compute_symmetrix_mace.py
@@ -16,6 +16,12 @@ been compiled with GPU-enabled backend but no GPUs are requested" --
 unlike test_pair_symmetrix_mace.py's bare `-k on -sf kk`, which only
 works on a host/serial-only Kokkos build.
 
+The kokkos id is skipped (not failed) when this LAMMPS build's KOKKOS
+package wasn't compiled with a GPU-capable backend -- e.g. a GitHub
+Actions runner's CPU-only build -- via a check at collection time (see
+_kokkos_gpu_available()), rather than letting LAMMPS hard-error on `-k on
+g 1` when the build can't honor it.
+
 Not wired into CI -- run manually, e.g.:
     pytest test_compute_symmetrix_mace.py -v
 """
@@ -105,7 +111,7 @@ def reference_descriptor(positions):
     return np.concatenate([h1_restored, H2], axis=1)    # (num_nodes, 2*num_channels)
 
 
-def build_lammps(cmdargs, group_subset_ids=None):
+def build_lammps(cmdargs, group_subset_ids=None, vjp_seed=None):
     # A single read_data call, not multiple create_atoms calls: LAMMPS/Kokkos
     # has a known, unresolved upstream bug where AtomKokkos::map_set_device()
     # segfaults (cudaErrorIllegalAddress) when create_atoms is invoked more
@@ -137,6 +143,30 @@ def build_lammps(cmdargs, group_subset_ids=None):
             compute         macedesc_sub sub symmetrix/mace/atom {MODEL_FILE} H O
         """
 
+    # Optionally seed compute symmetrix/maced/atom(/kk)'s VJP mode with an
+    # arbitrary fixed global vector -- used by test_vjp. There's no built-in
+    # LAMMPS compute for "a constant vector I chose in Python", so this
+    # builds one out of two primitives that are: one atom-style variable
+    # per seed entry, holding that constant (atom-style variables can be a
+    # plain constant expression -- it just means the value doesn't vary
+    # per atom), and `compute reduce ave` over all of them, which averages
+    # each input over the atoms in the group -- since every atom's value is
+    # identical, the average is exactly that constant, for any atom count.
+    # `compute reduce`'s vector_flag/size_vector make it a valid VJP seed
+    # compute (compute_symmetrix_maced_atom(_kokkos)'s only two
+    # requirements) without needing any dedicated test-only C++ compute.
+    vjp_cmds = ""
+    if vjp_seed is not None:
+        var_lines = "\n".join(
+            f"            variable        vjp_seed_{k} atom {float(v)!r}" for k, v in enumerate(vjp_seed)
+        )
+        var_names = " ".join(f"v_vjp_seed_{k}" for k in range(len(vjp_seed)))
+        vjp_cmds = f"""
+{var_lines}
+            compute         vjpseed all reduce ave {var_names}
+            compute         macedescvjp all symmetrix/maced/atom {MODEL_FILE} H O vjp vjpseed
+        """
+
     lmp = lammps(cmdargs=cmdargs)
     with tempfile.TemporaryDirectory() as tmpdir:
         data_path = str(Path(tmpdir) / "system.data")
@@ -158,10 +188,32 @@ def build_lammps(cmdargs, group_subset_ids=None):
             compute         macedesc all symmetrix/mace/atom {MODEL_FILE} H O
             compute         macedescgrad all symmetrix/maced/atom {MODEL_FILE} H O
             {group_cmds}
+            {vjp_cmds}
 
             run 0
         """)
     return lmp
+
+
+def _kokkos_gpu_available():
+    """True if *this LAMMPS build* has the KOKKOS package compiled in with
+    a GPU-capable backend (cuda/hip/sycl) -- used to skip (not fail) the
+    kokkos cmdargs id when the build itself can't honor `-k on g 1`, e.g.
+    a CI runner's CPU-only/host-Kokkos LAMMPS build. Checked via a
+    throwaway lammps instance's accelerator_config, which reports what the
+    library was actually compiled with -- not by probing for physical GPU
+    hardware (nvidia-smi etc.), which only catches "GPU-capable build, no
+    device present" and would still let a host-only Kokkos build blow up
+    on `-k on g 1` on a machine that happens to have a GPU.
+    """
+    lmp = lammps(cmdargs=["-screen", "none"])
+    try:
+        if not lmp.has_package("KOKKOS"):
+            return False
+        gpu_apis = {"cuda", "hip", "sycl"}
+        return bool(gpu_apis & set(lmp.accelerator_config["KOKKOS"]["api"]))
+    finally:
+        lmp.close()
 
 
 CMDARGS = [
@@ -170,6 +222,10 @@ CMDARGS = [
         ["-screen", "none", "-k", "on", "g", "1", "-sf", "kk",
          "-pk", "kokkos", "newton", "on", "neigh", "half"],
         id="kokkos",
+        marks=pytest.mark.skipif(
+            not _kokkos_gpu_available(),
+            reason="LAMMPS not built with a GPU-capable Kokkos backend -- skipping Kokkos GPU test",
+        ),
     ),
 ]
 
@@ -225,6 +281,52 @@ def test_descriptor_group_subset(cmdargs):
                 assert np.allclose(desc[row], 0.0, atol=1e-12), (
                     f"atom id {atom_id} is outside the compute's group and should be zero, "
                     f"got {desc[row]}"
+                )
+    finally:
+        lmp.close()
+
+
+@pytest.mark.parametrize("cmdargs", CMDARGS)
+def test_vjp(cmdargs):
+    """compute symmetrix/maced/atom(/kk) ... vjp <compute-id> -- the single
+    combined reverse pass seeded by an external global vector v = [v1|v2]
+    (length 2*num_channels), as opposed to test_jacobian's full
+    2*num_channels x 3*num_atoms Jacobian (one reverse pass per channel).
+
+    Ground truth: v . q(positions), where q = reference_descriptor(positions)
+    summed over atoms (the same global descriptor test_jacobian's finite
+    differences use) -- the VJP output for atom i, direction w should be
+    exactly d(v.q)/dpos[i,w], i.e. the full Jacobian contracted with v.
+    Runs on both CPU (compute_symmetrix_maced_atom.cpp's `if (use_vjp)`
+    branch) and Kokkos (compute_symmetrix_maced_atom_kokkos.cpp's run_vjp).
+    """
+    two_c = 2 * NUM_CHANNELS
+    seed = np.random.default_rng(12345).uniform(-1.0, 1.0, two_c)
+
+    lmp = build_lammps(cmdargs, vjp_seed=seed)
+    try:
+        vjp = lmp.numpy.extract_compute(
+            "macedescvjp", lmpmod.LMP_STYLE_ATOM, lmpmod.LMP_TYPE_ARRAY)
+        ids = lmp.numpy.extract_atom("id")
+        order = np.argsort(ids)
+        vjp = np.array(vjp, copy=True)[order]
+        assert vjp.shape == (len(ATOMS), 3)
+
+        h = 1e-4
+        positions = ATOMS.get_positions()
+        for atom_idx in range(len(ATOMS)):
+            for w in range(3):
+                pos_p = positions.copy()
+                pos_p[atom_idx, w] += h
+                pos_m = positions.copy()
+                pos_m[atom_idx, w] -= h
+                q_p = reference_descriptor(pos_p).sum(axis=0)
+                q_m = reference_descriptor(pos_m).sum(axis=0)
+                dq_dw_num = (q_p - q_m) / (2 * h)
+                expected = seed @ dq_dw_num
+                got = vjp[atom_idx, w]
+                assert got == pytest.approx(expected, rel=1e-3, abs=1e-4), (
+                    f"atom={atom_idx} dir={w}: lammps={got}, numerical={expected}"
                 )
     finally:
         lmp.close()

--- a/pair_symmetrix/test/test_compute_symmetrix_mace.py
+++ b/pair_symmetrix/test/test_compute_symmetrix_mace.py
@@ -7,8 +7,7 @@ forward/reverse layer values, just carried through to the final
 [h1_restored | H2] descriptor these computes expose.
 
 Parametrized over cmdargs: plain CPU vs `-k on g 1 -sf kk -pk kokkos
-newton on neigh half` (Kokkos/GPU, matching skmd.lammps_setup.make_lammps's
-cmdargs). This is what actually exercises compute_symmetrix_mace_atom_kokkos
+newton on neigh half` (Kokkos/GPU). This is what actually exercises compute_symmetrix_mace_atom_kokkos
 / compute_symmetrix_maced_atom_kokkos -- under -sf kk, `compute ...
 symmetrix/mace(d)/atom ...` auto-resolves to the /kk variant if one's
 registered. The explicit `g 1` is required: on a LAMMPS build compiled
@@ -106,15 +105,14 @@ def reference_descriptor(positions):
     return np.concatenate([h1_restored, H2], axis=1)    # (num_nodes, 2*num_channels)
 
 
-def build_lammps(cmdargs):
+def build_lammps(cmdargs, group_subset_ids=None):
     # A single read_data call, not multiple create_atoms calls: LAMMPS/Kokkos
     # has a known, unresolved upstream bug where AtomKokkos::map_set_device()
     # segfaults (cudaErrorIllegalAddress) when create_atoms is invoked more
     # than once in a session with atom_modify map active --
     # https://matsci.org/t/using-lammps-create-atoms-and-run-0-in-a-kokkos-cuda-interface/59054
-    # read_data doesn't hit this path, and it's also what
-    # skmd.lammps_setup.load_config_into_lammps actually uses in production,
-    # so this is a closer match to the real usage pattern anyway.
+    # read_data doesn't hit this path, and it's also a closer match to
+    # real production usage patterns anyway.
     # ATOMS's positions (e.g. (0,-2,0)) were chosen for a box centered on
     # the origin (the old create_atoms version used `region box block -10
     # 10 -10 10 -10 10`). A cell of [20,20,20] implies a [0,20) box instead
@@ -125,6 +123,19 @@ def build_lammps(cmdargs):
     atoms.translate([10.0, 10.0, 10.0])
     atoms.set_cell([20.0, 20.0, 20.0])
     atoms.set_pbc(True)
+
+    # Optionally define a subgroup containing only some atoms and attach a
+    # second compute to it, scoped by LAMMPS atom id -- used by
+    # test_descriptor_group_subset to check that the compute honors its
+    # group (rather than every atom in the neighbor list) the same way on
+    # both the CPU and Kokkos code paths.
+    group_cmds = ""
+    if group_subset_ids is not None:
+        ids_str = " ".join(str(i) for i in group_subset_ids)
+        group_cmds = f"""
+            group           sub id {ids_str}
+            compute         macedesc_sub sub symmetrix/mace/atom {MODEL_FILE} H O
+        """
 
     lmp = lammps(cmdargs=cmdargs)
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -146,6 +157,7 @@ def build_lammps(cmdargs):
 
             compute         macedesc all symmetrix/mace/atom {MODEL_FILE} H O
             compute         macedescgrad all symmetrix/maced/atom {MODEL_FILE} H O
+            {group_cmds}
 
             run 0
         """)
@@ -175,6 +187,45 @@ def test_descriptor(cmdargs):
         ref = reference_descriptor(ATOMS.get_positions())
         assert desc.shape == ref.shape
         assert np.allclose(desc, ref, rtol=1e-4, atol=1e-6)
+    finally:
+        lmp.close()
+
+
+@pytest.mark.parametrize("cmdargs", CMDARGS)
+def test_descriptor_group_subset(cmdargs):
+    """compute symmetrix/mace/atom(/kk) restricted to a group smaller than
+    "all" -- regression test for a real CPU/Kokkos divergence:
+    compute_symmetrix_mace_atom.cpp zeroes descriptor output for atoms
+    outside its group (`i < atom->nlocal && (atom->mask[i] & groupbit)`,
+    the standard LAMMPS per-atom-compute convention), but
+    compute_symmetrix_mace_atom_kokkos.cpp used to skip that check entirely
+    and write real descriptor values for every atom in the neighbor list
+    regardless of group. Attaches the compute to a 2-of-3-atom subgroup and
+    checks both that the in-group atoms still match the reference
+    descriptor and that the excluded atom's row comes back exactly zero.
+    """
+    subset_ids = [2, 3]    # exclude atom id 1 (the O atom) from the group
+    lmp = build_lammps(cmdargs, group_subset_ids=subset_ids)
+    try:
+        desc = lmp.numpy.extract_compute(
+            "macedesc_sub", lmpmod.LMP_STYLE_ATOM, lmpmod.LMP_TYPE_ARRAY)
+        ids = lmp.numpy.extract_atom("id")
+        order = np.argsort(ids)
+        desc = np.array(desc, copy=True)[order]
+        sorted_ids = np.array(ids, copy=True)[order].astype(int)
+
+        ref = reference_descriptor(ATOMS.get_positions())
+        assert desc.shape == ref.shape
+        for row, atom_id in enumerate(sorted_ids):
+            if atom_id in subset_ids:
+                assert np.allclose(desc[row], ref[row], rtol=1e-4, atol=1e-6), (
+                    f"in-group atom id {atom_id} should still match the reference descriptor"
+                )
+            else:
+                assert np.allclose(desc[row], 0.0, atol=1e-12), (
+                    f"atom id {atom_id} is outside the compute's group and should be zero, "
+                    f"got {desc[row]}"
+                )
     finally:
         lmp.close()
 

--- a/pair_symmetrix/test/test_compute_symmetrix_mace.py
+++ b/pair_symmetrix/test/test_compute_symmetrix_mace.py
@@ -1,0 +1,200 @@
+"""Tests for compute_symmetrix_mace_atom(/kk) and compute_symmetrix_maced_atom(/kk).
+
+Compares LAMMPS's per-atom descriptor/Jacobian computes against a reference
+computed by driving symmetrix.MACE (or symmetrix.MACEKokkos) directly --
+the same pattern test_mace.py in symmetrix/test/ uses for the raw
+forward/reverse layer values, just carried through to the final
+[h1_restored | H2] descriptor these computes expose.
+
+Parametrized over cmdargs exactly like test_pair_symmetrix_mace.py: plain
+CPU vs `-k on -sf kk` (Kokkos/GPU). This is what actually exercises
+compute_symmetrix_mace_atom_kokkos / compute_symmetrix_maced_atom_kokkos --
+under -sf kk, `compute ... symmetrix/mace(d)/atom ...` auto-resolves to
+the /kk variant if one's registered.
+
+Not wired into CI -- run manually, e.g.:
+    pytest test_compute_symmetrix_mace.py -v
+On a machine without a GPU, the "-k on -sf kk" cases will run Kokkos in
+whatever host/serial backend the LAMMPS build was configured with (still
+exercises the /kk code path, just not on-device).
+"""
+
+import json
+import os
+from urllib.request import urlretrieve
+
+import ase
+from ase.neighborlist import neighbor_list
+import numpy as np
+import pytest
+
+import lammps as lmpmod
+from lammps import lammps
+import symmetrix
+
+
+MODEL_FILE = "MACE-OFF23_small-1-8.json"
+if not os.path.exists(MODEL_FILE):
+    urlretrieve(
+        "https://www.dropbox.com/scl/fi/zbg122s1zeeb1j6ogheok/MACE-OFF23_small-1-8.json?rlkey=mqb7cje9y3l0smwf75cfoahr7&st=iabk9093&dl=1",
+        MODEL_FILE,
+    )
+
+with open(MODEL_FILE) as _fh:
+    _model_data = json.load(_fh)
+NUM_CHANNELS = _model_data["num_channels"]
+NUM_LM = (_model_data["L_max"] + 1) ** 2
+# CBLAS-equivalent orientation check lives in the reference_descriptor()
+# docstring below -- this must exactly match compute_symmetrix_mace_atom's
+# cblas_dgemv(CblasTrans, ...) and compute_symmetrix_mace_atom_kokkos's
+# `s += linear_up_l0_inv(col,row) * H1(...,col)` kernel.
+LINEAR_UP_L0_INV = np.array(_model_data["linear_up_l0_inv"]).reshape(NUM_CHANNELS, NUM_CHANNELS)
+
+# Same 3-atom system test_mace.py / test_pair_symmetrix_mace.py already use.
+ELEMENTS = ["H", "O"]    # LAMMPS type 1 -> H, type 2 -> O
+ATOMS = ase.Atoms(
+    "OHH",
+    positions=[[0.0, -2.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+)
+
+
+def reference_descriptor(positions):
+    """[h1_restored | H2] per atom, driving symmetrix.MACE directly (CPU,
+    independent of whichever LAMMPS backend -- CPU or Kokkos -- is under
+    test, so it stays a trustworthy ground truth for both).
+
+    h1_restored[row] = sum_col LINEAR_UP_L0_INV[col, row] * H1[atom, 0, col]
+                      = (H1[:, 0, :] @ LINEAR_UP_L0_INV)[atom, row]
+    i.e. y = A^T x with A stored row-major -- matches
+    compute_symmetrix_mace_atom.cpp's cblas_dgemv(CblasTrans, ...) call and
+    compute_symmetrix_mace_atom_kokkos.cpp's device kernel exactly.
+    """
+    evaluator = symmetrix.MACE(MODEL_FILE)
+
+    atoms = ATOMS.copy()
+    atoms.set_positions(positions)
+    atomic_numbers = atoms.get_atomic_numbers().tolist()
+    mace_atomic_numbers = evaluator.atomic_numbers
+    i_list, j_list, r, xyz = neighbor_list("ijdD", atoms, evaluator.r_cut)
+    xyz = -xyz    # sign convention established in symmetrix/test/test_mace.py
+    num_nodes = len(atoms)
+    node_types = [mace_atomic_numbers.index(atomic_numbers[i]) for i in range(num_nodes)]
+    num_neigh = [int(np.sum(i_list == i)) for i in range(num_nodes)]
+    neigh_types = [mace_atomic_numbers.index(atomic_numbers[j]) for j in j_list]
+
+    evaluator.compute_Y(xyz.flatten())
+    evaluator.compute_R0(num_nodes, node_types, num_neigh, neigh_types, r)
+    evaluator.compute_A0(num_nodes, node_types, num_neigh, neigh_types)
+    evaluator.compute_A0_scaled(num_nodes, node_types, num_neigh, neigh_types, r)
+    evaluator.compute_M0(num_nodes, node_types)
+    evaluator.compute_H1(num_nodes)
+    evaluator.compute_R1(num_nodes, node_types, num_neigh, neigh_types, r)
+    evaluator.compute_Phi1(num_nodes, num_neigh, j_list)
+    evaluator.compute_A1(num_nodes)
+    evaluator.compute_A1_scaled(num_nodes, node_types, num_neigh, neigh_types, r)
+    evaluator.compute_M1(num_nodes, node_types)
+    evaluator.compute_H2(num_nodes, node_types)
+
+    H1 = np.array(evaluator.H1).reshape(num_nodes, NUM_LM, NUM_CHANNELS)
+    H2 = np.array(evaluator.H2).reshape(num_nodes, NUM_CHANNELS)
+    h1_restored = H1[:, 0, :] @ LINEAR_UP_L0_INV
+    return np.concatenate([h1_restored, H2], axis=1)    # (num_nodes, 2*num_channels)
+
+
+def build_lammps(cmdargs):
+    lmp = lammps(cmdargs=cmdargs)
+    lmp.commands_string(f"""
+        clear
+        units           metal
+        atom_style      atomic
+        atom_modify     map yes sort 0 0
+        boundary        p p p
+
+        region          box block -10 10 -10 10 -10 10
+        create_box      2 box
+        create_atoms    2 single  0.0 -2.0  0.0 units box
+        create_atoms    1 single  1.0  0.0  0.0 units box
+        create_atoms    1 single  0.0  1.0  0.0 units box
+        mass            1 1.008
+        mass            2 15.999
+
+        pair_style      symmetrix/mace
+        pair_coeff      * * {MODEL_FILE} H O
+
+        compute         macedesc all symmetrix/mace/atom {MODEL_FILE} H O
+        compute         macedescgrad all symmetrix/maced/atom {MODEL_FILE} H O
+
+        run 0
+    """)
+    return lmp
+
+
+CMDARGS = [
+    pytest.param(["-screen", "none"], id="cpu"),
+    pytest.param(["-screen", "none", "-k", "on", "-sf", "kk"], id="kokkos"),
+]
+
+
+@pytest.mark.parametrize("cmdargs", CMDARGS)
+def test_descriptor(cmdargs):
+    lmp = build_lammps(cmdargs)
+    try:
+        desc = lmp.numpy.extract_compute(
+            "macedesc", lmpmod.LMP_STYLE_ATOM, lmpmod.LMP_TYPE_ARRAY)
+        ids = lmp.numpy.extract_atom("id")
+        order = np.argsort(ids)
+        desc = np.array(desc, copy=True)[order]
+
+        ref = reference_descriptor(ATOMS.get_positions())
+        assert desc.shape == ref.shape
+        assert np.allclose(desc, ref, rtol=1e-4, atol=1e-6)
+    finally:
+        lmp.close()
+
+
+@pytest.mark.parametrize("cmdargs", CMDARGS)
+def test_jacobian(cmdargs):
+    """Spot-checks a handful of (atom, direction, channel) Jacobian entries
+    against central finite differences of reference_descriptor's column
+    sum -- full 2*num_channels x 3*num_atoms coverage would be correct but
+    slow (each column needs 2 extra reference_descriptor() calls); this
+    samples enough columns across both the H1 block and H2 block to catch
+    a wrong seed, a transposed sign, or a swapped block ordering.
+    """
+    lmp = build_lammps(cmdargs)
+    try:
+        jac = lmp.numpy.extract_compute(
+            "macedescgrad", lmpmod.LMP_STYLE_ATOM, lmpmod.LMP_TYPE_ARRAY)
+        ids = lmp.numpy.extract_atom("id")
+        order = np.argsort(ids)
+        jac = np.array(jac, copy=True)[order]
+        # layout: jac[atom][{0,1,2}*(2*num_channels) + col],
+        # col in [0, num_channels) -> d(h1_restored[col])/d{x,y,z}[atom]
+        # col in [num_channels, 2*num_channels) -> d(H2[col-C])/d{x,y,z}[atom]
+        two_c = 2 * NUM_CHANNELS
+        assert jac.shape == (len(ATOMS), 3 * two_c)
+
+        h = 1e-4
+        positions = ATOMS.get_positions()
+        sample_cols = sorted(set([0, 1, NUM_CHANNELS // 2, NUM_CHANNELS, NUM_CHANNELS + 1,
+                                   two_c - 1]))
+        for atom_idx in range(len(ATOMS)):
+            for w in range(3):
+                pos_p = positions.copy()
+                pos_p[atom_idx, w] += h
+                pos_m = positions.copy()
+                pos_m[atom_idx, w] -= h
+                # reference_descriptor returns (num_atoms, 2C); the global
+                # descriptor q = sum over atoms, so d q[col] / d pos[atom,w]
+                # only needs the *summed* forward difference, not per-atom.
+                q_p = reference_descriptor(pos_p).sum(axis=0)
+                q_m = reference_descriptor(pos_m).sum(axis=0)
+                dq_dw_num = (q_p - q_m) / (2 * h)
+                for col in sample_cols:
+                    got = jac[atom_idx, w * two_c + col]
+                    assert got == pytest.approx(dq_dw_num[col], rel=1e-3, abs=1e-4), (
+                        f"atom={atom_idx} dir={w} col={col}: "
+                        f"lammps={got}, numerical={dq_dw_num[col]}"
+                    )
+    finally:
+        lmp.close()

--- a/pair_symmetrix/test/test_compute_symmetrix_mace.py
+++ b/pair_symmetrix/test/test_compute_symmetrix_mace.py
@@ -23,9 +23,12 @@ Not wired into CI -- run manually, e.g.:
 
 import json
 import os
+import tempfile
+from pathlib import Path
 from urllib.request import urlretrieve
 
 import ase
+from ase.io.lammpsdata import write_lammps_data
 from ase.neighborlist import neighbor_list
 import numpy as np
 import pytest
@@ -104,30 +107,39 @@ def reference_descriptor(positions):
 
 
 def build_lammps(cmdargs):
+    # A single read_data call, not multiple create_atoms calls: LAMMPS/Kokkos
+    # has a known, unresolved upstream bug where AtomKokkos::map_set_device()
+    # segfaults (cudaErrorIllegalAddress) when create_atoms is invoked more
+    # than once in a session with atom_modify map active --
+    # https://matsci.org/t/using-lammps-create-atoms-and-run-0-in-a-kokkos-cuda-interface/59054
+    # read_data doesn't hit this path, and it's also what
+    # skmd.lammps_setup.load_config_into_lammps actually uses in production,
+    # so this is a closer match to the real usage pattern anyway.
+    atoms = ATOMS.copy()
+    atoms.set_cell([20.0, 20.0, 20.0])
+    atoms.set_pbc(True)
+
     lmp = lammps(cmdargs=cmdargs)
-    lmp.commands_string(f"""
-        clear
-        units           metal
-        atom_style      atomic
-        atom_modify     map yes sort 0 0
-        boundary        p p p
+    with tempfile.TemporaryDirectory() as tmpdir:
+        data_path = str(Path(tmpdir) / "system.data")
+        write_lammps_data(data_path, atoms, atom_style="atomic", specorder=ELEMENTS)
+        lmp.commands_string(f"""
+            clear
+            units           metal
+            atom_style      atomic
+            atom_modify     map yes sort 0 0
+            boundary        p p p
 
-        region          box block -10 10 -10 10 -10 10
-        create_box      2 box
-        create_atoms    2 single  0.0 -2.0  0.0 units box
-        create_atoms    1 single  1.0  0.0  0.0 units box
-        create_atoms    1 single  0.0  1.0  0.0 units box
-        mass            1 1.008
-        mass            2 15.999
+            read_data       {data_path}
 
-        pair_style      symmetrix/mace
-        pair_coeff      * * {MODEL_FILE} H O
+            pair_style      symmetrix/mace
+            pair_coeff      * * {MODEL_FILE} H O
 
-        compute         macedesc all symmetrix/mace/atom {MODEL_FILE} H O
-        compute         macedescgrad all symmetrix/maced/atom {MODEL_FILE} H O
+            compute         macedesc all symmetrix/mace/atom {MODEL_FILE} H O
+            compute         macedescgrad all symmetrix/maced/atom {MODEL_FILE} H O
 
-        run 0
-    """)
+            run 0
+        """)
     return lmp
 
 

--- a/pair_symmetrix/test/test_compute_symmetrix_mace.py
+++ b/pair_symmetrix/test/test_compute_symmetrix_mace.py
@@ -115,7 +115,14 @@ def build_lammps(cmdargs):
     # read_data doesn't hit this path, and it's also what
     # skmd.lammps_setup.load_config_into_lammps actually uses in production,
     # so this is a closer match to the real usage pattern anyway.
+    # ATOMS's positions (e.g. (0,-2,0)) were chosen for a box centered on
+    # the origin (the old create_atoms version used `region box block -10
+    # 10 -10 10 -10 10`). A cell of [20,20,20] implies a [0,20) box instead
+    # -- shifting by +10 in each dimension keeps every atom comfortably
+    # inside it, away from a periodic boundary (translation doesn't affect
+    # the descriptor, which only depends on relative positions).
     atoms = ATOMS.copy()
+    atoms.translate([10.0, 10.0, 10.0])
     atoms.set_cell([20.0, 20.0, 20.0])
     atoms.set_pbc(True)
 

--- a/pair_symmetrix/test/test_compute_symmetrix_mace.py
+++ b/pair_symmetrix/test/test_compute_symmetrix_mace.py
@@ -131,6 +131,8 @@ def build_lammps(cmdargs):
             boundary        p p p
 
             read_data       {data_path}
+            mass            1 1.008
+            mass            2 15.999
 
             pair_style      symmetrix/mace
             pair_coeff      * * {MODEL_FILE} H O

--- a/pair_symmetrix/test/test_pair_symmetrix_mace.py
+++ b/pair_symmetrix/test/test_pair_symmetrix_mace.py
@@ -22,7 +22,8 @@ if not os.path.exists("mace-mp-0b3-medium-hea.json"):
     "cmdargs",
     [
         ["-screen", "none"],
-        ["-screen", "none", "-k", "on", "-sf", "kk"],  # kokkos
+        ["-screen", "none", "-k", "on", "g", "1", "-sf", "kk",
+         "-pk", "kokkos", "newton", "on", "neigh", "half"],  # kokkos
     ]
 )
 @pytest.mark.parametrize(
@@ -104,7 +105,8 @@ def test_h20(cmdargs, pair_style):
     "cmdargs",
     [
         ["-screen", "none"],
-        ["-screen", "none", "-k", "on", "-sf", "kk"],  # kokkos
+        ["-screen", "none", "-k", "on", "g", "1", "-sf", "kk",
+         "-pk", "kokkos", "newton", "on", "neigh", "half"],  # kokkos
     ]
 )
 @pytest.mark.parametrize(
@@ -179,7 +181,8 @@ def test_h20_zbl(cmdargs, pair_style):
     "cmdargs",
     [
         ["-screen", "none"],
-        ["-screen", "none", "-k", "on", "-sf", "kk"],  # kokkos
+        ["-screen", "none", "-k", "on", "g", "1", "-sf", "kk",
+         "-pk", "kokkos", "newton", "on", "neigh", "half"],  # kokkos
     ]
 )
 @pytest.mark.parametrize(
@@ -281,7 +284,8 @@ def test_water(cmdargs, pair_style):
     "cmdargs",
     [
         ["-screen", "none"],
-        ["-screen", "none", "-k", "on", "-sf", "kk"],  # kokkos
+        ["-screen", "none", "-k", "on", "g", "1", "-sf", "kk",
+         "-pk", "kokkos", "newton", "on", "neigh", "half"],  # kokkos
     ]
 )
 @pytest.mark.parametrize(

--- a/symmetrix/source/symmetrix/extract_mace_data.py
+++ b/symmetrix/source/symmetrix/extract_mace_data.py
@@ -503,6 +503,10 @@ def extract_mace_data(model, species, head=None, num_spline_points=256):
     readout_1_weights = np.linalg.inv(weights_to_fuse[0,:,:]) @ readout_1_weights
     output['readout_1_weights'] = (readout_1_weights * model.scale_shift.scale.item()).tolist()
 
+    # store inverse of l=0 block for descriptor postprocessing in Symmetrix
+    W0_inv = np.linalg.inv(weights_to_fuse[0, :, :])
+    output["linear_up_l0_inv"] = W0_inv.flatten().tolist()
+
     # nonlinear readout
     #output["mlp_hidden_layers"] = 16 // TODO
     output["readout_2_weights_1"] = (


### PR DESCRIPTION
A useful feature for `symmetrix` would be the ability to use a LAMMPS `compute` to directly extract the per-atom descriptors and descriptor gradients, following the precedent set by [compute sna/atom ](https://docs.lammps.org/compute_sna_atom.html). 

To be clear, by 'descriptor' what I mean is the invariant part of the final layer, the part which is typically used as the input to the MLP readout. 

This PR will aim to

- [x] Implement a CPU compute for descriptor extraction (similar to `compute sna/atom`).
- [x] Implement a CPU compute for descriptor gradient extraction (similar to `compute snad/atom`).
- [x] Write good tests for both the above.

Before merging, would be good to:
 - Sort out the file location (computes are currently placed in `pair_symmetrix/` for ease of use with `install.sh`). 
 - Decide on a good name (right now commands will be `compute symmetrix/mace/atom` and `compute symmetrix/maced/atom`)
 - Discuss if a Kokkos implementation is necessary. 
 - Potentially discuss moving duplicated code to different files. 