### PR TITLE
fix: clear error when model file is missing or malformed (closes #20)

### DIFF
--- a/libsymmetrix/source/mace.cpp
+++ b/libsymmetrix/source/mace.cpp
@@ -1,5 +1,6 @@
 #include <iostream> //TODO
 #include <fstream>
+#include <stdexcept>
 #include <numbers>
 #include <numeric>
 
@@ -906,7 +907,16 @@ void MACE::load_from_json(
     const std::string filename)
 {
     std::ifstream f(filename);
-    nlohmann::json file = nlohmann::json::parse(f);
+    if (!f) {
+        throw std::runtime_error("Could not open model file: " + filename);
+    }
+    nlohmann::json file;
+    try {
+        file = nlohmann::json::parse(f);
+    } catch (const nlohmann::json::parse_error& e) {
+        throw std::runtime_error(
+            "Failed to parse model file '" + filename + "': " + e.what());
+    }
 
     // Basic model information
     num_elements = file["num_elements"];

--- a/libsymmetrix/source/mace_kokkos.cpp
+++ b/libsymmetrix/source/mace_kokkos.cpp
@@ -1,4 +1,5 @@
 #include <fstream>
+#include <stdexcept>
 #include <numbers>
 
 // TODO: remove some of these headers?
@@ -1545,7 +1546,16 @@ template <typename Precision>
 void MACEKokkos<Precision>::load_from_json(std::string filename)
 {
     std::ifstream f(filename);
-    nlohmann::json file = nlohmann::json::parse(f);
+    if (!f) {
+        throw std::runtime_error("Could not open model file: " + filename);
+    }
+    nlohmann::json file;
+    try {
+        file = nlohmann::json::parse(f);
+    } catch (const nlohmann::json::parse_error& e) {
+        throw std::runtime_error(
+            "Failed to parse model file '" + filename + "': " + e.what());
+    }
     
     // Basic model information
     num_elements = file["num_elements"];


### PR DESCRIPTION
Fixes #20.

Loading a missing or malformed model file previously ran `nlohmann::json::parse` on a failed/unopened stream, producing a confusing crash rather than a useful message:

```
Loading MACEKokkos model from '.../model.json' ... malloc_consolidate(): invalid chunk size
```

This adds two checks in `load_from_json` (in both `mace.cpp` and `mace_kokkos.cpp`):
- if the file cannot be opened, throw `Could not open model file: <path>`
- if parsing fails, throw `Failed to parse model file '<path>': <detail>`

Verified on macOS: loading a nonexistent path now throws `Could not open model file: /tmp/does_not_exist.json` instead of crashing.