### PR TITLE
fix: provide assoc_legendre fallback for libc++ (macOS build)

### DIFF
--- a/libsymmetrix/source/spherical_harmonic.cpp
+++ b/libsymmetrix/source/spherical_harmonic.cpp
@@ -4,16 +4,43 @@
 
 #include "spherical_harmonic.hpp"
 
+// Associated Legendre polynomial P_l^m(x), computed via the standard
+// upward recurrence (no Condon-Shortley phase, matching std::assoc_legendre).
+// Provided here because libc++ (e.g. on macOS) does not implement the C++17
+// mathematical special functions, unlike libstdc++.
+static double assoc_legendre(int l, int m, double x) {
+    if (m < 0 || m > l) return 0.0;
+    double pmm = 1.0;
+    if (m > 0) {
+        const double somx2 = std::sqrt((1.0 - x) * (1.0 + x));
+        double fact = 1.0;
+        for (int i = 1; i <= m; ++i) {
+            pmm *= fact * somx2;
+            fact += 2.0;
+        }
+    }
+    if (l == m) return pmm;
+    double pmmp1 = x * (2 * m + 1) * pmm;
+    if (l == m + 1) return pmmp1;
+    double pll = 0.0;
+    for (int ll = m + 2; ll <= l; ++ll) {
+        pll = ((2 * ll - 1) * x * pmmp1 - (ll + m - 1) * pmm) / (ll - m);
+        pmm = pmmp1;
+        pmmp1 = pll;
+    }
+    return pll;
+}
+
 std::complex<double> sph_harm(int l, int m, double polar, double azimuth) {
     if (m >=0) {
         return std::pow(-1,m)
             * std::sqrt((2*l+1)/(4*M_PI)*std::tgamma(1+l-m)/std::tgamma(1+l+m))
-            * std::assoc_legendre(l,m,std::cos(polar))
+            * assoc_legendre(l,m,std::cos(polar))
             * std::exp(std::complex<double>(0,1)*double(m)*azimuth);
     } else {
         return std::pow(-1,m)
             * std::sqrt((2*l+1)/(4*M_PI)*std::tgamma(1+l-m)/std::tgamma(1+l+m))
-            * std::pow(-1,m)*std::tgamma(1+l+m)/std::tgamma(1+l-m)*std::assoc_legendre(l,-m,std::cos(polar))
+            * std::pow(-1,m)*std::tgamma(1+l+m)/std::tgamma(1+l-m)*assoc_legendre(l,-m,std::cos(polar))
             * std::exp(std::complex<double>(0,1)*double(m)*azimuth);
     }
 }


### PR DESCRIPTION
`spherical_harmonic.cpp` uses `std::assoc_legendre`, one of the C++17 mathematical special functions. These are optional in the standard, and libc++ (the default standard library on macOS) does not implement them, so the build currently fails on macOS with:

```
error: no member named 'assoc_legendre' in namespace 'std'
```

This replaces the two `std::assoc_legendre` call sites with a small standalone implementation using the standard upward recurrence. The convention matches `std::assoc_legendre` exactly (no Condon-Shortley phase). I verified the output is bit-identical to libstdc++'s `std::assoc_legendre` across a range of (l, m, x) values.

The affected functions (`sph_harm` / `real_sph_harm`) are reference routines not on the production `sphericart` path, so there is no performance impact. Verified that `libsymmetrix` now builds cleanly on macOS (Apple Clang) with the Kokkos serial backend.