### PR TITLE
fix: handle empty neighbor list for isolated atoms (closes #42)

### DIFF
--- a/symmetrix/source/symmetrix/symmetrix_calc.py
+++ b/symmetrix/source/symmetrix/symmetrix_calc.py
@@ -75,7 +75,10 @@ class Symmetrix(Calculator):
         ase_atomic_numbers = self.atoms.get_atomic_numbers().tolist()
         mace_atomic_numbers = self.evaluator.atomic_numbers
         i_list, j_list, r, xyz = neighbor_list('ijdD', self.atoms, self.cutoff)
-        num_nodes = np.max(i_list) + 1
+        # `num_nodes` is the number of atoms; deriving it from `i_list` fails when
+        # the neighbor list is empty (e.g. isolated atoms beyond the cutoff) and
+        # under-counts if the highest-indexed atoms have no neighbors.
+        num_nodes = len(self.atoms)
         node_types = [mace_atomic_numbers.index(ase_atomic_numbers[i]) for i in range(num_nodes)]
         num_neigh = np.bincount(j_list, minlength=num_nodes)
         neigh_types = [mace_atomic_numbers.index(ase_atomic_numbers[j]) for j in j_list]

--- a/symmetrix/test/test_symmetrix_calc.py
+++ b/symmetrix/test/test_symmetrix_calc.py
@@ -227,3 +227,20 @@ def do_grad_test(atoms, calc, check, ax=None, label=None, plot_factor=1.0):
 
     if check:
         assert passed_f and passed_s
+
+
+@pytest.mark.parametrize("use_kokkos", [True, False])
+def test_isolated_atoms(model_cache, use_kokkos):
+    # Two atoms beyond the model cutoff produce an empty neighbor list.
+    # Regression test for https://github.com/wcwitt/symmetrix/issues/42
+    calc = Symmetrix(model_cache["mace-mp-0b3-medium-1-8.json"], use_kokkos=use_kokkos)
+    atoms = Atoms('OO', cell=[20] * 3, positions=[[0, 0, 0], [10, 0, 0]], pbc=[True] * 3)
+    atoms.calc = calc
+
+    energy = atoms.get_potential_energy()
+    forces = atoms.get_forces()
+
+    assert np.isfinite(energy)
+    assert forces.shape == (2, 3)
+    # isolated atoms feel no forces
+    assert np.allclose(forces, 0.0, atol=1e-8)


### PR DESCRIPTION
Fixes #42.

When a system has atoms with no neighbors within the cutoff (e.g. two isolated atoms far apart), the neighbor list is empty and `num_nodes = np.max(i_list) + 1` raises:

```
ValueError: zero-size array to reduction operation maximum which has no identity
```

This sets `num_nodes = len(self.atoms)` instead. Besides fixing the crash, this is more correct in general: deriving the node count from `i_list` also under-counts when the highest-indexed atoms happen to have no neighbors.

With the empty neighbor list, the downstream `np.bincount(..., minlength=num_nodes)` calls already return correctly-sized zero arrays, so isolated atoms get zero forces and their self-energies, as expected.

Added a regression test (`test_isolated_atoms`) reproducing the exact case from the issue (two O atoms 10 Å apart), checking that the energy is finite and the forces are zero.