### PR TITLE
Add field-aware MACE support and compact v2 model format

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,8 +62,14 @@ jobs:
       run: |
         uv venv --clear
         source .venv/bin/activate
-        uv pip install pip numpy pytest
+        uv pip install pip pytest "./symmetrix" \
+          "mace-torch @ git+https://github.com/mdi-group/mace-field.git@1.0.2"
         deactivate
+    - name: Cache test models
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/symmetrix/test-models
+        key: symmetrix-test-models-macefield-1.0.2
     - name: Clone and build LAMMPS
       run: |
         source .venv/bin/activate
@@ -104,8 +110,10 @@ jobs:
         include:
         - mace-torch: "mace-torch==0.3.10"
           torch: "torch==2.5.*"
-        - mace-torch: "mace-torch"
+          field-aware: false
+        - mace-torch: "mace-torch @ git+https://github.com/mdi-group/mace-field.git@1.0.2"
           torch: "torch"
+          field-aware: true
     steps:
     - name: Clone repo
       uses: actions/checkout@v6
@@ -123,17 +131,65 @@ jobs:
       run: |
         uv venv --clear
         source .venv/bin/activate
-        uv pip install "${{ matrix.torch }}" "${{ matrix.mace-torch }}" "./symmetrix[mace]"
+        uv pip install "${{ matrix.torch }}" "${{ matrix.mace-torch }}" "./symmetrix[mace]" pytest
+        deactivate
+    - name: Cache test models
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/symmetrix/test-models
+        key: symmetrix-test-models-macefield-1.0.2
+    - name: Test MACEField model download
+      run: |
+        source .venv/bin/activate
+        PYTHONPATH=symmetrix/test python -c "from model_downloads import macefield_model_path; print(macefield_model_path())"
+        deactivate
+    - name: Test compact MACEField conversion and ASE integration
+      if: matrix.field-aware
+      run: |
+        source .venv/bin/activate
+        cd symmetrix/test
+        pytest -q \
+          test_extract_mace_data.py \
+          test_symmetrix_calc.py::test_compact_macefield_calculator_replaces_active_composition_cache \
+          test_symmetrix_calc.py::test_macefield_native_json_ase_response_properties_match_pytorch \
+          test_symmetrix_calc.py::test_macefield_json_kokkos_response_properties_match_native
         deactivate
     - name: Test model extraction
       run: |
         source .venv/bin/activate
-        # check for valid symmetrix json from atomic numbers and default filename
+        # check compact universal conversion and its default filename
         wget https://github.com/ACEsuit/mace-off/raw/refs/heads/main/mace_off23/MACE-OFF23_small.model
-        symmetrix_extract_mace --model MACE-OFF23_small.model --atomic-numbers 1 8
-        python3 -c "from symmetrix import Symmetrix; calc = Symmetrix('MACE-OFF23_small-1-8.json', species=[1, 8])"
-        # check for valid symmetrix json from checmical symbols and specified filename
-        wget https://github.com/ACEsuit/mace-off/raw/refs/heads/main/mace_off23/MACE-OFF23_medium.model
-        symmetrix_extract_mace --model MACE-OFF23_medium.model --chemical-symbols H O -o extract_test.json
-        python3 -c "from symmetrix import Symmetrix; calc = Symmetrix('extract_test.json', species=[1, 8])"
+        symmetrix_extract_mace --model MACE-OFF23_small.model
+        python3 -c "from symmetrix import Symmetrix; calc = Symmetrix('MACE-OFF23_small-universal.json')"
+        # compare legacy pair splines from chemical symbols with compact output
+        symmetrix_extract_mace --model MACE-OFF23_small.model --chemical-symbols H O --radial-format pair-splines -o extract_test.json
+        python3 - <<'PY'
+        import numpy as np
+        from ase import Atoms
+        from symmetrix import Symmetrix
+
+        atoms = Atoms("OH", positions=[[0, 0, 0], [0, 0, 1]], cell=[10, 10, 10])
+        for dtype, energy_tolerance, force_tolerance in (
+            ("float64", 1e-10, 1e-9),
+            ("float32", 1e-4, 1e-4),
+        ):
+            compact_atoms = atoms.copy()
+            legacy_atoms = atoms.copy()
+            compact_atoms.calc = Symmetrix(
+                "MACE-OFF23_small-universal.json", use_kokkos=True, dtype=dtype,
+            )
+            legacy_atoms.calc = Symmetrix(
+                "extract_test.json", use_kokkos=True, dtype=dtype,
+            )
+            assert np.allclose(
+                compact_atoms.get_potential_energy(),
+                legacy_atoms.get_potential_energy(),
+                atol=energy_tolerance,
+            )
+            assert np.allclose(
+                compact_atoms.get_forces(),
+                legacy_atoms.get_forces(),
+                atol=force_tolerance,
+            )
+        PY
         deactivate

--- a/libsymmetrix/CMakeLists.txt
+++ b/libsymmetrix/CMakeLists.txt
@@ -24,6 +24,7 @@ endif()
 # ----- libsymmetrix -----
 
 set(SYMMETRIX_SOURCE_FILES
+    source/compact_radial.cpp
     source/cubic_spline.cpp
     source/cubic_spline_set.cpp
     source/mace.cpp

--- a/libsymmetrix/source/compact_radial.cpp
+++ b/libsymmetrix/source/compact_radial.cpp
@@ -1,0 +1,283 @@
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+#include <utility>
+
+#include <nlohmann/json.hpp>
+
+#include "compact_radial.hpp"
+
+namespace {
+
+CompactRadialModel::Network parse_network(
+    const nlohmann::json& definition,
+    const std::string& name)
+{
+    CompactRadialModel::Network network;
+    network.shape = definition.at("shape").get<std::vector<int>>();
+    network.weights = definition.at("weights").get<std::vector<std::vector<double>>>();
+    network.activation_scale = definition.at("activation_scale").get<double>();
+    const auto postprocess = definition.value("postprocess", std::string());
+    if (!postprocess.empty() && postprocess != "tanh-square")
+        throw std::invalid_argument(
+            "Compact radial network " + name + " has unsupported postprocessing.");
+    network.tanh_square = postprocess == "tanh-square";
+
+    if (definition.at("activation").get<std::string>() != "silu")
+        throw std::invalid_argument("Compact radial network " + name + " must use SiLU.");
+    if (network.shape.size() < 2 || network.weights.size() != network.shape.size()-1)
+        throw std::invalid_argument("Compact radial network " + name + " has an invalid shape.");
+    if (!std::isfinite(network.activation_scale) || network.activation_scale <= 0.0)
+        throw std::invalid_argument(
+            "Compact radial network " + name + " has an invalid activation scale.");
+    for (int layer=0; layer<network.weights.size(); ++layer) {
+        if (network.shape[layer] <= 0 || network.shape[layer+1] <= 0)
+            throw std::invalid_argument(
+                "Compact radial network " + name + " has a non-positive layer size.");
+        const auto expected = static_cast<std::size_t>(network.shape[layer]*network.shape[layer+1]);
+        if (network.weights[layer].size() != expected)
+            throw std::invalid_argument("Compact radial network " + name + " has invalid weights.");
+        if (!std::all_of(
+                network.weights[layer].begin(),
+                network.weights[layer].end(),
+                [] (double value) { return std::isfinite(value); }))
+            throw std::invalid_argument(
+                "Compact radial network " + name + " has non-finite weights.");
+    }
+
+    network.mlp = std::make_unique<MultilayerPerceptron>(
+        network.shape,
+        network.weights,
+        network.activation_scale);
+    return network;
+}
+
+}  // namespace
+
+CompactRadialModel::CompactRadialModel(
+    std::string definition_json,
+    std::vector<int> atomic_numbers,
+    double r_cut)
+    : atomic_numbers(std::move(atomic_numbers))
+{
+    const auto definition = nlohmann::json::parse(definition_json);
+    grid_min = definition.at("spline_grid_min").get<double>();
+    spline_points = definition.at("num_spline_points").get<int>();
+    if (!std::isfinite(grid_min) || grid_min <= 0.0)
+        throw std::invalid_argument("Compact radial model has an invalid spline grid minimum.");
+    if (spline_points < 4)
+        throw std::invalid_argument("Compact radial model requires at least four spline points.");
+    h = (r_cut-grid_min)/(spline_points-1);
+    if (!(h > 0.0))
+        throw std::invalid_argument("Compact radial model has an invalid spline grid.");
+
+    const auto& basis = definition.at("basis");
+    if (basis.at("type").get<std::string>() != "bessel")
+        throw std::invalid_argument("Compact radial model only supports a Bessel basis.");
+    bessel_weights = basis.at("weights").get<std::vector<double>>();
+    bessel_prefactor = basis.at("prefactor").get<double>();
+    if (bessel_weights.empty()
+        || !std::isfinite(bessel_prefactor)
+        || !std::all_of(
+            bessel_weights.begin(), bessel_weights.end(),
+            [] (double value) { return std::isfinite(value); }))
+        throw std::invalid_argument("Compact radial model has invalid Bessel data.");
+
+    const auto& cutoff = definition.at("cutoff");
+    if (cutoff.at("type").get<std::string>() != "polynomial")
+        throw std::invalid_argument("Compact radial model only supports a polynomial cutoff.");
+    cutoff_r_max = cutoff.at("r_max").get<double>();
+    cutoff_p = cutoff.at("p").get<int>();
+    if (!std::isfinite(cutoff_r_max) || cutoff_p <= 0)
+        throw std::invalid_argument("Compact radial model has invalid cutoff data.");
+    if (std::abs(cutoff_r_max-r_cut) > 1e-12)
+        throw std::invalid_argument("Compact radial cutoff does not match model r_cut.");
+
+    const auto& transform = definition.at("distance_transform");
+    const auto transform_type = transform.at("type").get<std::string>();
+    use_agnesi = transform_type == "agnesi";
+    if (use_agnesi) {
+        agnesi_a = transform.at("a").get<double>();
+        agnesi_q = transform.at("q").get<double>();
+        agnesi_p = transform.at("p").get<double>();
+        covalent_radii = transform.at("covalent_radii").get<std::vector<double>>();
+        if (covalent_radii.size() != this->atomic_numbers.size())
+            throw std::invalid_argument("Compact radial covalent radii do not match atomic numbers.");
+        if (!std::isfinite(agnesi_a)
+            || !std::isfinite(agnesi_q)
+            || !std::isfinite(agnesi_p)
+            || !std::all_of(
+                covalent_radii.begin(), covalent_radii.end(),
+                [] (double value) { return std::isfinite(value) && value > 0.0; }))
+            throw std::invalid_argument("Compact radial model has invalid Agnesi data.");
+    } else if (transform_type != "none") {
+        throw std::invalid_argument("Compact radial model has an unsupported distance transform.");
+    }
+
+    const auto& networks = definition.at("networks");
+    R0_network = parse_network(networks.at("R0"), "R0");
+    R1_network = parse_network(networks.at("R1"), "R1");
+    if (R0_network.shape.front() != bessel_weights.size()
+        || R1_network.shape.front() != bessel_weights.size())
+        throw std::invalid_argument("Compact radial network input does not match the Bessel basis.");
+    if (R0_network.tanh_square || R1_network.tanh_square)
+        throw std::invalid_argument("Compact radial R0/R1 networks cannot use postprocessing.");
+    if (networks.contains("A0")) {
+        A0_network = std::make_unique<Network>(parse_network(networks.at("A0"), "A0"));
+        if (A0_network->shape.front() != bessel_weights.size()
+            || A0_network->shape.back() != 1
+            || !A0_network->tanh_square)
+            throw std::invalid_argument("Compact radial A0 network has an invalid shape or postprocessing.");
+    }
+    if (networks.contains("A1")) {
+        A1_network = std::make_unique<Network>(parse_network(networks.at("A1"), "A1"));
+        if (A1_network->shape.front() != bessel_weights.size()
+            || A1_network->shape.back() != 1
+            || !A1_network->tanh_square)
+            throw std::invalid_argument("Compact radial A1 network has an invalid shape or postprocessing.");
+    }
+}
+
+double CompactRadialModel::spline_h() const
+{
+    return h;
+}
+
+double CompactRadialModel::spline_min() const
+{
+    return grid_min;
+}
+
+int CompactRadialModel::num_spline_points() const
+{
+    return spline_points;
+}
+
+bool CompactRadialModel::has_A0() const
+{
+    return static_cast<bool>(A0_network);
+}
+
+bool CompactRadialModel::has_A1() const
+{
+    return static_cast<bool>(A1_network);
+}
+
+std::vector<double> CompactRadialModel::radial_features(int type_i, int type_j) const
+{
+    if (type_i < 0 || type_i >= atomic_numbers.size()
+        || type_j < 0 || type_j >= atomic_numbers.size())
+        throw std::out_of_range("Compact radial model type index is out of range.");
+
+    double r0 = 1.0;
+    if (use_agnesi)
+        r0 = 0.5*(covalent_radii[type_i]+covalent_radii[type_j]);
+
+    auto features = std::vector<double>(spline_points*bessel_weights.size());
+    for (int node=0; node<spline_points; ++node) {
+        const double r = grid_min+node*h;
+        double transformed_r = r;
+        if (use_agnesi) {
+            const double scaled_r = r/r0;
+            transformed_r = 1.0/(
+                1.0
+                + agnesi_a*std::pow(scaled_r, agnesi_q)
+                    /(1.0+std::pow(scaled_r, agnesi_q-agnesi_p)));
+        }
+
+        double cutoff_value = 0.0;
+        if (r < cutoff_r_max) {
+            const double scaled_r = r/cutoff_r_max;
+            cutoff_value = 1.0
+                - ((cutoff_p+1.0)*(cutoff_p+2.0)/2.0)*std::pow(scaled_r, cutoff_p)
+                + cutoff_p*(cutoff_p+2.0)*std::pow(scaled_r, cutoff_p+1)
+                - (cutoff_p*(cutoff_p+1.0)/2.0)*std::pow(scaled_r, cutoff_p+2);
+        }
+
+        for (int basis=0; basis<bessel_weights.size(); ++basis) {
+            features[node*bessel_weights.size()+basis] =
+                bessel_prefactor
+                * std::sin(bessel_weights[basis]*transformed_r)
+                / transformed_r
+                * cutoff_value;
+        }
+    }
+    return features;
+}
+
+RadialSplineData CompactRadialModel::evaluate_network(
+    Network& network,
+    const std::vector<double>& features)
+{
+    auto batch_values = network.mlp->evaluate_batch(features, spline_points);
+    const int num_functions = network.shape.back();
+    if (network.tanh_square) {
+        for (auto& value : batch_values)
+            value = std::tanh(value*value);
+    }
+
+    RadialSplineData result;
+    result.values.resize(num_functions, std::vector<double>(spline_points));
+    result.derivatives.resize(num_functions, std::vector<double>(spline_points));
+    for (int function=0; function<num_functions; ++function) {
+        for (int node=0; node<spline_points; ++node)
+            result.values[function][node] = batch_values[node*num_functions+function];
+        result.derivatives[function] = spline_derivatives(result.values[function]);
+    }
+    return result;
+}
+
+std::vector<double> CompactRadialModel::spline_derivatives(
+    const std::vector<double>& values) const
+{
+    if (values.size() != spline_points)
+        throw std::invalid_argument("Compact radial spline values have an invalid size.");
+
+    const int unknowns = spline_points-2;
+    auto lower = std::vector<double>(unknowns, 0.0);
+    auto diagonal = std::vector<double>(unknowns, 4.0);
+    auto upper = std::vector<double>(unknowns, 0.0);
+    auto rhs = std::vector<double>(unknowns, 0.0);
+
+    const double left_not_a_knot =
+        2.0*(-values[0]+2.0*values[1]-values[2])/h;
+    upper[0] = 2.0;
+    rhs[0] = 3.0*(values[2]-values[0])/h-left_not_a_knot;
+    for (int node=2; node<spline_points-1; ++node) {
+        const int row = node-1;
+        lower[row] = 1.0;
+        if (node+1 <= spline_points-2)
+            upper[row] = 1.0;
+        rhs[row] = 3.0*(values[node+1]-values[node-1])/h;
+    }
+
+    for (int row=1; row<unknowns; ++row) {
+        const double factor = lower[row]/diagonal[row-1];
+        diagonal[row] -= factor*upper[row-1];
+        rhs[row] -= factor*rhs[row-1];
+    }
+    auto solution = std::vector<double>(unknowns, 0.0);
+    solution.back() = rhs.back()/diagonal.back();
+    for (int row=unknowns-2; row>=0; --row)
+        solution[row] = (rhs[row]-upper[row]*solution[row+1])/diagonal[row];
+
+    auto derivatives = std::vector<double>(spline_points, 0.0);
+    for (int node=1; node<spline_points-1; ++node)
+        derivatives[node] = solution[node-1];
+    derivatives[0] = derivatives[2]+left_not_a_knot;
+    derivatives.back() = 0.0;
+    return derivatives;
+}
+
+CompactRadialPairTables CompactRadialModel::materialize_pair(int type_i, int type_j)
+{
+    const auto features = radial_features(type_i, type_j);
+    CompactRadialPairTables result;
+    result.R0 = evaluate_network(R0_network, features);
+    result.R1 = evaluate_network(R1_network, features);
+    if (A0_network)
+        result.A0 = evaluate_network(*A0_network, features);
+    if (A1_network)
+        result.A1 = evaluate_network(*A1_network, features);
+    return result;
+}

--- a/libsymmetrix/source/compact_radial.hpp
+++ b/libsymmetrix/source/compact_radial.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "multilayer_perceptron.hpp"
+
+struct RadialSplineData {
+    std::vector<std::vector<double>> values;
+    std::vector<std::vector<double>> derivatives;
+};
+
+struct CompactRadialPairTables {
+    RadialSplineData R0;
+    RadialSplineData R1;
+    RadialSplineData A0;
+    RadialSplineData A1;
+};
+
+class CompactRadialModel {
+public:
+    struct Network {
+        std::vector<int> shape;
+        std::vector<std::vector<double>> weights;
+        double activation_scale;
+        bool tanh_square;
+        std::unique_ptr<MultilayerPerceptron> mlp;
+    };
+
+    CompactRadialModel(
+        std::string definition_json,
+        std::vector<int> atomic_numbers,
+        double r_cut);
+
+    CompactRadialPairTables materialize_pair(int type_i, int type_j);
+
+    double spline_h() const;
+    double spline_min() const;
+    int num_spline_points() const;
+    bool has_A0() const;
+    bool has_A1() const;
+
+private:
+    double grid_min;
+    int spline_points;
+    double cutoff_r_max;
+    int cutoff_p;
+    double h;
+    std::vector<int> atomic_numbers;
+    std::vector<double> bessel_weights;
+    double bessel_prefactor;
+
+    bool use_agnesi;
+    double agnesi_a;
+    double agnesi_q;
+    double agnesi_p;
+    std::vector<double> covalent_radii;
+
+    Network R0_network;
+    Network R1_network;
+    std::unique_ptr<Network> A0_network;
+    std::unique_ptr<Network> A1_network;
+
+    std::vector<double> radial_features(int type_i, int type_j) const;
+    RadialSplineData evaluate_network(Network& network, const std::vector<double>& features);
+    std::vector<double> spline_derivatives(const std::vector<double>& values) const;
+};

--- a/libsymmetrix/source/cubic_spline.cpp
+++ b/libsymmetrix/source/cubic_spline.cpp
@@ -1,26 +1,37 @@
-#include <stdexcept>
-#include <vector>
-#include <string>
 #include <algorithm>
 #include <cmath>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 #include "cubic_spline.hpp"
 
 CubicSpline::CubicSpline(
     double h,
     std::vector<double> nodal_values,
-    std::vector<double> nodal_derivs)
+    std::vector<double> nodal_derivs,
+    double x0)
     : h(h),
+      x0(x0),
       c(generate_coefficients(h, nodal_values, nodal_derivs))
 {
 }
 
 double CubicSpline::evaluate(double r)
 {
-    if (r<0 or r>h*c.size()/4 or std::isnan(r))
+    const int num_intervals = c.size()/4;
+    int i = static_cast<int>(std::floor((r-x0)/h));
+    double x = r-x0-h*i;
+    const double upper_bound = x0+h*num_intervals;
+    if (std::isnan(r) || ((r < x0 || r > upper_bound) && x0 == 0.0))
         throw std::invalid_argument("Out of bounds in CubicSpline::evaluate. r=" + std::to_string(r));
-    const int i = std::clamp(static_cast<int>(r / h), 0, static_cast<int>(c.size()/4 - 1));
-    const double x = r - h*i;
+    if (i < 0) {
+        i = 0;
+        x = 0.0;
+    } else if (i >= num_intervals) {
+        i = num_intervals-1;
+        x = h;
+    }
     const double xx = x*x;
     const double xxx = xx*x;
     const int i4 = 4*i;
@@ -30,10 +41,19 @@ double CubicSpline::evaluate(double r)
 
 std::tuple<double,double> CubicSpline::evaluate_deriv(double r)
 {
-    if (r<0 or r>h*c.size()/4 or std::isnan(r))
+    const int num_intervals = c.size()/4;
+    int i = static_cast<int>(std::floor((r-x0)/h));
+    double x = r-x0-h*i;
+    const double upper_bound = x0+h*num_intervals;
+    if (std::isnan(r) || ((r < x0 || r > upper_bound) && x0 == 0.0))
         throw std::invalid_argument("Out of bounds in CubicSpline::evaluate_deriv. r=" + std::to_string(r));
-    const int i = std::clamp(static_cast<int>(r / h), 0, static_cast<int>(c.size()/4 - 1));
-    const double x = r - h*i;
+    if (i < 0) {
+        i = 0;
+        x = 0.0;
+    } else if (i >= num_intervals) {
+        i = num_intervals-1;
+        x = h;
+    }
     const double xx = x*x;
     const double xxx = xx*x;
     const int i4 = 4*i;
@@ -43,10 +63,19 @@ std::tuple<double,double> CubicSpline::evaluate_deriv(double r)
 
 std::tuple<double,double> CubicSpline::evaluate_deriv_divided(double r)
 {
-    if (r<=0 or r>h*c.size()/4 or std::isnan(r))
+    const int num_intervals = c.size()/4;
+    int i = static_cast<int>(std::floor((r-x0)/h));
+    double x = r-x0-h*i;
+    const double upper_bound = x0+h*num_intervals;
+    if (r <= 0.0 || std::isnan(r) || (r > upper_bound && x0 == 0.0))
         throw std::invalid_argument("Out of bounds in CubicSpline::evaluate_deriv_divided. r=" + std::to_string(r));
-    const int i = std::clamp(static_cast<int>(r / h), 0, static_cast<int>(c.size()/4 - 1));
-    const double x = r - h*i;
+    if (i < 0) {
+        i = 0;
+        x = 0.0;
+    } else if (i >= num_intervals) {
+        i = num_intervals-1;
+        x = h;
+    }
     const double xx = x*x;
     const double xxx = xx*x;
     const int i4 = 4*i;

--- a/libsymmetrix/source/cubic_spline.hpp
+++ b/libsymmetrix/source/cubic_spline.hpp
@@ -9,7 +9,8 @@ public:
 
 CubicSpline(double h,
             std::vector<double> nodal_values,
-            std::vector<double> nodal_derivs);
+            std::vector<double> nodal_derivs,
+            double x0 = 0.0);
 
 auto evaluate(double r) -> double;
 auto evaluate_deriv(double r) -> std::tuple<double,double>;
@@ -18,6 +19,7 @@ auto evaluate_deriv_divided(double r) -> std::tuple<double,double>;
 private:
 
 double h;
+double x0;
 std::vector<double> c;
 
 auto generate_coefficients(

--- a/libsymmetrix/source/cubic_spline_set.cpp
+++ b/libsymmetrix/source/cubic_spline_set.cpp
@@ -1,14 +1,17 @@
 #include <vector>
+#include <cmath>
 
 #include "cubic_spline_set.hpp"
 
 CubicSplineSet::CubicSplineSet(
     double h,
     std::vector<std::vector<double>> nodal_values,
-    std::vector<std::vector<double>> nodal_derivs)
+    std::vector<std::vector<double>> nodal_derivs,
+    double x0)
 {
     // TODO: sanitize input
     this->h = h;
+    this->x0 = x0;
     num_nodes = nodal_values[0].size();
     num_splines = nodal_values.size();
     c = std::vector<double>(4*num_splines*(num_nodes-1), 0.0);
@@ -28,9 +31,15 @@ void CubicSplineSet::evaluate(
     double r,
     std::span<double> values)
 {
-    // TODO: bounds checking
-    const int i = static_cast<int>(r / h);
-    const double x = r - h*i;
+    int i = static_cast<int>(std::floor((r-x0)/h));
+    double x = r-x0-h*i;
+    if (i < 0) {
+        i = 0;
+        x = 0.0;
+    } else if (i >= num_nodes-1) {
+        i = num_nodes-2;
+        x = h;
+    }
     const double xx = x*x;
     const double xxx = xx*x;
     double* c_i = c.data() + 4*i*num_splines;
@@ -51,9 +60,15 @@ void CubicSplineSet::evaluate_derivs(double r,
                                      std::span<double> values,
                                      std::span<double> derivs)
 {
-    // TODO: bounds checking
-    const int i = static_cast<int>(r / h);
-    const double x = r - h*i;
+    int i = static_cast<int>(std::floor((r-x0)/h));
+    double x = r-x0-h*i;
+    if (i < 0) {
+        i = 0;
+        x = 0.0;
+    } else if (i >= num_nodes-1) {
+        i = num_nodes-2;
+        x = h;
+    }
     const double xx = x*x;
     const double xxx = xx*x;
     const double two_x = 2*x;

--- a/libsymmetrix/source/cubic_spline_set.hpp
+++ b/libsymmetrix/source/cubic_spline_set.hpp
@@ -9,7 +9,8 @@ public:
 
 CubicSplineSet(double h,
                std::vector<std::vector<double>> nodal_values,
-               std::vector<std::vector<double>> nodal_derivs);
+               std::vector<std::vector<double>> nodal_derivs,
+               double x0 = 0.0);
 
 void evaluate(double r, std::span<double> values);
 void evaluate_derivs(double r, std::span<double> values, std::span<double> derivs);
@@ -20,6 +21,7 @@ int num_splines;
 private:
 
 double h;
+double x0;
 int num_nodes;
 std::vector<double> c;
 

--- a/libsymmetrix/source/mace.cpp
+++ b/libsymmetrix/source/mace.cpp
@@ -1,7 +1,10 @@
+#include <algorithm>
 #include <iostream> //TODO
 #include <fstream>
+#include <cmath>
 #include <numbers>
 #include <numeric>
+#include <stdexcept>
 
 #include "nlohmann/json.hpp"
 #include "sphericart.hpp"
@@ -12,6 +15,101 @@
 MACE::MACE(std::string filename)
 {
     load_from_json(filename);
+}
+
+void MACE::prepare_active_types(std::span<const int> node_types)
+{
+    if (!uses_compact_radial)
+        return;
+
+    auto requested_types = std::vector<int>(node_types.begin(), node_types.end());
+    std::sort(requested_types.begin(), requested_types.end());
+    requested_types.erase(
+        std::unique(requested_types.begin(), requested_types.end()),
+        requested_types.end());
+    if (requested_types.empty())
+        throw std::invalid_argument("MACE compact radial cache requires at least one active type.");
+    for (const int type : requested_types)
+        if (type < 0 || type >= atomic_numbers.size())
+            throw std::out_of_range("MACE active type index is out of range.");
+    if (requested_types == active_types)
+        return;
+
+    auto new_spl_set_0 = std::vector<std::unique_ptr<CubicSplineSet>>();
+    auto new_spl_set_1 = std::vector<std::unique_ptr<CubicSplineSet>>();
+    auto new_A0_splines = std::vector<CubicSpline>();
+    auto new_A1_splines = std::vector<CubicSpline>();
+    const int pair_count = requested_types.size()*(requested_types.size()+1)/2;
+    new_spl_set_0.reserve(pair_count);
+    new_spl_set_1.reserve(pair_count);
+    if (A0_scaled)
+        new_A0_splines.reserve(pair_count);
+    if (A1_scaled)
+        new_A1_splines.reserve(pair_count);
+
+    const double h = compact_radial_model->spline_h();
+    const double x0 = compact_radial_model->spline_min();
+    for (int local_i=0; local_i<requested_types.size(); ++local_i) {
+        for (int local_j=local_i; local_j<requested_types.size(); ++local_j) {
+            auto tables = compact_radial_model->materialize_pair(
+                requested_types[local_i], requested_types[local_j]);
+            const auto expected_R0 = static_cast<std::size_t>((l_max+1)*num_channels);
+            const auto expected_R1 = static_cast<std::size_t>(Phi1_l.size()*num_channels);
+            if (tables.R0.values.size() != expected_R0
+                || tables.R0.derivatives.size() != expected_R0)
+                throw std::runtime_error("Compact radial R0 output has an invalid size.");
+            if (tables.R1.values.size() != expected_R1
+                || tables.R1.derivatives.size() != expected_R1)
+                throw std::runtime_error("Compact radial R1 output has an invalid size.");
+            new_spl_set_0.push_back(std::make_unique<CubicSplineSet>(
+                h, std::move(tables.R0.values), std::move(tables.R0.derivatives), x0));
+            new_spl_set_1.push_back(std::make_unique<CubicSplineSet>(
+                h, std::move(tables.R1.values), std::move(tables.R1.derivatives), x0));
+            if (A0_scaled) {
+                if (tables.A0.values.size() != 1 || tables.A0.derivatives.size() != 1)
+                    throw std::runtime_error("Compact radial A0 network must have one output.");
+                new_A0_splines.emplace_back(
+                    h, std::move(tables.A0.values[0]), std::move(tables.A0.derivatives[0]), x0);
+            }
+            if (A1_scaled) {
+                if (tables.A1.values.size() != 1 || tables.A1.derivatives.size() != 1)
+                    throw std::runtime_error("Compact radial A1 network must have one output.");
+                new_A1_splines.emplace_back(
+                    h, std::move(tables.A1.values[0]), std::move(tables.A1.derivatives[0]), x0);
+            }
+        }
+    }
+
+    auto new_type_to_active = std::vector<int>(atomic_numbers.size(), -1);
+    auto new_active_atomic_numbers = std::vector<int>();
+    new_active_atomic_numbers.reserve(requested_types.size());
+    for (int active=0; active<requested_types.size(); ++active) {
+        new_type_to_active[requested_types[active]] = active;
+        new_active_atomic_numbers.push_back(atomic_numbers[requested_types[active]]);
+    }
+
+    spl_set_0 = std::move(new_spl_set_0);
+    spl_set_1 = std::move(new_spl_set_1);
+    A0_splines = std::move(new_A0_splines);
+    A1_splines = std::move(new_A1_splines);
+    type_to_active = std::move(new_type_to_active);
+    active_atomic_numbers = std::move(new_active_atomic_numbers);
+    active_types = std::move(requested_types);
+}
+
+int MACE::radial_pair_index(int type_i, int type_j) const
+{
+    if (type_i < 0 || type_i >= type_to_active.size()
+        || type_j < 0 || type_j >= type_to_active.size())
+        throw std::out_of_range("MACE radial type index is out of range.");
+    const int active_i = type_to_active[type_i];
+    const int active_j = type_to_active[type_j];
+    if (active_i < 0 || active_j < 0)
+        throw std::runtime_error("MACE radial cache is not prepared for an active type.");
+    const int num_active = active_types.size();
+    return (active_i <= active_j)
+        ? active_i*(2*num_active-active_i-1)/2+active_j
+        : active_j*(2*num_active-active_j-1)/2+active_i;
 }
 
 void MACE::compute_node_energies_forces(
@@ -63,6 +161,774 @@ void MACE::compute_node_energies_forces(
     reverse_A0(num_nodes, node_types, num_neigh, neigh_types, xyz, r);
 }
 
+void MACE::compute_node_energies_forces_field(
+    const int num_nodes,
+    std::span<const int> node_types,
+    std::span<const int> num_neigh,
+    std::span<const int> neigh_indices,
+    std::span<const int> neigh_types,
+    std::span<const double> xyz,
+    std::span<const double> r,
+    std::span<const double> electric_field)
+{
+    if (!has_field_coupling)
+        throw std::invalid_argument(
+            "MACE::compute_node_energies_forces_field requires field coupling.");
+
+    node_energies.resize(num_nodes);
+    std::fill(node_energies.begin(), node_energies.end(), 0.0);
+    node_forces.resize(xyz.size());
+    std::fill(node_forces.begin(), node_forces.end(), 0.0);
+
+    if (has_zbl)
+        zbl.compute_ZBL(
+            num_nodes, node_types, num_neigh, neigh_types,
+            atomic_numbers, r, xyz, node_energies, node_forces);
+
+    compute_Y(xyz);
+
+    compute_R0(num_nodes, node_types, num_neigh, neigh_types, r);
+    compute_A0(num_nodes, node_types, num_neigh, neigh_types);
+    compute_A0_scaled(num_nodes, node_types, num_neigh, neigh_types, r);
+    compute_M0(num_nodes, node_types);
+    compute_H1_product(num_nodes);
+    compute_field_H1(num_nodes, electric_field);
+    compute_H1_linear_up(num_nodes);
+
+    compute_R1(num_nodes, node_types, num_neigh, neigh_types, r);
+    compute_Phi1(num_nodes, num_neigh, neigh_indices);
+    compute_A1(num_nodes);
+    compute_A1_scaled(num_nodes, node_types, num_neigh, neigh_types, r);
+    compute_M1(num_nodes, node_types);
+    compute_H2(num_nodes, node_types);
+
+    compute_readouts(num_nodes, node_types);
+
+    reverse_H2(num_nodes, node_types, false);
+    reverse_M1(num_nodes, node_types);
+    reverse_A1_scaled(num_nodes, node_types, num_neigh, neigh_types, xyz, r, false);
+    reverse_A1(num_nodes);
+    reverse_Phi1(num_nodes, num_neigh, neigh_indices, xyz, r, false, false);
+    reverse_H1_linear_up(num_nodes);
+    reverse_field_H1(num_nodes, electric_field);
+
+    reverse_H1_product(num_nodes);
+    reverse_M0(num_nodes, node_types);
+    reverse_A0_scaled(num_nodes, node_types, num_neigh, neigh_types, xyz, r);
+    reverse_A0(num_nodes, node_types, num_neigh, neigh_types, xyz, r);
+}
+
+void MACE::compute_electric_field_hessian(
+    const int num_nodes,
+    std::span<const int> node_types,
+    std::span<const int> num_neigh,
+    std::span<const int> neigh_indices,
+    std::span<const int> neigh_types,
+    std::span<const double> xyz,
+    std::span<const double> r,
+    std::span<const double> electric_field)
+{
+    if (not has_field_coupling)
+        throw std::invalid_argument("MACE::compute_electric_field_hessian requires field coupling.");
+    if (electric_field.size() != 3)
+        throw std::invalid_argument("MACE::compute_electric_field_hessian requires a graph-level electric field.");
+
+    node_energies.resize(num_nodes);
+    std::fill(node_energies.begin(), node_energies.end(), 0.0);
+    node_forces.resize(xyz.size());
+    std::fill(node_forces.begin(), node_forces.end(), 0.0);
+
+    compute_Y(xyz);
+    compute_R0(num_nodes, node_types, num_neigh, neigh_types, r);
+    compute_A0(num_nodes, node_types, num_neigh, neigh_types);
+    compute_A0_scaled(num_nodes, node_types, num_neigh, neigh_types, r);
+    compute_M0(num_nodes, node_types);
+    compute_H1_product(num_nodes);
+    compute_field_H1(num_nodes, electric_field);
+    compute_H1_linear_up(num_nodes);
+    compute_R1(num_nodes, node_types, num_neigh, neigh_types, r);
+    compute_Phi1(num_nodes, num_neigh, neigh_indices);
+    compute_A1(num_nodes);
+    compute_A1_scaled(num_nodes, node_types, num_neigh, neigh_types, r);
+    compute_M1(num_nodes, node_types);
+    compute_H2(num_nodes, node_types);
+    compute_readouts(num_nodes, node_types);
+
+    electric_field_hessian.assign(9, 0.0);
+    electric_field_force_derivative.assign(3*xyz.size(), 0.0);
+
+    const int channel_pairs = num_channels*num_channels;
+    const double inv_sqrt_3 = 1.0/std::sqrt(3.0);
+    const auto h1_index = [this](int i, int lm, int k) {
+        return (i*num_LM + lm)*num_channels + k;
+    };
+    const auto vector_index = [this](int i, int k, int component) {
+        return (i*num_channels + k)*3 + component;
+    };
+
+    auto A1_scale_factors = std::vector<double>(num_nodes, 1.0);
+    if (A1_scaled) {
+        int ij = 0;
+        for (int i=0; i<num_nodes; ++i) {
+            const int type_i = node_types[i];
+            for (int j=0; j<num_neigh[i]; ++j) {
+                const int type_j = neigh_types[ij];
+                const int type_ij = radial_pair_index(type_i, type_j);
+                A1_scale_factors[i] += A1_splines[type_ij].evaluate(r[ij]);
+                ij += 1;
+            }
+        }
+    }
+
+    auto A0_scale_factors = std::vector<double>(num_nodes, 1.0);
+    if (A0_scaled) {
+        int ij = 0;
+        for (int i=0; i<num_nodes; ++i) {
+            const int type_i = node_types[i];
+            for (int j=0; j<num_neigh[i]; ++j) {
+                const int type_j = neigh_types[ij];
+                const int type_ij = radial_pair_index(type_i, type_j);
+                A0_scale_factors[i] += A0_splines[type_ij].evaluate(r[ij]);
+                ij += 1;
+            }
+        }
+    }
+
+    int num_lme_local = 0;
+    std::vector<int> num_e(l_max+1,0);
+    for (auto l : Phi1_l) {
+        num_lme_local += 2*l+1;
+        num_e[l] += 1;
+    }
+
+    for (int seed=0; seed<3; ++seed) {
+        auto H1_dot = std::vector<double>(H1.size(), 0.0);
+        auto delta_scalar_dot = std::vector<double>(num_nodes*num_channels, 0.0);
+        auto delta_vector_dot = std::vector<double>(num_nodes*num_channels*3, 0.0);
+        auto linear_scalar_dot = std::vector<double>(num_nodes*num_channels, 0.0);
+        auto linear_vector_dot = std::vector<double>(num_nodes*num_channels*3, 0.0);
+
+        for (int i=0; i<num_nodes; ++i) {
+            for (int u=0; u<num_channels; ++u) {
+                const double scalar_in = H1_pre_field[h1_index(i, 0, u)];
+                const double vector_in = H1_pre_field[h1_index(i, 1+seed, u)];
+                for (int w=0; w<num_channels; ++w) {
+                    const int weight_index = u*num_channels + w;
+                    delta_vector_dot[vector_index(i, w, seed)] +=
+                        field_feats_scalar_to_vector_path_weight
+                        * field_feats_weight[weight_index]
+                        * inv_sqrt_3
+                        * scalar_in;
+                    delta_scalar_dot[i*num_channels + w] +=
+                        -field_feats_vector_to_scalar_path_weight
+                        * field_feats_weight[channel_pairs + weight_index]
+                        * inv_sqrt_3
+                        * vector_in;
+                }
+            }
+            for (int u=0; u<num_channels; ++u) {
+                for (int w=0; w<num_channels; ++w) {
+                    const int weight_index = u*num_channels + w;
+                    linear_scalar_dot[i*num_channels + w] +=
+                        field_linear_scalar_path_weight
+                        * field_linear_weight[weight_index]
+                        * delta_scalar_dot[i*num_channels + u];
+                    for (int component=0; component<3; ++component) {
+                        linear_vector_dot[vector_index(i, w, component)] +=
+                            field_linear_vector_path_weight
+                            * field_linear_weight[channel_pairs + weight_index]
+                            * delta_vector_dot[vector_index(i, u, component)];
+                    }
+                }
+            }
+            for (int k=0; k<num_channels; ++k) {
+                H1_dot[h1_index(i, 0, k)] = -linear_scalar_dot[i*num_channels + k];
+                for (int component=0; component<3; ++component)
+                    H1_dot[h1_index(i, 1+component, k)] =
+                        linear_vector_dot[vector_index(i, k, component)];
+            }
+        }
+
+        auto H1_dot_before_linear_up = H1_dot;
+        std::fill(H1_dot.begin(), H1_dot.end(), 0.0);
+        for (int i=0; i<num_nodes; ++i) {
+            for (int l=0; l<=L_max; ++l) {
+                const auto H1_dot_in_il = H1_dot_before_linear_up.data()+(i*num_LM+l*l)*num_channels;
+                const auto weights_l = H1_linear_up_weights.data()+l*num_channels*num_channels;
+                auto H1_dot_il = H1_dot.data()+(i*num_LM+l*l)*num_channels;
+                cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,
+                            2*l+1, num_channels, num_channels,
+                            1.0, H1_dot_in_il, num_channels,
+                            weights_l, num_channels,
+                            0.0, H1_dot_il, num_channels);
+            }
+        }
+
+        auto Phi1r_dot = std::vector<double>(Phi1r.size(), 0.0);
+        auto Phi1_dot = std::vector<double>(Phi1.size(), 0.0);
+        int ij = 0;
+        for (int i=0; i<num_nodes; ++i) {
+            auto Phi1r_dot_i = Phi1r_dot.data()+i*num_lelm1lm2*num_channels;
+            for (int j=0; j<num_neigh[i]; ++j) {
+                auto R1_ij = R1.data()+ij*spl_set_1[0]->num_splines;
+                auto Y_ij = Y.data()+ij*num_lm;
+                auto H1_dot_ij = H1_dot.data()+neigh_indices[ij]*num_LM*num_channels;
+                int lelm1lm2 = 0;
+                for (int lel1l2=0; lel1l2<Phi1_l.size(); ++lel1l2) {
+                    const int l1 = Phi1_l1[lel1l2];
+                    const int l2 = Phi1_l2[lel1l2];
+                    auto R1_ij_lel1l2 = R1_ij+lel1l2*num_channels;
+                    for (int lm1=l1*l1; lm1<=l1*(l1+2); ++lm1) {
+                        const double Y_ij_lm1 = Y_ij[lm1];
+                        for (int lm2=l2*l2; lm2<=l2*(l2+2); ++lm2) {
+                            auto H1_dot_ij_lm2 = H1_dot_ij+lm2*num_channels;
+                            auto Phi1r_dot_i_lelm1lm2 = Phi1r_dot_i+lelm1lm2*num_channels;
+                            for (int k=0; k<num_channels; ++k)
+                                Phi1r_dot_i_lelm1lm2[k] +=
+                                    R1_ij_lel1l2[k] * Y_ij_lm1 * H1_dot_ij_lm2[k];
+                            lelm1lm2 += 1;
+                        }
+                    }
+                }
+                ij += 1;
+            }
+        }
+        for (int i=0; i<num_nodes; ++i) {
+            auto Phi1_dot_i = Phi1_dot.data()+i*num_lme*num_channels;
+            auto Phi1r_dot_i = Phi1r_dot.data()+i*num_lelm1lm2*num_channels;
+            for (int p=0; p<Phi1_clebsch_gordan.size(); ++p) {
+                const double C = Phi1_clebsch_gordan[p];
+                auto Phi1_dot_i_lme = Phi1_dot_i+Phi1_lme[p]*num_channels;
+                auto Phi1r_dot_i_lelm1lm2 = Phi1r_dot_i+Phi1_lelm1lm2[p]*num_channels;
+                for (int k=0; k<num_channels; ++k)
+                    Phi1_dot_i_lme[k] += C * Phi1r_dot_i_lelm1lm2[k];
+            }
+        }
+
+        auto A1_dot = std::vector<double>(A1.size(), 0.0);
+        for (int i=0; i<num_nodes; ++i) {
+            auto Phi1_dot_il = Phi1_dot.data()+i*num_lme_local*num_channels;
+            auto A1_dot_il = A1_dot.data()+i*num_lm*num_channels;
+            for (int l=0; l<=l_max; ++l) {
+                cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,
+                            2*l+1, num_channels, num_e[l]*num_channels,
+                            1.0, Phi1_dot_il, num_e[l]*num_channels,
+                            A1_weights[l].data(), num_channels,
+                            0.0, A1_dot_il, num_channels);
+                Phi1_dot_il += (2*l+1)*num_e[l]*num_channels;
+                A1_dot_il += (2*l+1)*num_channels;
+            }
+        }
+        if (A1_scaled) {
+            for (int i=0; i<num_nodes; ++i) {
+                auto A1_dot_i = A1_dot.data()+i*num_lm*num_channels;
+                for (int lmk=0; lmk<num_lm*num_channels; ++lmk)
+                    A1_dot_i[lmk] /= A1_scale_factors[i];
+            }
+        }
+
+        auto M1_dot = std::vector<double>(M1.size(), 0.0);
+        auto M1_grad_dot = std::vector<double>(M1_grad.size(), 0.0);
+        for (int i=0; i<num_nodes; ++i) {
+            auto A1_i = A1.data()+i*num_lm*num_channels;
+            auto A1_dot_i = A1_dot.data()+i*num_lm*num_channels;
+            auto M1_grad_dot_i = M1_grad_dot.data()+i*num_channels*num_lm;
+            auto x = std::vector<double>(num_lm);
+            auto x_dot = std::vector<double>(num_lm);
+            for (int k=0; k<num_channels; ++k) {
+                cblas_dcopy(num_lm, A1_i+k, num_channels, x.data(), 1);
+                cblas_dcopy(num_lm, A1_dot_i+k, num_channels, x_dot.data(), 1);
+                auto [f, g, g_dot] =
+                    P1[node_types[i]*num_channels+k].evaluate_gradient_directional(x, x_dot);
+                M1_dot[i*num_channels+k] = cblas_ddot(num_lm, g.data(), 1, x_dot.data(), 1);
+                cblas_dcopy(num_lm, g_dot.data(), 1, M1_grad_dot_i+k, num_channels);
+            }
+        }
+
+        auto H2_dot = std::vector<double>(H2.size(), 0.0);
+        for (int i=0; i<num_nodes; ++i) {
+            auto H2_dot_i = H2_dot.data()+i*num_channels;
+            auto H1_dot_i = H1_dot.data()+i*num_LM*num_channels;
+            cblas_dgemv(CblasRowMajor, CblasTrans,
+                        num_channels, num_channels,
+                        1.0, H2_weights_for_H1[node_types[i]].data(), num_channels,
+                        H1_dot_i, 1,
+                        0.0, H2_dot_i, 1);
+            auto M1_dot_i = M1_dot.data()+i*num_channels;
+            cblas_dgemv(CblasRowMajor, CblasTrans,
+                        num_channels, num_channels,
+                        1.0, H2_weights_for_M1.data(), num_channels,
+                        M1_dot_i, 1,
+                        1.0, H2_dot_i, 1);
+        }
+
+        auto H1_adj_local = std::vector<double>(H1.size(), 0.0);
+        auto H1_adj_dot = std::vector<double>(H1.size(), 0.0);
+        auto H2_adj_local = std::vector<double>(H2.size(), 0.0);
+        auto H2_adj_dot = std::vector<double>(H2.size(), 0.0);
+        for (int i=0; i<num_nodes; ++i) {
+            for (int k=0; k<num_channels; ++k)
+                H1_adj_local[i*num_LM*num_channels+k] = readout_1_weights[k];
+            auto x = std::vector<double>(H2.begin()+i*num_channels, H2.begin()+(i+1)*num_channels);
+            auto x_dot = std::vector<double>(H2_dot.begin()+i*num_channels, H2_dot.begin()+(i+1)*num_channels);
+            auto [f, g, g_dot] = readout_2->evaluate_gradient_directional(x, x_dot);
+            for (int k=0; k<num_channels; ++k) {
+                H2_adj_local[i*num_channels+k] = g[k];
+                H2_adj_dot[i*num_channels+k] = g_dot[k];
+            }
+        }
+
+        auto M1_adj_local = std::vector<double>(M1.size(), 0.0);
+        auto M1_adj_dot = std::vector<double>(M1.size(), 0.0);
+        for (int i=0; i<num_nodes; ++i) {
+            auto H2_adj_i = H2_adj_local.data()+i*num_channels;
+            auto H2_adj_dot_i = H2_adj_dot.data()+i*num_channels;
+            auto H1_adj_i = H1_adj_local.data()+i*num_LM*num_channels;
+            auto H1_adj_dot_i = H1_adj_dot.data()+i*num_LM*num_channels;
+            cblas_dgemv(CblasRowMajor, CblasNoTrans,
+                        num_channels, num_channels,
+                        1.0, H2_weights_for_H1[node_types[i]].data(), num_channels,
+                        H2_adj_i, 1,
+                        1.0, H1_adj_i, 1);
+            cblas_dgemv(CblasRowMajor, CblasNoTrans,
+                        num_channels, num_channels,
+                        1.0, H2_weights_for_H1[node_types[i]].data(), num_channels,
+                        H2_adj_dot_i, 1,
+                        1.0, H1_adj_dot_i, 1);
+            auto M1_adj_i = M1_adj_local.data()+i*num_channels;
+            auto M1_adj_dot_i = M1_adj_dot.data()+i*num_channels;
+            cblas_dgemv(CblasRowMajor, CblasNoTrans,
+                        num_channels, num_channels,
+                        1.0, H2_weights_for_M1.data(), num_channels,
+                        H2_adj_i, 1,
+                        0.0, M1_adj_i, 1);
+            cblas_dgemv(CblasRowMajor, CblasNoTrans,
+                        num_channels, num_channels,
+                        1.0, H2_weights_for_M1.data(), num_channels,
+                        H2_adj_dot_i, 1,
+                        0.0, M1_adj_dot_i, 1);
+        }
+
+        auto A1_adj_local = std::vector<double>(A1.size(), 0.0);
+        auto A1_adj_dot = std::vector<double>(A1.size(), 0.0);
+        for (int i=0; i<num_nodes; ++i) {
+            auto M1_adj_i = M1_adj_local.data()+i*num_channels;
+            auto M1_adj_dot_i = M1_adj_dot.data()+i*num_channels;
+            for (int lm=0; lm<num_lm; ++lm) {
+                auto A1_adj_ilm = A1_adj_local.data()+(i*num_lm+lm)*num_channels;
+                auto A1_adj_dot_ilm = A1_adj_dot.data()+(i*num_lm+lm)*num_channels;
+                auto M1_grad_ilm = M1_grad.data()+(i*num_lm+lm)*num_channels;
+                auto M1_grad_dot_ilm = M1_grad_dot.data()+(i*num_lm+lm)*num_channels;
+                for (int k=0; k<num_channels; ++k) {
+                    A1_adj_ilm[k] = M1_grad_ilm[k] * M1_adj_i[k];
+                    A1_adj_dot_ilm[k] =
+                        M1_grad_dot_ilm[k] * M1_adj_i[k]
+                        + M1_grad_ilm[k] * M1_adj_dot_i[k];
+                }
+            }
+        }
+        if (A1_scaled) {
+            int ij_scale = 0;
+            for (int i=0; i<num_nodes; ++i) {
+                const int type_i = node_types[i];
+                auto A1_i = A1.data()+i*num_lm*num_channels;
+                auto A1_dot_i = A1_dot.data()+i*num_lm*num_channels;
+                auto A1_adj_i = A1_adj_local.data()+i*num_lm*num_channels;
+                auto A1_adj_dot_i = A1_adj_dot.data()+i*num_lm*num_channels;
+                double dA1_dot_A1_dot = 0.0;
+                for (int lmk=0; lmk<num_lm*num_channels; ++lmk) {
+                    dA1_dot_A1_dot +=
+                        A1_adj_dot_i[lmk] * A1_i[lmk]
+                        + A1_adj_i[lmk] * A1_dot_i[lmk];
+                }
+                for (int j=0; j<num_neigh[i]; ++j) {
+                    const int type_j = neigh_types[ij_scale];
+                    const int type_ij = radial_pair_index(type_i, type_j);
+                    auto [f,d] = A1_splines[type_ij].evaluate_deriv(r[ij_scale]);
+                    auto xyz_ij = xyz.data()+ij_scale*3;
+                    auto force_deriv_ij =
+                        electric_field_force_derivative.data()+seed*xyz.size()+ij_scale*3;
+                    force_deriv_ij[0] += dA1_dot_A1_dot/A1_scale_factors[i]*d*xyz_ij[0]/r[ij_scale];
+                    force_deriv_ij[1] += dA1_dot_A1_dot/A1_scale_factors[i]*d*xyz_ij[1]/r[ij_scale];
+                    force_deriv_ij[2] += dA1_dot_A1_dot/A1_scale_factors[i]*d*xyz_ij[2]/r[ij_scale];
+                    ij_scale += 1;
+                }
+            }
+            for (int i=0; i<num_nodes; ++i) {
+                auto A1_adj_i = A1_adj_local.data()+i*num_lm*num_channels;
+                auto A1_adj_dot_i = A1_adj_dot.data()+i*num_lm*num_channels;
+                for (int lmk=0; lmk<num_lm*num_channels; ++lmk) {
+                    A1_adj_i[lmk] /= A1_scale_factors[i];
+                    A1_adj_dot_i[lmk] /= A1_scale_factors[i];
+                }
+            }
+        }
+
+        auto dPhi1_local = std::vector<double>(Phi1.size(), 0.0);
+        auto dPhi1_dot = std::vector<double>(Phi1.size(), 0.0);
+        for (int i=0; i<num_nodes; ++i) {
+            auto A1_adj_il = A1_adj_local.data()+i*num_lm*num_channels;
+            auto A1_adj_dot_il = A1_adj_dot.data()+i*num_lm*num_channels;
+            auto dPhi1_il = dPhi1_local.data()+i*num_lme_local*num_channels;
+            auto dPhi1_dot_il = dPhi1_dot.data()+i*num_lme_local*num_channels;
+            for (int l=0; l<=l_max; ++l) {
+                cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasTrans,
+                            2*l+1, num_e[l]*num_channels, num_channels,
+                            1.0, A1_adj_il, num_channels,
+                            A1_weights[l].data(), num_channels,
+                            0.0, dPhi1_il, num_e[l]*num_channels);
+                cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasTrans,
+                            2*l+1, num_e[l]*num_channels, num_channels,
+                            1.0, A1_adj_dot_il, num_channels,
+                            A1_weights[l].data(), num_channels,
+                            0.0, dPhi1_dot_il, num_e[l]*num_channels);
+                A1_adj_il += (2*l+1)*num_channels;
+                A1_adj_dot_il += (2*l+1)*num_channels;
+                dPhi1_il += (2*l+1)*num_e[l]*num_channels;
+                dPhi1_dot_il += (2*l+1)*num_e[l]*num_channels;
+            }
+        }
+
+        auto dPhi1r_local = std::vector<double>(Phi1r.size(), 0.0);
+        auto dPhi1r_dot = std::vector<double>(Phi1r.size(), 0.0);
+        for (int i=0; i<num_nodes; ++i) {
+            auto dPhi1r_i = dPhi1r_local.data()+i*num_lelm1lm2*num_channels;
+            auto dPhi1r_dot_i = dPhi1r_dot.data()+i*num_lelm1lm2*num_channels;
+            auto dPhi1_i = dPhi1_local.data()+i*num_lme*num_channels;
+            auto dPhi1_dot_i = dPhi1_dot.data()+i*num_lme*num_channels;
+            for (int p=0; p<Phi1_clebsch_gordan.size(); ++p) {
+                const double C = Phi1_clebsch_gordan[p];
+                auto dPhi1r_i_lelm1lm2 = dPhi1r_i+Phi1_lelm1lm2[p]*num_channels;
+                auto dPhi1r_dot_i_lelm1lm2 = dPhi1r_dot_i+Phi1_lelm1lm2[p]*num_channels;
+                auto dPhi1_i_lme = dPhi1_i+Phi1_lme[p]*num_channels;
+                auto dPhi1_dot_i_lme = dPhi1_dot_i+Phi1_lme[p]*num_channels;
+                for (int k=0; k<num_channels; ++k) {
+                    dPhi1r_i_lelm1lm2[k] += C * dPhi1_i_lme[k];
+                    dPhi1r_dot_i_lelm1lm2[k] += C * dPhi1_dot_i_lme[k];
+                }
+            }
+        }
+
+        ij = 0;
+        for (int i=0; i<num_nodes; ++i) {
+            auto dPhi1r_i = dPhi1r_local.data()+i*num_lelm1lm2*num_channels;
+            auto dPhi1r_dot_i = dPhi1r_dot.data()+i*num_lelm1lm2*num_channels;
+            for (int j=0; j<num_neigh[i]; ++j) {
+                auto R1_ij = R1.data()+ij*spl_set_1[0]->num_splines;
+                auto R1_deriv_ij = R1_deriv.data()+ij*spl_set_1[0]->num_splines;
+                auto Y_ij = Y.data()+ij*num_lm;
+                auto Y_grad_ij = Y_grad.data()+ij*3*num_lm;
+                auto H1_ij = H1.data()+neigh_indices[ij]*num_LM*num_channels;
+                auto H1_dot_ij = H1_dot.data()+neigh_indices[ij]*num_LM*num_channels;
+                auto H1_adj_ij = H1_adj_local.data()+neigh_indices[ij]*num_LM*num_channels;
+                auto H1_adj_dot_ij = H1_adj_dot.data()+neigh_indices[ij]*num_LM*num_channels;
+                auto xyz_ij = xyz.data()+ij*3;
+                auto force_deriv_ij = electric_field_force_derivative.data()+seed*xyz.size()+ij*3;
+                int lelm1lm2 = 0;
+                for (int lel1l2=0; lel1l2<Phi1_l.size(); ++lel1l2) {
+                    const int l1 = Phi1_l1[lel1l2];
+                    const int l2 = Phi1_l2[lel1l2];
+                    auto R1_ij_lel1l2 = R1_ij+lel1l2*num_channels;
+                    auto R1_deriv_ij_lel1l2 = R1_deriv_ij+lel1l2*num_channels;
+                    for (int lm1=l1*l1; lm1<=l1*(l1+2); ++lm1) {
+                        const double Y_ij_lm1 = Y_ij[lm1];
+                        const double Y_grad_ij_x_lm1 = Y_grad_ij[0*num_lm+lm1];
+                        const double Y_grad_ij_y_lm1 = Y_grad_ij[1*num_lm+lm1];
+                        const double Y_grad_ij_z_lm1 = Y_grad_ij[2*num_lm+lm1];
+                        for (int lm2=l2*l2; lm2<=l2*(l2+2); ++lm2) {
+                            auto H1_ij_lm2 = H1_ij+lm2*num_channels;
+                            auto H1_dot_ij_lm2 = H1_dot_ij+lm2*num_channels;
+                            auto H1_adj_ij_lm2 = H1_adj_ij+lm2*num_channels;
+                            auto H1_adj_dot_ij_lm2 = H1_adj_dot_ij+lm2*num_channels;
+                            auto dPhi1r_i_lelm1lm2 = dPhi1r_i+lelm1lm2*num_channels;
+                            auto dPhi1r_dot_i_lelm1lm2 = dPhi1r_dot_i+lelm1lm2*num_channels;
+                            for (int k=0; k<num_channels; ++k) {
+                                const double force_factor_x =
+                                    xyz_ij[0]/r[ij] * R1_deriv_ij_lel1l2[k] * Y_ij_lm1 * H1_ij_lm2[k]
+                                    + R1_ij_lel1l2[k] * Y_grad_ij_x_lm1 * H1_ij_lm2[k];
+                                const double force_factor_y =
+                                    xyz_ij[1]/r[ij] * R1_deriv_ij_lel1l2[k] * Y_ij_lm1 * H1_ij_lm2[k]
+                                    + R1_ij_lel1l2[k] * Y_grad_ij_y_lm1 * H1_ij_lm2[k];
+                                const double force_factor_z =
+                                    xyz_ij[2]/r[ij] * R1_deriv_ij_lel1l2[k] * Y_ij_lm1 * H1_ij_lm2[k]
+                                    + R1_ij_lel1l2[k] * Y_grad_ij_z_lm1 * H1_ij_lm2[k];
+                                const double force_factor_dot_x =
+                                    xyz_ij[0]/r[ij] * R1_deriv_ij_lel1l2[k] * Y_ij_lm1 * H1_dot_ij_lm2[k]
+                                    + R1_ij_lel1l2[k] * Y_grad_ij_x_lm1 * H1_dot_ij_lm2[k];
+                                const double force_factor_dot_y =
+                                    xyz_ij[1]/r[ij] * R1_deriv_ij_lel1l2[k] * Y_ij_lm1 * H1_dot_ij_lm2[k]
+                                    + R1_ij_lel1l2[k] * Y_grad_ij_y_lm1 * H1_dot_ij_lm2[k];
+                                const double force_factor_dot_z =
+                                    xyz_ij[2]/r[ij] * R1_deriv_ij_lel1l2[k] * Y_ij_lm1 * H1_dot_ij_lm2[k]
+                                    + R1_ij_lel1l2[k] * Y_grad_ij_z_lm1 * H1_dot_ij_lm2[k];
+                                force_deriv_ij[0] += -(
+                                    dPhi1r_dot_i_lelm1lm2[k] * force_factor_x
+                                    + dPhi1r_i_lelm1lm2[k] * force_factor_dot_x);
+                                force_deriv_ij[1] += -(
+                                    dPhi1r_dot_i_lelm1lm2[k] * force_factor_y
+                                    + dPhi1r_i_lelm1lm2[k] * force_factor_dot_y);
+                                force_deriv_ij[2] += -(
+                                    dPhi1r_dot_i_lelm1lm2[k] * force_factor_z
+                                    + dPhi1r_i_lelm1lm2[k] * force_factor_dot_z);
+                                H1_adj_ij_lm2[k] +=
+                                    R1_ij_lel1l2[k]*Y_ij_lm1*dPhi1r_i_lelm1lm2[k];
+                                H1_adj_dot_ij_lm2[k] +=
+                                    R1_ij_lel1l2[k]*Y_ij_lm1*dPhi1r_dot_i_lelm1lm2[k];
+                            }
+                            lelm1lm2 += 1;
+                        }
+                    }
+                }
+                ij += 1;
+            }
+        }
+
+        auto H1_adj_before_linear_up = H1_adj_local;
+        auto H1_adj_dot_before_linear_up = H1_adj_dot;
+        std::fill(H1_adj_local.begin(), H1_adj_local.end(), 0.0);
+        std::fill(H1_adj_dot.begin(), H1_adj_dot.end(), 0.0);
+        for (int i=0; i<num_nodes; ++i) {
+            for (int l=0; l<=L_max; ++l) {
+                const auto H1_adj_il = H1_adj_before_linear_up.data()+(i*num_LM+l*l)*num_channels;
+                const auto H1_adj_dot_il = H1_adj_dot_before_linear_up.data()+(i*num_LM+l*l)*num_channels;
+                const auto weights_l = H1_linear_up_weights.data()+l*num_channels*num_channels;
+                auto H1_pre_adj_il = H1_adj_local.data()+(i*num_LM+l*l)*num_channels;
+                auto H1_pre_adj_dot_il = H1_adj_dot.data()+(i*num_LM+l*l)*num_channels;
+                cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasTrans,
+                            2*l+1, num_channels, num_channels,
+                            1.0, H1_adj_il, num_channels,
+                            weights_l, num_channels,
+                            0.0, H1_pre_adj_il, num_channels);
+                cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasTrans,
+                            2*l+1, num_channels, num_channels,
+                            1.0, H1_adj_dot_il, num_channels,
+                            weights_l, num_channels,
+                            0.0, H1_pre_adj_dot_il, num_channels);
+            }
+        }
+
+        auto delta_scalar_adj = std::vector<double>(num_nodes*num_channels, 0.0);
+        auto delta_vector_adj = std::vector<double>(num_nodes*num_channels*3, 0.0);
+        auto delta_scalar_adj_dot = std::vector<double>(num_nodes*num_channels, 0.0);
+        auto delta_vector_adj_dot = std::vector<double>(num_nodes*num_channels*3, 0.0);
+        auto H1_pre_adj = H1_adj_local;
+        auto H1_pre_adj_dot = H1_adj_dot;
+        for (int i=0; i<num_nodes; ++i) {
+            for (int u=0; u<num_channels; ++u) {
+                for (int w=0; w<num_channels; ++w) {
+                    const int weight_index = u*num_channels + w;
+                    delta_scalar_adj[i*num_channels + u] +=
+                        -field_linear_scalar_path_weight
+                        * field_linear_weight[weight_index]
+                        * H1_adj_local[h1_index(i, 0, w)];
+                    delta_scalar_adj_dot[i*num_channels + u] +=
+                        -field_linear_scalar_path_weight
+                        * field_linear_weight[weight_index]
+                        * H1_adj_dot[h1_index(i, 0, w)];
+                    for (int component=0; component<3; ++component) {
+                        delta_vector_adj_dot[vector_index(i, u, component)] +=
+                            field_linear_vector_path_weight
+                            * field_linear_weight[channel_pairs + weight_index]
+                            * H1_adj_dot[h1_index(i, 1+component, w)];
+                        delta_vector_adj[vector_index(i, u, component)] +=
+                            field_linear_vector_path_weight
+                            * field_linear_weight[channel_pairs + weight_index]
+                            * H1_adj_local[h1_index(i, 1+component, w)];
+                    }
+                }
+            }
+            for (int u=0; u<num_channels; ++u) {
+                const double scalar_in = H1_pre_field[h1_index(i, 0, u)];
+                for (int w=0; w<num_channels; ++w) {
+                    const int weight_index = u*num_channels + w;
+                    const double scalar_to_vector_weight =
+                        field_feats_scalar_to_vector_path_weight
+                        * field_feats_weight[weight_index]
+                        * inv_sqrt_3;
+                    const double vector_to_scalar_weight =
+                        field_feats_vector_to_scalar_path_weight
+                        * field_feats_weight[channel_pairs + weight_index]
+                        * inv_sqrt_3;
+                    const double scalar_delta_adj =
+                        delta_scalar_adj[i*num_channels + w];
+                    const double scalar_delta_adj_dot =
+                        delta_scalar_adj_dot[i*num_channels + w];
+                    for (int component=0; component<3; ++component) {
+                        const double field_dot = (component == seed) ? 1.0 : 0.0;
+                        const double vector_delta_adj =
+                            delta_vector_adj[vector_index(i, w, component)];
+                        const double vector_delta_adj_dot =
+                            delta_vector_adj_dot[vector_index(i, w, component)];
+                        H1_pre_adj[h1_index(i, 0, u)] +=
+                            vector_delta_adj*scalar_to_vector_weight*electric_field[component];
+                        H1_pre_adj_dot[h1_index(i, 0, u)] +=
+                            vector_delta_adj_dot*scalar_to_vector_weight*electric_field[component]
+                            + vector_delta_adj*scalar_to_vector_weight*field_dot;
+                        electric_field_hessian[component*3 + seed] +=
+                            vector_delta_adj_dot*scalar_to_vector_weight*scalar_in;
+                        H1_pre_adj[h1_index(i, 1+component, u)] +=
+                            -scalar_delta_adj*vector_to_scalar_weight*electric_field[component];
+                        H1_pre_adj_dot[h1_index(i, 1+component, u)] +=
+                            -scalar_delta_adj_dot*vector_to_scalar_weight*electric_field[component]
+                            - scalar_delta_adj*vector_to_scalar_weight*field_dot;
+                        electric_field_hessian[component*3 + seed] +=
+                            -scalar_delta_adj_dot*vector_to_scalar_weight
+                            * H1_pre_field[h1_index(i, 1+component, u)];
+                    }
+                }
+            }
+        }
+        H1_adj_local = std::move(H1_pre_adj);
+        H1_adj_dot = std::move(H1_pre_adj_dot);
+
+        auto M0_adj_local = std::vector<double>(M0.size(), 0.0);
+        auto M0_adj_dot = std::vector<double>(M0.size(), 0.0);
+        for (int i=0; i<num_nodes; ++i) {
+            for (int l=0; l<=L_max; ++l) {
+                const auto H1_adj_il = H1_adj_local.data()+(i*num_LM+l*l)*num_channels;
+                const auto H1_adj_dot_il = H1_adj_dot.data()+(i*num_LM+l*l)*num_channels;
+                const auto weights_l = H1_product_weights.data()+l*num_channels*num_channels;
+                auto M0_adj_il = M0_adj_local.data()+(i*num_LM+l*l)*num_channels;
+                auto M0_adj_dot_il = M0_adj_dot.data()+(i*num_LM+l*l)*num_channels;
+                cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasTrans,
+                            2*l+1, num_channels, num_channels,
+                            1.0, H1_adj_il, num_channels,
+                            weights_l, num_channels,
+                            0.0, M0_adj_il, num_channels);
+                cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasTrans,
+                            2*l+1, num_channels, num_channels,
+                            1.0, H1_adj_dot_il, num_channels,
+                            weights_l, num_channels,
+                            0.0, M0_adj_dot_il, num_channels);
+            }
+        }
+
+        auto A0_adj_local = std::vector<double>(A0.size(), 0.0);
+        auto A0_adj_dot = std::vector<double>(A0.size(), 0.0);
+        for (int i=0; i<num_nodes; ++i) {
+            auto A0_adj_i = A0_adj_local.data()+i*num_lm*num_channels;
+            auto A0_adj_dot_i = A0_adj_dot.data()+i*num_lm*num_channels;
+            auto M0_adj_i = M0_adj_local.data()+i*num_LM*num_channels;
+            auto M0_adj_dot_i = M0_adj_dot.data()+i*num_LM*num_channels;
+            auto M0_grad_i = M0_grad.data()+i*num_LM*num_channels*num_lm;
+            for (int lm=0; lm<num_lm; ++lm) {
+                auto A0_adj_ilm = A0_adj_i + lm*num_channels;
+                auto A0_adj_dot_ilm = A0_adj_dot_i + lm*num_channels;
+                for (int lmp=0; lmp<num_LM; ++lmp) {
+                    auto M0_adj_ilmp = M0_adj_i + lmp*num_channels;
+                    auto M0_adj_dot_ilmp = M0_adj_dot_i + lmp*num_channels;
+                    auto M0_grad_ilmplm =
+                        M0_grad_i + lmp*num_lm*num_channels + lm*num_channels;
+                    for (int k=0; k<num_channels; ++k) {
+                        A0_adj_ilm[k] += M0_grad_ilmplm[k] * M0_adj_ilmp[k];
+                        A0_adj_dot_ilm[k] += M0_grad_ilmplm[k] * M0_adj_dot_ilmp[k];
+                    }
+                }
+            }
+        }
+
+        if (A0_scaled) {
+            int ij_scale = 0;
+            for (int i=0; i<num_nodes; ++i) {
+                const int type_i = node_types[i];
+                auto A0_i = A0.data()+i*num_lm*num_channels;
+                auto A0_adj_dot_i = A0_adj_dot.data()+i*num_lm*num_channels;
+                double dA0_dot_A0_dot = 0.0;
+                for (int lmk=0; lmk<num_lm*num_channels; ++lmk)
+                    dA0_dot_A0_dot += A0_adj_dot_i[lmk] * A0_i[lmk];
+                for (int j=0; j<num_neigh[i]; ++j) {
+                    const int type_j = neigh_types[ij_scale];
+                    const int type_ij = radial_pair_index(type_i, type_j);
+                    auto [f,d] = A0_splines[type_ij].evaluate_deriv(r[ij_scale]);
+                    auto xyz_ij = xyz.data()+ij_scale*3;
+                    auto force_deriv_ij =
+                        electric_field_force_derivative.data()+seed*xyz.size()+ij_scale*3;
+                    force_deriv_ij[0] += dA0_dot_A0_dot/A0_scale_factors[i]*d*xyz_ij[0]/r[ij_scale];
+                    force_deriv_ij[1] += dA0_dot_A0_dot/A0_scale_factors[i]*d*xyz_ij[1]/r[ij_scale];
+                    force_deriv_ij[2] += dA0_dot_A0_dot/A0_scale_factors[i]*d*xyz_ij[2]/r[ij_scale];
+                    ij_scale += 1;
+                }
+            }
+            for (int i=0; i<num_nodes; ++i) {
+                auto A0_adj_i = A0_adj_local.data()+i*num_lm*num_channels;
+                auto A0_adj_dot_i = A0_adj_dot.data()+i*num_lm*num_channels;
+                for (int lmk=0; lmk<num_lm*num_channels; ++lmk) {
+                    A0_adj_i[lmk] /= A0_scale_factors[i];
+                    A0_adj_dot_i[lmk] /= A0_scale_factors[i];
+                }
+            }
+        }
+
+        int ij_a0 = 0;
+        for (int i=0; i<num_nodes; ++i) {
+            auto Phi0_adj_dot_i = std::vector<double>(num_lm*num_channels, 0.0);
+            for (int l=0; l<=l_max; ++l) {
+                auto Phi0_adj_dot_il = Phi0_adj_dot_i.data()+l*l*num_channels;
+                auto A0_adj_dot_il = A0_adj_dot.data()+(i*num_lm+l*l)*num_channels;
+                cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasTrans,
+                            2*l+1, num_channels, num_channels,
+                            1.0, A0_adj_dot_il, num_channels,
+                            A0_weights[node_types[i]][l].data(), num_channels,
+                            0.0, Phi0_adj_dot_il, num_channels);
+            }
+
+            for (int j=0; j<num_neigh[i]; ++j) {
+                auto xyz_ij = xyz.data()+ij_a0*3;
+                const double r_ij = r[ij_a0];
+                auto Y_ij = Y.data()+ij_a0*num_lm;
+                auto Y_grad_ij = Y_grad.data()+ij_a0*3*num_lm;
+                auto H0_ij = H0_weights.data()+neigh_types[ij_a0]*num_channels;
+                auto force_deriv_ij = electric_field_force_derivative.data()+seed*xyz.size()+ij_a0*3;
+                for (int l=0; l<=l_max; ++l) {
+                    auto R0_ij_l = R0.data()+ij_a0*(l_max+1)*num_channels+l*num_channels;
+                    auto R0_deriv_ij_l = R0_deriv.data()+ij_a0*(l_max+1)*num_channels+l*num_channels;
+                    for (int m=-l; m<=l; ++m) {
+                        const int lm = l*l+l+m;
+                        const double Y_ij_lm = Y_ij[lm];
+                        const double Y_grad_ij_lm_x = Y_grad_ij[lm];
+                        const double Y_grad_ij_lm_y = Y_grad_ij[num_lm+lm];
+                        const double Y_grad_ij_lm_z = Y_grad_ij[2*num_lm+lm];
+                        auto Phi0_adj_dot_i_lm = Phi0_adj_dot_i.data()+lm*num_channels;
+                        for (int k=0; k<num_channels; ++k) {
+                            force_deriv_ij[0] += -Phi0_adj_dot_i_lm[k] * (
+                                xyz_ij[0]/r_ij * R0_deriv_ij_l[k] * Y_ij_lm * H0_ij[k]
+                                + R0_ij_l[k] * Y_grad_ij_lm_x * H0_ij[k]);
+                            force_deriv_ij[1] += -Phi0_adj_dot_i_lm[k] * (
+                                xyz_ij[1]/r_ij * R0_deriv_ij_l[k] * Y_ij_lm * H0_ij[k]
+                                + R0_ij_l[k] * Y_grad_ij_lm_y * H0_ij[k]);
+                            force_deriv_ij[2] += -Phi0_adj_dot_i_lm[k] * (
+                                xyz_ij[2]/r_ij * R0_deriv_ij_l[k] * Y_ij_lm * H0_ij[k]
+                                + R0_ij_l[k] * Y_grad_ij_lm_z * H0_ij[k]);
+                        }
+                    }
+                }
+                ij_a0 += 1;
+            }
+        }
+    }
+}
+
+void MACE::compute_electric_field_force_derivative(
+    const int num_nodes,
+    std::span<const int> node_types,
+    std::span<const int> num_neigh,
+    std::span<const int> neigh_indices,
+    std::span<const int> neigh_types,
+    std::span<const double> xyz,
+    std::span<const double> r,
+    std::span<const double> electric_field)
+{
+    compute_electric_field_hessian(
+        num_nodes,
+        node_types,
+        num_neigh,
+        neigh_indices,
+        neigh_types,
+        xyz,
+        r,
+        electric_field);
+}
+
 void MACE::compute_R0(
     const int num_nodes,
     std::span<const int> node_types,
@@ -70,6 +936,9 @@ void MACE::compute_R0(
     std::span<const int> neigh_types,
     std::span<const double> r)
 {
+    if (spl_set_0.empty())
+        throw std::runtime_error(
+            "MACE compact radial cache is not prepared; call prepare_active_types first.");
     const int num_spl = spl_set_0[0]->num_splines;
     R0.resize(r.size()*num_spl);
     R0_deriv.resize(R0.size());
@@ -78,15 +947,190 @@ void MACE::compute_R0(
         const int type_i = node_types[i];
         for (int j=0; j<num_neigh[i]; ++j) {
             const int type_j = neigh_types[ij];
-            const int type_ij = (type_i <= type_j)
-                ? type_i*(2*atomic_numbers.size()-type_i-1)/2 + type_j
-                : type_j*(2*atomic_numbers.size()-type_j-1)/2 + type_i;
+            const int type_ij = radial_pair_index(type_i, type_j);
             auto R0_ij = std::span<double>(R0.data()+ij*num_spl,num_spl);
             auto R0_deriv_ij = std::span<double>(R0_deriv.data()+ij*num_spl,num_spl);
             spl_set_0[type_ij]->evaluate_derivs(r[ij], R0_ij, R0_deriv_ij);
             ij += 1;
         }
     }
+}
+
+void MACE::compute_field_H1(
+    const int num_nodes,
+    std::span<const double> electric_field)
+{
+    if (!has_field_coupling)
+        return;
+
+    if (L_max != 1 || num_LM != 4)
+        throw std::runtime_error("MACEField H1 coupling currently requires L_max == 1.");
+
+    if (electric_field.size() != 3 && electric_field.size() != 3*num_nodes)
+        throw std::runtime_error("MACEField electric_field must have shape (3,) or (num_nodes, 3).");
+
+    const int hidden_size = num_LM*num_channels;
+    if (H1.size() != num_nodes*hidden_size)
+        throw std::runtime_error("MACEField H1 buffer size does not match num_nodes.");
+
+    const int channel_pairs = num_channels*num_channels;
+    if (field_feats_weight.size() != 2*channel_pairs
+        || field_linear_weight.size() != 2*channel_pairs)
+        throw std::runtime_error("MACEField field coupling weights do not match num_channels.");
+
+    H1_pre_field = H1;
+    std::vector<double> delta_scalar(num_nodes*num_channels, 0.0);
+    std::vector<double> delta_vector(num_nodes*num_channels*3, 0.0);
+    std::vector<double> linear_scalar(num_nodes*num_channels, 0.0);
+    std::vector<double> linear_vector(num_nodes*num_channels*3, 0.0);
+
+    const double inv_sqrt_3 = 1.0/std::sqrt(3.0);
+    const auto h1_index = [this](int i, int lm, int k) {
+        return (i*num_LM + lm)*num_channels + k;
+    };
+    const auto vector_index = [this](int i, int k, int component) {
+        return (i*num_channels + k)*3 + component;
+    };
+
+    for (int i=0; i<num_nodes; ++i) {
+        const double* field_i = electric_field.data() + (electric_field.size() == 3 ? 0 : 3*i);
+
+        for (int u=0; u<num_channels; ++u) {
+            const double scalar_in = H1_pre_field[h1_index(i, 0, u)];
+            double vector_dot_field = 0.0;
+            for (int component=0; component<3; ++component)
+                vector_dot_field += -H1_pre_field[h1_index(i, 1+component, u)]*field_i[component];
+
+            for (int w=0; w<num_channels; ++w) {
+                const int weight_index = u*num_channels + w;
+                const double scalar_to_vector_weight =
+                    field_feats_scalar_to_vector_path_weight
+                    * field_feats_weight[weight_index]
+                    * inv_sqrt_3;
+                const double vector_to_scalar_weight =
+                    field_feats_vector_to_scalar_path_weight
+                    * field_feats_weight[channel_pairs + weight_index]
+                    * inv_sqrt_3;
+
+                for (int component=0; component<3; ++component)
+                    delta_vector[vector_index(i, w, component)] +=
+                        scalar_to_vector_weight*scalar_in*field_i[component];
+
+                delta_scalar[i*num_channels + w] += vector_to_scalar_weight*vector_dot_field;
+            }
+        }
+
+        for (int u=0; u<num_channels; ++u) {
+            const double scalar_in = delta_scalar[i*num_channels + u];
+            for (int w=0; w<num_channels; ++w) {
+                const int weight_index = u*num_channels + w;
+                linear_scalar[i*num_channels + w] +=
+                    field_linear_scalar_path_weight
+                    * field_linear_weight[weight_index]
+                    * scalar_in;
+                for (int component=0; component<3; ++component)
+                    linear_vector[vector_index(i, w, component)] +=
+                        field_linear_vector_path_weight
+                        * field_linear_weight[channel_pairs + weight_index]
+                        * delta_vector[vector_index(i, u, component)];
+            }
+        }
+
+        for (int k=0; k<num_channels; ++k) {
+            H1[h1_index(i, 0, k)] =
+                H1_pre_field[h1_index(i, 0, k)] - linear_scalar[i*num_channels + k];
+            for (int component=0; component<3; ++component)
+                H1[h1_index(i, 1+component, k)] =
+                    H1_pre_field[h1_index(i, 1+component, k)]
+                    + linear_vector[vector_index(i, k, component)];
+        }
+    }
+}
+
+void MACE::reverse_field_H1(
+    const int num_nodes,
+    std::span<const double> electric_field)
+{
+    if (!has_field_coupling)
+        return;
+
+    if (electric_field.size() != 3 && electric_field.size() != 3*num_nodes)
+        throw std::runtime_error("MACEField electric_field must have shape (3,) or (num_nodes, 3).");
+
+    const int hidden_size = num_LM*num_channels;
+    if (H1_adj.size() != num_nodes*hidden_size || H1_pre_field.size() != num_nodes*hidden_size)
+        throw std::runtime_error("MACEField reverse_field_H1 requires H1_adj and saved pre-field H1 buffers.");
+
+    const int channel_pairs = num_channels*num_channels;
+    const bool global_field = electric_field.size() == 3;
+    electric_field_adj.assign(electric_field.size(), 0.0);
+
+    std::vector<double> delta_scalar_adj(num_nodes*num_channels, 0.0);
+    std::vector<double> delta_vector_adj(num_nodes*num_channels*3, 0.0);
+    std::vector<double> H1_pre_adj = H1_adj;
+
+    const double inv_sqrt_3 = 1.0/std::sqrt(3.0);
+    const auto h1_index = [this](int i, int lm, int k) {
+        return (i*num_LM + lm)*num_channels + k;
+    };
+    const auto vector_index = [this](int i, int k, int component) {
+        return (i*num_channels + k)*3 + component;
+    };
+
+    for (int i=0; i<num_nodes; ++i) {
+        const double* field_i = electric_field.data() + (global_field ? 0 : 3*i);
+        double* field_adj_i = electric_field_adj.data() + (global_field ? 0 : 3*i);
+
+        // Reverse field_linear. H1_post = H1_pre - field_linear(delta).
+        for (int u=0; u<num_channels; ++u) {
+            for (int w=0; w<num_channels; ++w) {
+                const int weight_index = u*num_channels + w;
+                delta_scalar_adj[i*num_channels + u] +=
+                    -field_linear_scalar_path_weight
+                    * field_linear_weight[weight_index]
+                    * H1_adj[h1_index(i, 0, w)];
+                for (int component=0; component<3; ++component)
+                    delta_vector_adj[vector_index(i, u, component)] +=
+                        field_linear_vector_path_weight
+                        * field_linear_weight[channel_pairs + weight_index]
+                        * H1_adj[h1_index(i, 1+component, w)];
+            }
+        }
+
+        // Reverse field_feats scalar->vector and vector->scalar paths.
+        for (int u=0; u<num_channels; ++u) {
+            const double scalar_in = H1_pre_field[h1_index(i, 0, u)];
+            for (int w=0; w<num_channels; ++w) {
+                const int weight_index = u*num_channels + w;
+                const double scalar_to_vector_weight =
+                    field_feats_scalar_to_vector_path_weight
+                    * field_feats_weight[weight_index]
+                    * inv_sqrt_3;
+                const double vector_to_scalar_weight =
+                    field_feats_vector_to_scalar_path_weight
+                    * field_feats_weight[channel_pairs + weight_index]
+                    * inv_sqrt_3;
+                const double scalar_delta_adj = delta_scalar_adj[i*num_channels + w];
+
+                for (int component=0; component<3; ++component) {
+                    const double vector_delta_adj =
+                        delta_vector_adj[vector_index(i, w, component)];
+                    H1_pre_adj[h1_index(i, 0, u)] +=
+                        vector_delta_adj*scalar_to_vector_weight*field_i[component];
+                    field_adj_i[component] +=
+                        vector_delta_adj*scalar_to_vector_weight*scalar_in;
+
+                    H1_pre_adj[h1_index(i, 1+component, u)] +=
+                        -scalar_delta_adj*vector_to_scalar_weight*field_i[component];
+                    field_adj_i[component] +=
+                        -scalar_delta_adj*vector_to_scalar_weight
+                        * H1_pre_field[h1_index(i, 1+component, u)];
+                }
+            }
+        }
+    }
+
+    H1_adj = std::move(H1_pre_adj);
 }
 
 void MACE::compute_R1(
@@ -96,6 +1140,9 @@ void MACE::compute_R1(
     std::span<const int> neigh_types,
     std::span<const double> r)
 {
+    if (spl_set_1.empty())
+        throw std::runtime_error(
+            "MACE compact radial cache is not prepared; call prepare_active_types first.");
     const int num_spl = spl_set_1[0]->num_splines;
     R1.resize(r.size()*num_spl);
     R1_deriv.resize(R1.size());
@@ -104,9 +1151,7 @@ void MACE::compute_R1(
         const int type_i = node_types[i];
         for (int j=0; j<num_neigh[i]; ++j) {
             const int type_j = neigh_types[ij];
-            const int type_ij = (type_i <= type_j)
-                ? type_i*(2*atomic_numbers.size()-type_i-1)/2 + type_j
-                : type_j*(2*atomic_numbers.size()-type_j-1)/2 + type_i;
+            const int type_ij = radial_pair_index(type_i, type_j);
             auto R1_ij = std::span<double>(R1.data()+ij*num_spl,num_spl);
             auto R1_deriv_ij = std::span<double>(R1_deriv.data()+ij*num_spl,num_spl);
             spl_set_1[type_ij]->evaluate_derivs(r[ij], R1_ij, R1_deriv_ij);
@@ -284,9 +1329,7 @@ void MACE::compute_A0_scaled(
         double A0_scale_factor = 1.0;
         for (int j=0; j<num_neigh[i]; ++j) {
             const int type_j = neigh_types[ij];
-            const int type_ij = (type_i <= type_j)
-                ? type_i*(2*atomic_numbers.size()-type_i-1)/2 + type_j
-                : type_j*(2*atomic_numbers.size()-type_j-1)/2 + type_i;
+            const int type_ij = radial_pair_index(type_i, type_j);
             A0_scale_factor += A0_splines[type_ij].evaluate(r[ij]);
             ij += 1;
         }
@@ -315,9 +1358,7 @@ void MACE::reverse_A0_scaled(
         double A0_scale_factor = 1.0;
         for (int j=0; j<num_neigh[i]; ++j) {
             const int type_j = neigh_types[ij];
-            const int type_ij = (type_i <= type_j)
-                ? type_i*(2*atomic_numbers.size()-type_i-1)/2 + type_j
-                : type_j*(2*atomic_numbers.size()-type_j-1)/2 + type_i;
+            const int type_ij = radial_pair_index(type_i, type_j);
             A0_scale_factor += A0_splines[type_ij].evaluate(r[ij]);
             ij += 1;
         }
@@ -328,9 +1369,7 @@ void MACE::reverse_A0_scaled(
         ij = ij - num_neigh[i];
         for (int j=0; j<num_neigh[i]; ++j) {
             const int type_j = neigh_types[ij];
-            const int type_ij = (type_i <= type_j)
-                ? type_i*(2*atomic_numbers.size()-type_i-1)/2 + type_j
-                : type_j*(2*atomic_numbers.size()-type_j-1)/2 + type_i;
+            const int type_ij = radial_pair_index(type_i, type_j);
             auto [f,d] = A0_splines[type_ij].evaluate_deriv(r[ij]);
             auto xyz_ij = xyz.data()+ij*3;
             auto node_forces_ij = node_forces.data()+ij*3;
@@ -446,6 +1485,118 @@ void MACE::reverse_H1(
                 0.0,            // const double beta
                 M0_adj_il,      // double *c
                 num_channels);  // const MKL_INT ldc
+        }
+    }
+}
+
+void MACE::compute_H1_product(
+    const int num_nodes)
+{
+    H1.resize(M0.size());
+    for (int i=0; i<num_nodes; ++i) {
+        for (int l=0; l<=L_max; ++l) {
+            const auto M0_il = M0.data()+(i*num_LM+l*l)*num_channels;
+            const auto weights_l = H1_product_weights.data()+l*num_channels*num_channels;
+            auto H1_il = H1.data()+(i*num_LM+l*l)*num_channels;
+            cblas_dgemm(
+                CblasRowMajor,
+                CblasNoTrans,
+                CblasNoTrans,
+                2*l+1,
+                num_channels,
+                num_channels,
+                1.0,
+                M0_il,
+                num_channels,
+                weights_l,
+                num_channels,
+                0.0,
+                H1_il,
+                num_channels);
+        }
+    }
+}
+
+void MACE::compute_H1_linear_up(
+    const int num_nodes)
+{
+    auto H1_before_linear_up = H1;
+    for (int i=0; i<num_nodes; ++i) {
+        for (int l=0; l<=L_max; ++l) {
+            const auto H1_in_il = H1_before_linear_up.data()+(i*num_LM+l*l)*num_channels;
+            const auto weights_l = H1_linear_up_weights.data()+l*num_channels*num_channels;
+            auto H1_il = H1.data()+(i*num_LM+l*l)*num_channels;
+            cblas_dgemm(
+                CblasRowMajor,
+                CblasNoTrans,
+                CblasNoTrans,
+                2*l+1,
+                num_channels,
+                num_channels,
+                1.0,
+                H1_in_il,
+                num_channels,
+                weights_l,
+                num_channels,
+                0.0,
+                H1_il,
+                num_channels);
+        }
+    }
+}
+
+void MACE::reverse_H1_linear_up(
+    const int num_nodes)
+{
+    auto H1_adj_before_linear_up = H1_adj;
+    for (int i=0; i<num_nodes; ++i) {
+        for (int l=0; l<=L_max; ++l) {
+            const auto H1_adj_il = H1_adj_before_linear_up.data()+(i*num_LM+l*l)*num_channels;
+            const auto weights_l = H1_linear_up_weights.data()+l*num_channels*num_channels;
+            auto H1_pre_adj_il = H1_adj.data()+(i*num_LM+l*l)*num_channels;
+            cblas_dgemm(
+                CblasRowMajor,
+                CblasNoTrans,
+                CblasTrans,
+                2*l+1,
+                num_channels,
+                num_channels,
+                1.0,
+                H1_adj_il,
+                num_channels,
+                weights_l,
+                num_channels,
+                0.0,
+                H1_pre_adj_il,
+                num_channels);
+        }
+    }
+}
+
+void MACE::reverse_H1_product(
+    const int num_nodes)
+{
+    M0_adj.resize(M0.size());
+    for (int i=0; i<num_nodes; ++i) {
+        for (int l=0; l<=L_max; ++l) {
+            const auto H1_adj_il = H1_adj.data()+(i*num_LM+l*l)*num_channels;
+            const auto weights_l = H1_product_weights.data()+l*num_channels*num_channels;
+            auto M0_adj_il = M0_adj.data()+(i*num_LM+l*l)*num_channels;
+            cblas_dgemm(
+                CblasRowMajor,
+                CblasNoTrans,
+                CblasTrans,
+                2*l+1,
+                num_channels,
+                num_channels,
+                1.0,
+                H1_adj_il,
+                num_channels,
+                weights_l,
+                num_channels,
+                0.0,
+                M0_adj_il,
+                num_channels);
         }
     }
 }
@@ -692,9 +1843,7 @@ void MACE::compute_A1_scaled(
         double A1_scale_factor = 1.0;
         for (int j=0; j<num_neigh[i]; ++j) {
             const int type_j = neigh_types[ij];
-            const int type_ij = (type_i <= type_j)
-                ? type_i*(2*atomic_numbers.size()-type_i-1)/2 + type_j
-                : type_j*(2*atomic_numbers.size()-type_j-1)/2 + type_i;
+            const int type_ij = radial_pair_index(type_i, type_j);
             A1_scale_factor += A1_splines[type_ij].evaluate(r[ij]);
             ij += 1;
         }
@@ -726,9 +1875,7 @@ void MACE::reverse_A1_scaled(
         double A1_scale_factor = 1.0;
         for (int j=0; j<num_neigh[i]; ++j) {
             const int type_j = neigh_types[ij];
-            const int type_ij = (type_i <= type_j)
-                ? type_i*(2*atomic_numbers.size()-type_i-1)/2 + type_j
-                : type_j*(2*atomic_numbers.size()-type_j-1)/2 + type_i;
+            const int type_ij = radial_pair_index(type_i, type_j);
             A1_scale_factor += A1_splines[type_ij].evaluate(r[ij]);
             ij += 1;
         }
@@ -739,9 +1886,7 @@ void MACE::reverse_A1_scaled(
         ij = ij - num_neigh[i];
         for (int j=0; j<num_neigh[i]; ++j) {
             const int type_j = neigh_types[ij];
-            const int type_ij = (type_i <= type_j)
-                ? type_i*(2*atomic_numbers.size()-type_i-1)/2 + type_j
-                : type_j*(2*atomic_numbers.size()-type_j-1)/2 + type_i;
+            const int type_ij = radial_pair_index(type_i, type_j);
             auto [f,d] = A1_splines[type_ij].evaluate_deriv(r[ij]);
             auto xyz_ij = xyz.data()+ij*3;
             auto node_forces_ij = node_forces.data()+ij*3;
@@ -929,16 +2074,35 @@ void MACE::load_from_json(
             file["zbl_covalent_radii"].get<std::vector<double>>(),
             file["zbl_p"].get<int>());
 
-    // Radial splines
-    const double spl_h = file["radial_spline_h"];
-    auto spl_values_0 = file["radial_spline_values_0"].get<std::vector<std::vector<std::vector<double>>>>();
-    auto spl_derivs_0 = file["radial_spline_derivs_0"].get<std::vector<std::vector<std::vector<double>>>>();
-    for (int i=0; i<spl_values_0.size(); ++i)
-        spl_set_0.push_back(std::make_unique<CubicSplineSet>(spl_h, spl_values_0[i], spl_derivs_0[i]));
-    auto spl_values_1 = file["radial_spline_values_1"].get<std::vector<std::vector<std::vector<double>>>>();
-    auto spl_derivs_1 = file["radial_spline_derivs_1"].get<std::vector<std::vector<std::vector<double>>>>();
-    for (int i=0; i<spl_values_1.size(); ++i)
-        spl_set_1.push_back(std::make_unique<CubicSplineSet>(spl_h, spl_values_1[i], spl_derivs_1[i]));
+    // Radial representation
+    const int format_version = file.value("symmetrix_format_version", 1);
+    uses_compact_radial = format_version == 2;
+    if (uses_compact_radial) {
+        if (file.value("radial_representation", std::string()) != "compact")
+            throw std::invalid_argument("Symmetrix format version 2 requires compact radial data.");
+        compact_radial_model = std::make_unique<CompactRadialModel>(
+            file.at("compact_radial").dump(), atomic_numbers, r_cut);
+        type_to_active.assign(atomic_numbers.size(), -1);
+    } else if (format_version == 1) {
+        const double spl_h = file["radial_spline_h"];
+        const double spl_min = file.value("radial_spline_min", 0.0);
+        auto spl_values_0 = file["radial_spline_values_0"].get<std::vector<std::vector<std::vector<double>>>>();
+        auto spl_derivs_0 = file["radial_spline_derivs_0"].get<std::vector<std::vector<std::vector<double>>>>();
+        for (int i=0; i<spl_values_0.size(); ++i)
+            spl_set_0.push_back(std::make_unique<CubicSplineSet>(
+                spl_h, spl_values_0[i], spl_derivs_0[i], spl_min));
+        auto spl_values_1 = file["radial_spline_values_1"].get<std::vector<std::vector<std::vector<double>>>>();
+        auto spl_derivs_1 = file["radial_spline_derivs_1"].get<std::vector<std::vector<std::vector<double>>>>();
+        for (int i=0; i<spl_values_1.size(); ++i)
+            spl_set_1.push_back(std::make_unique<CubicSplineSet>(
+                spl_h, spl_values_1[i], spl_derivs_1[i], spl_min));
+        active_types.resize(atomic_numbers.size());
+        std::iota(active_types.begin(), active_types.end(), 0);
+        type_to_active = active_types;
+        active_atomic_numbers = atomic_numbers;
+    } else {
+        throw std::invalid_argument("Unsupported Symmetrix model format version.");
+    }
 
     // H0
     H0_weights = file["H0_weights"].get<std::vector<double>>();
@@ -948,13 +2112,17 @@ void MACE::load_from_json(
 
     // A0 scaling
     A0_scaled = file["A0_scaled"].get<bool>();
-    if (A0_scaled) {
+    if (A0_scaled && !uses_compact_radial) {
         const double A0_spline_h = file["A0_spline_h"];
+        const double A0_spline_min = file.value("A0_spline_min", 0.0);
         auto A0_spline_values = file["A0_spline_values"].get<std::vector<std::vector<double>>>();
         auto A0_spline_derivs = file["A0_spline_derivs"].get<std::vector<std::vector<double>>>();
         for (int i=0; i<A0_spline_values.size(); ++i)
-            A0_splines.push_back(CubicSpline(A0_spline_h, A0_spline_values[i], A0_spline_derivs[i]));
+            A0_splines.push_back(CubicSpline(
+                A0_spline_h, A0_spline_values[i], A0_spline_derivs[i], A0_spline_min));
     }
+    if (uses_compact_radial && A0_scaled != compact_radial_model->has_A0())
+        throw std::invalid_argument("Compact radial A0 network does not match A0_scaled.");
 
     // M0
     auto M0_weights = file["M0_weights"].get<std::map<std::string,std::map<std::string,std::map<std::string,std::vector<double>>>>>();
@@ -973,6 +2141,91 @@ void MACE::load_from_json(
 
     // H1
     H1_weights = file["H1_weights"].get<std::vector<double>>();
+    H1_product_weights = file.value("H1_product_weights", std::vector<double>{});
+    H1_linear_up_weights = file.value("H1_linear_up_weights", std::vector<double>{});
+
+    // MACEField H1 coupling
+    has_field_coupling = file.value("has_field_coupling", false);
+    field_feats_scalar_to_vector_path_weight = 0.0;
+    field_feats_vector_to_scalar_path_weight = 0.0;
+    field_linear_scalar_path_weight = 0.0;
+    field_linear_vector_path_weight = 0.0;
+    if (has_field_coupling) {
+        auto field_couplings = file["field_couplings"];
+        if (field_couplings.size() != 1)
+            throw std::runtime_error("MACEField JSON must contain exactly one field coupling.");
+        auto coupling = field_couplings[0];
+        const auto hidden_irreps = std::to_string(num_channels)
+            + "x0e+" + std::to_string(num_channels) + "x1o";
+        if (coupling["field_feats_irreps_in1"].get<std::string>() != hidden_irreps
+            || coupling["field_feats_irreps_in2"].get<std::string>() != "1x1o"
+            || coupling["field_feats_irreps_out"].get<std::string>() != hidden_irreps
+            || coupling["field_linear_irreps_in"].get<std::string>() != hidden_irreps
+            || coupling["field_linear_irreps_out"].get<std::string>() != hidden_irreps)
+            throw std::runtime_error("Unsupported MACEField field coupling irreps.");
+        if (L_max != 1)
+            throw std::runtime_error("MACEField JSON field coupling currently requires L_max == 1.");
+        if (H1_product_weights.size() != H1_weights.size()
+            || H1_linear_up_weights.size() != H1_weights.size())
+            throw std::runtime_error("MACEField JSON must contain split H1 product and linear_up weights.");
+
+        field_feats_weight = coupling["field_feats_weight"].get<std::vector<double>>();
+        field_feats_output_mask = coupling["field_feats_output_mask"].get<std::vector<double>>();
+        field_linear_weight = coupling["field_linear_weight"].get<std::vector<double>>();
+        field_linear_bias = coupling["field_linear_bias"].get<std::vector<double>>();
+        field_linear_output_mask = coupling["field_linear_output_mask"].get<std::vector<double>>();
+
+        const int channel_pairs = num_channels*num_channels;
+        if (field_feats_weight.size() != 2*channel_pairs
+            || field_linear_weight.size() != 2*channel_pairs
+            || field_feats_output_mask.size() != 4*num_channels
+            || field_linear_output_mask.size() != 4*num_channels
+            || !field_linear_bias.empty())
+            throw std::runtime_error("MACEField JSON field coupling tensor sizes are unsupported.");
+        for (double mask_value : field_feats_output_mask)
+            if (mask_value != 1.0)
+                throw std::runtime_error("Unsupported MACEField field_feats output mask.");
+        for (double mask_value : field_linear_output_mask)
+            if (mask_value != 1.0)
+                throw std::runtime_error("Unsupported MACEField field_linear output mask.");
+
+        auto field_feats_instructions = coupling["field_feats_instructions"];
+        if (field_feats_instructions.size() != 2)
+            throw std::runtime_error("MACEField field_feats must contain exactly two instructions.");
+        for (const auto& instruction : field_feats_instructions) {
+            if (instruction["connection_mode"].get<std::string>() != "uvw")
+                throw std::runtime_error("MACEField field_feats only supports uvw instructions.");
+            auto path_shape = instruction["path_shape"].get<std::vector<int>>();
+            if (path_shape != std::vector<int>{num_channels, 1, num_channels})
+                throw std::runtime_error("Unsupported MACEField field_feats path shape.");
+            const int i_in1 = instruction["i_in1"].get<int>();
+            const int i_in2 = instruction["i_in2"].get<int>();
+            const int i_out = instruction["i_out"].get<int>();
+            if (i_in1 == 0 && i_in2 == 0 && i_out == 1)
+                field_feats_scalar_to_vector_path_weight = instruction["path_weight"].get<double>();
+            else if (i_in1 == 1 && i_in2 == 0 && i_out == 0)
+                field_feats_vector_to_scalar_path_weight = instruction["path_weight"].get<double>();
+            else
+                throw std::runtime_error("Unsupported MACEField field_feats instruction.");
+        }
+
+        auto field_linear_instructions = coupling["field_linear_instructions"];
+        if (field_linear_instructions.size() != 2)
+            throw std::runtime_error("MACEField field_linear must contain exactly two instructions.");
+        for (const auto& instruction : field_linear_instructions) {
+            auto path_shape = instruction["path_shape"].get<std::vector<int>>();
+            if (path_shape != std::vector<int>{num_channels, num_channels})
+                throw std::runtime_error("Unsupported MACEField field_linear path shape.");
+            const int i_in = instruction["i_in"].get<int>();
+            const int i_out = instruction["i_out"].get<int>();
+            if (i_in == 0 && i_out == 0)
+                field_linear_scalar_path_weight = instruction["path_weight"].get<double>();
+            else if (i_in == 1 && i_out == 1)
+                field_linear_vector_path_weight = instruction["path_weight"].get<double>();
+            else
+                throw std::runtime_error("Unsupported MACEField field_linear instruction.");
+        }
+    }
 
     // Phi1
     Phi1_l = file["Phi1_l"].get<std::vector<int>>();
@@ -993,13 +2246,17 @@ void MACE::load_from_json(
 
     // A1 scaling
     A1_scaled = file["A1_scaled"].get<bool>();
-    if (A1_scaled) {
+    if (A1_scaled && !uses_compact_radial) {
         const double A1_spline_h = file["A1_spline_h"];
+        const double A1_spline_min = file.value("A1_spline_min", 0.0);
         auto A1_spline_values = file["A1_spline_values"].get<std::vector<std::vector<double>>>();
         auto A1_spline_derivs = file["A1_spline_derivs"].get<std::vector<std::vector<double>>>();
         for (int i=0; i<A1_spline_values.size(); ++i)
-            A1_splines.push_back(CubicSpline(A1_spline_h, A1_spline_values[i], A1_spline_derivs[i]));
+            A1_splines.push_back(CubicSpline(
+                A1_spline_h, A1_spline_values[i], A1_spline_derivs[i], A1_spline_min));
     }
+    if (uses_compact_radial && A1_scaled != compact_radial_model->has_A1())
+        throw std::invalid_argument("Compact radial A1 network does not match A1_scaled.");
 
     // M1
     auto M1_weights = file["M1_weights"].get<std::map<std::string,std::map<std::string,std::vector<double>>>>();

--- a/libsymmetrix/source/mace.hpp
+++ b/libsymmetrix/source/mace.hpp
@@ -3,6 +3,7 @@
 #include <vector>
 #include <span>
 
+#include "compact_radial.hpp"
 #include "cubic_spline.hpp"
 #include "cubic_spline_set.hpp"
 #include "multilayer_perceptron.hpp"
@@ -23,6 +24,8 @@ int l_max, num_lm;
 int L_max, num_LM;
 std::vector<int> atomic_numbers;
 std::vector<double> atomic_energies;
+std::vector<int> active_atomic_numbers;
+void prepare_active_types(std::span<const int> node_types);
 
 // Node energies and forces
 std::vector<double> node_energies, node_forces;
@@ -33,12 +36,24 @@ void compute_node_energies_forces(const int num_nodes,
                                   std::span<const int> neigh_types,
                                   std::span<const double> xyz,
                                   std::span<const double> r);
+void compute_node_energies_forces_field(const int num_nodes,
+                                        std::span<const int> node_types,
+                                        std::span<const int> num_neigh,
+                                        std::span<const int> neigh_indices,
+                                        std::span<const int> neigh_types,
+                                        std::span<const double> xyz,
+                                        std::span<const double> r,
+                                        std::span<const double> electric_field);
 
 // ZBL
 bool has_zbl;
 ZBL zbl;
 
 // Radial functions
+bool uses_compact_radial = false;
+std::unique_ptr<CompactRadialModel> compact_radial_model;
+std::vector<int> active_types;
+std::vector<int> type_to_active;
 std::vector<std::unique_ptr<CubicSplineSet>> spl_set_0;
 std::vector<double> R0, R0_deriv;
 void compute_R0(const int num_nodes,
@@ -55,6 +70,7 @@ void compute_R1(const int num_nodes,
                 std::span<const int> num_neigh,
                 std::span<const int> neigh_types,
                 std::span<const double> r);
+int radial_pair_index(int type_i, int type_j) const;
 
 // Spherical harmonics
 std::vector<double> Y, Y_grad;
@@ -109,6 +125,46 @@ std::vector<double> H1, H1_adj;
 std::vector<double> H1_weights;
 void compute_H1(const int num_nodes);
 void reverse_H1(const int num_nodes);
+std::vector<double> H1_product_weights;
+std::vector<double> H1_linear_up_weights;
+void compute_H1_product(const int num_nodes);
+void compute_H1_linear_up(const int num_nodes);
+void reverse_H1_linear_up(const int num_nodes);
+void reverse_H1_product(const int num_nodes);
+
+// MACEField coupling after H1
+bool has_field_coupling;
+std::vector<double> H1_pre_field;
+std::vector<double> field_feats_weight;
+std::vector<double> field_feats_output_mask;
+std::vector<double> field_linear_weight;
+std::vector<double> field_linear_bias;
+std::vector<double> field_linear_output_mask;
+std::vector<double> electric_field_adj;
+std::vector<double> electric_field_hessian;
+std::vector<double> electric_field_force_derivative;
+double field_feats_scalar_to_vector_path_weight;
+double field_feats_vector_to_scalar_path_weight;
+double field_linear_scalar_path_weight;
+double field_linear_vector_path_weight;
+void compute_field_H1(const int num_nodes, std::span<const double> electric_field);
+void reverse_field_H1(const int num_nodes, std::span<const double> electric_field);
+void compute_electric_field_hessian(const int num_nodes,
+                                    std::span<const int> node_types,
+                                    std::span<const int> num_neigh,
+                                    std::span<const int> neigh_indices,
+                                    std::span<const int> neigh_types,
+                                    std::span<const double> xyz,
+                                    std::span<const double> r,
+                                    std::span<const double> electric_field);
+void compute_electric_field_force_derivative(const int num_nodes,
+                                             std::span<const int> node_types,
+                                             std::span<const int> num_neigh,
+                                             std::span<const int> neigh_indices,
+                                             std::span<const int> neigh_types,
+                                             std::span<const double> xyz,
+                                             std::span<const double> r,
+                                             std::span<const double> electric_field);
 
 // Phi1
 int num_lelm1lm2, num_lme;

--- a/libsymmetrix/source/mace_kokkos.cpp
+++ b/libsymmetrix/source/mace_kokkos.cpp
@@ -1,5 +1,9 @@
+#include <algorithm>
+#include <cmath>
 #include <fstream>
 #include <numbers>
+#include <numeric>
+#include <stdexcept>
 
 // TODO: remove some of these headers?
 #include "KokkosBatched_Util.hpp"
@@ -29,6 +33,171 @@ using Kokkos::TeamVectorMDRange;
 using Kokkos::View;
 
 template <typename Precision>
+struct ReverseFieldH1GlobalReducer {
+    using value_type = double[];
+
+    static constexpr unsigned value_count = 3;
+
+    int num_channels;
+    int channel_pairs;
+    double inv_sqrt_3;
+    double field_feats_scalar_to_vector_path_weight;
+    double field_feats_vector_to_scalar_path_weight;
+    double field_linear_scalar_path_weight;
+    double field_linear_vector_path_weight;
+    Kokkos::View<Precision**,Kokkos::LayoutRight> delta_scalar_adj;
+    Kokkos::View<Precision***,Kokkos::LayoutRight> delta_vector_adj;
+    Kokkos::View<Precision***,Kokkos::LayoutRight> H1_pre_adj;
+    Kokkos::View<Precision***,Kokkos::LayoutRight> H1_adj;
+    Kokkos::View<Precision***,Kokkos::LayoutRight> H1_pre_field;
+    Kokkos::View<Precision*> field_feats_weight;
+    Kokkos::View<Precision*> field_linear_weight;
+    Kokkos::View<const double*> electric_field;
+    Kokkos::View<double*> electric_field_adj;
+
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const int i, double local_electric_field_adj[]) const {
+        for (int u=0; u<num_channels; ++u) {
+            for (int w=0; w<num_channels; ++w) {
+                const int weight_index = u*num_channels + w;
+                delta_scalar_adj(i,u) +=
+                    -field_linear_scalar_path_weight
+                    * field_linear_weight(weight_index)
+                    * H1_adj(i,0,w);
+                for (int component=0; component<3; ++component)
+                    delta_vector_adj(i,u,component) +=
+                        field_linear_vector_path_weight
+                        * field_linear_weight(channel_pairs + weight_index)
+                        * H1_adj(i,1+component,w);
+            }
+        }
+
+        for (int u=0; u<num_channels; ++u) {
+            const Precision scalar_in = H1_pre_field(i,0,u);
+            for (int w=0; w<num_channels; ++w) {
+                const int weight_index = u*num_channels + w;
+                const Precision scalar_to_vector_weight =
+                    field_feats_scalar_to_vector_path_weight
+                    * field_feats_weight(weight_index)
+                    * inv_sqrt_3;
+                const Precision vector_to_scalar_weight =
+                    field_feats_vector_to_scalar_path_weight
+                    * field_feats_weight(channel_pairs + weight_index)
+                    * inv_sqrt_3;
+                const Precision scalar_delta_adj = delta_scalar_adj(i,w);
+
+                for (int component=0; component<3; ++component) {
+                    const Precision vector_delta_adj = delta_vector_adj(i,w,component);
+                    H1_pre_adj(i,0,u) +=
+                        vector_delta_adj*scalar_to_vector_weight*electric_field(component);
+                    local_electric_field_adj[component] +=
+                        static_cast<double>(vector_delta_adj*scalar_to_vector_weight*scalar_in);
+
+                    H1_pre_adj(i,1+component,u) +=
+                        -scalar_delta_adj*vector_to_scalar_weight*electric_field(component);
+                    local_electric_field_adj[component] +=
+                        static_cast<double>(
+                            -scalar_delta_adj*vector_to_scalar_weight
+                            * H1_pre_field(i,1+component,u));
+                }
+            }
+        }
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    void init(double update[]) const {
+        for (int component=0; component<3; ++component)
+            update[component] = 0.0;
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    void join(double dst[], const double src[]) const {
+        for (int component=0; component<3; ++component)
+            dst[component] += src[component];
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    void final(double update[]) const {
+        for (int component=0; component<3; ++component)
+            electric_field_adj(component) = update[component];
+    }
+};
+
+template <typename Precision>
+struct AnalyticFieldReverseReducer {
+    using value_type = double[];
+
+    static constexpr unsigned value_count = 3;
+
+    int num_channels;
+    int seed;
+    Kokkos::View<Precision***,Kokkos::LayoutRight> H1_adj;
+    Kokkos::View<Precision***,Kokkos::LayoutRight> H1_adj_dot;
+    Kokkos::View<Precision***,Kokkos::LayoutRight> H1_pre_field;
+    Kokkos::View<Precision***,Kokkos::LayoutRight> H1_product_adj_dot;
+    Kokkos::View<Precision***,Kokkos::LayoutRight> H1_linear_up_weights;
+    Kokkos::View<Precision**,Kokkos::LayoutRight> scalar_to_vector_up;
+    Kokkos::View<Precision**,Kokkos::LayoutRight> vector_to_scalar_up;
+    Kokkos::View<const double*> electric_field;
+    Kokkos::View<double*> electric_field_hessian;
+
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const int index, double local_hessian[]) const {
+        const int i = index/num_channels;
+        const int input = index%num_channels;
+        Precision scalar_dot = 0.0;
+        Precision vector_dot[3] = {};
+        const Precision scalar_feature = H1_pre_field(i,0,input);
+        for (int output=0; output<num_channels; ++output) {
+            const Precision scalar_vector = scalar_to_vector_up(input,output);
+            const Precision vector_scalar = vector_to_scalar_up(input,output);
+            const Precision scalar_adjoint = H1_adj(i,0,output);
+            const Precision scalar_adjoint_dot = H1_adj_dot(i,0,output);
+            scalar_dot += H1_linear_up_weights(0,input,output)
+                *scalar_adjoint_dot;
+            for (int component=0; component<3; ++component) {
+                const Precision vector_adjoint = H1_adj(i,1+component,output);
+                const Precision vector_adjoint_dot =
+                    H1_adj_dot(i,1+component,output);
+                const Precision field_component = static_cast<Precision>(
+                    electric_field(component));
+                vector_dot[component] +=
+                    H1_linear_up_weights(1,input,output)*vector_adjoint_dot
+                    +vector_scalar*(field_component*scalar_adjoint_dot
+                        +(component == seed ? scalar_adjoint : Precision(0)));
+                scalar_dot += scalar_vector*(field_component*vector_adjoint_dot
+                    +(component == seed ? vector_adjoint : Precision(0)));
+                local_hessian[component] += static_cast<double>(
+                    scalar_vector*scalar_feature*vector_adjoint_dot
+                    +vector_scalar*H1_pre_field(i,1+component,input)
+                        *scalar_adjoint_dot);
+            }
+        }
+        H1_product_adj_dot(i,0,input) = scalar_dot;
+        for (int component=0; component<3; ++component)
+            H1_product_adj_dot(i,1+component,input) = vector_dot[component];
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    void init(double update[]) const {
+        for (int component=0; component<3; ++component)
+            update[component] = 0.0;
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    void join(double dst[], const double src[]) const {
+        for (int component=0; component<3; ++component)
+            dst[component] += src[component];
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    void final(double update[]) const {
+        for (int component=0; component<3; ++component)
+            electric_field_hessian(component*3+seed) += update[component];
+    }
+};
+
+template <typename Precision>
 MACEKokkos<Precision>::MACEKokkos(std::string filename)
 {
     load_from_json(filename);
@@ -51,6 +220,159 @@ MACEKokkos<Precision>::~MACEKokkos()
 }
 
 template <typename Precision>
+void MACEKokkos<Precision>::prepare_active_types(std::vector<int> node_types)
+{
+    if (!uses_compact_radial)
+        return;
+
+    std::sort(node_types.begin(), node_types.end());
+    node_types.erase(std::unique(node_types.begin(), node_types.end()), node_types.end());
+    if (node_types.empty())
+        throw std::invalid_argument("MACEKokkos compact radial cache requires at least one active type.");
+    for (const int type : node_types)
+        if (type < 0 || type >= atomic_numbers_host.size())
+            throw std::out_of_range("MACEKokkos active type index is out of range.");
+    if (node_types == active_types)
+        return;
+
+    Kokkos::fence();
+    const int active_count = node_types.size();
+    const int pair_count = active_count*(active_count+1)/2;
+    auto pair_tables = std::vector<CompactRadialPairTables>();
+    pair_tables.reserve(pair_count);
+    for (int active_i=0; active_i<active_count; ++active_i)
+        for (int active_j=active_i; active_j<active_count; ++active_j)
+            pair_tables.push_back(compact_radial_model->materialize_pair(
+                node_types[active_i], node_types[active_j]));
+
+    const double h = compact_radial_model->spline_h();
+    const double x0 = compact_radial_model->spline_min();
+    const int spline_nodes = compact_radial_model->num_spline_points();
+    const int R0_functions = (l_max+1)*num_channels;
+    auto new_R0_coefficients = Kokkos::View<Precision****,Kokkos::LayoutRight>(
+        "R0 compact coefficients", active_count*active_count,
+        spline_nodes-1, 4, R0_functions);
+    auto h_R0_coefficients = Kokkos::create_mirror_view(new_R0_coefficients);
+    for (int active_i=0; active_i<active_count; ++active_i) {
+        for (int active_j=0; active_j<active_count; ++active_j) {
+            const int ordered_pair = active_i*active_count+active_j;
+            const int unordered_pair = (active_i <= active_j)
+                ? active_i*(2*active_count-active_i-1)/2+active_j
+                : active_j*(2*active_count-active_j-1)/2+active_i;
+            const int global_i = node_types[active_i];
+            const int global_j = node_types[active_j];
+            const auto& values = pair_tables[unordered_pair].R0.values;
+            const auto& derivatives = pair_tables[unordered_pair].R0.derivatives;
+            if (values.size() != R0_functions || derivatives.size() != R0_functions)
+                throw std::runtime_error("Compact radial R0 output has an invalid size.");
+            for (int node=0; node<spline_nodes-1; ++node) {
+                for (int lk=0; lk<R0_functions; ++lk) {
+                    const double value = values[lk][node];
+                    const double deriv = derivatives[lk][node];
+                    const double next_value = values[lk][node+1];
+                    const double next_deriv = derivatives[lk][node+1];
+                    h_R0_coefficients(ordered_pair,node,0,lk) = static_cast<Precision>(value);
+                    h_R0_coefficients(ordered_pair,node,1,lk) = static_cast<Precision>(deriv);
+                    h_R0_coefficients(ordered_pair,node,2,lk) = static_cast<Precision>(
+                        (-3*value-2*h*deriv+3*next_value-h*next_deriv)/(h*h));
+                    h_R0_coefficients(ordered_pair,node,3,lk) = static_cast<Precision>(
+                        (2*value+h*deriv-2*next_value+h*next_deriv)/(h*h*h));
+                }
+
+                for (int lk=0; lk<R0_functions; ++lk) {
+                    const int channel = lk%num_channels;
+                    const auto H0_weight = static_cast<Precision>(
+                        H0_weights_host[global_j*num_channels+channel]);
+                    for (int coefficient=0; coefficient<4; ++coefficient)
+                        h_R0_coefficients(ordered_pair,node,coefficient,lk) *= H0_weight;
+                }
+
+                for (int l=0; l<=l_max; ++l) {
+                    auto original = std::vector<Precision>(4*num_channels);
+                    for (int coefficient=0; coefficient<4; ++coefficient)
+                        for (int channel=0; channel<num_channels; ++channel)
+                            original[coefficient*num_channels+channel] =
+                                h_R0_coefficients(
+                                    ordered_pair,node,coefficient,l*num_channels+channel);
+                    for (int coefficient=0; coefficient<4; ++coefficient) {
+                        for (int channel=0; channel<num_channels; ++channel) {
+                            Precision fused = 0.0;
+                            for (int input_channel=0; input_channel<num_channels; ++input_channel)
+                                fused += static_cast<Precision>(
+                                    A0_weights_host[global_i][l][input_channel*num_channels+channel])
+                                    * original[coefficient*num_channels+input_channel];
+                            h_R0_coefficients(
+                                ordered_pair,node,coefficient,l*num_channels+channel) = fused;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Kokkos::deep_copy(new_R0_coefficients, h_R0_coefficients);
+
+    auto R1_values = std::vector<std::vector<std::vector<double>>>();
+    auto R1_derivatives = std::vector<std::vector<std::vector<double>>>();
+    auto A0_values = std::vector<std::vector<std::vector<double>>>();
+    auto A0_derivatives = std::vector<std::vector<std::vector<double>>>();
+    auto A1_values = std::vector<std::vector<std::vector<double>>>();
+    auto A1_derivatives = std::vector<std::vector<std::vector<double>>>();
+    R1_values.reserve(pair_count);
+    R1_derivatives.reserve(pair_count);
+    for (auto& tables : pair_tables) {
+        const auto expected_R1 = static_cast<std::size_t>(Phi1_l.size()*num_channels);
+        if (tables.R1.values.size() != expected_R1
+            || tables.R1.derivatives.size() != expected_R1)
+            throw std::runtime_error("Compact radial R1 output has an invalid size.");
+        R1_values.push_back(std::move(tables.R1.values));
+        R1_derivatives.push_back(std::move(tables.R1.derivatives));
+        if (A0_scaled) {
+            A0_values.push_back(std::move(tables.A0.values));
+            A0_derivatives.push_back(std::move(tables.A0.derivatives));
+        }
+        if (A1_scaled) {
+            A1_values.push_back(std::move(tables.A1.values));
+            A1_derivatives.push_back(std::move(tables.A1.derivatives));
+        }
+    }
+    auto new_radial_1 =
+        RadialFunctionSetKokkos<Precision>(h, R1_values, R1_derivatives, x0);
+    auto new_A0_splines = RadialFunctionSetKokkos<double>();
+    auto new_A1_splines = RadialFunctionSetKokkos<double>();
+    if (A0_scaled)
+        new_A0_splines =
+            RadialFunctionSetKokkos<double>(h, A0_values, A0_derivatives, x0);
+    if (A1_scaled)
+        new_A1_splines =
+            RadialFunctionSetKokkos<double>(h, A1_values, A1_derivatives, x0);
+
+    auto new_type_to_active = Kokkos::View<int*>("compact type_to_active", atomic_numbers_host.size());
+    auto h_type_to_active = Kokkos::create_mirror_view(new_type_to_active);
+    Kokkos::deep_copy(h_type_to_active, -1);
+    auto new_active_atomic_numbers = std::vector<int>();
+    new_active_atomic_numbers.reserve(active_count);
+    for (int active=0; active<active_count; ++active) {
+        h_type_to_active(node_types[active]) = active;
+        new_active_atomic_numbers.push_back(atomic_numbers_host[node_types[active]]);
+    }
+    Kokkos::deep_copy(new_type_to_active, h_type_to_active);
+    Kokkos::fence();
+
+    R0_spline_h = h;
+    R0_spline_min = x0;
+    R0_spline_coefficients = new_R0_coefficients;
+    radial_1 = std::move(new_radial_1);
+    if (A0_scaled)
+        A0_splines = std::move(new_A0_splines);
+    if (A1_scaled)
+        A1_splines = std::move(new_A1_splines);
+    type_to_active = new_type_to_active;
+    num_active_types = active_count;
+    active_atomic_numbers = std::move(new_active_atomic_numbers);
+    active_types = std::move(node_types);
+}
+
+template <typename Precision>
 void MACEKokkos<Precision>::compute_node_energies_forces(
     const int num_nodes,
     Kokkos::View<const int*> node_types,
@@ -60,9 +382,9 @@ void MACEKokkos<Precision>::compute_node_energies_forces(
     Kokkos::View<const double*> xyz,
     Kokkos::View<const double*> r)
 {
-    if (node_energies.size() < num_nodes)
+    if (node_energies.size() != num_nodes)
         Kokkos::realloc(node_energies, num_nodes);
-    if (node_forces.size() < xyz.size())
+    if (node_forces.size() != xyz.size())
         Kokkos::realloc(node_forces, xyz.size());
     Kokkos::deep_copy(node_energies, 0.0);
     Kokkos::deep_copy(node_forces, 0.0);
@@ -102,6 +424,68 @@ void MACEKokkos<Precision>::compute_node_energies_forces(
 }
 
 template <typename Precision>
+void MACEKokkos<Precision>::compute_node_energies_forces_field(
+    const int num_nodes,
+    Kokkos::View<const int*> node_types,
+    Kokkos::View<const int*> num_neigh,
+    Kokkos::View<const int*> neigh_indices,
+    Kokkos::View<const int*> neigh_types,
+    Kokkos::View<const double*> xyz,
+    Kokkos::View<const double*> r,
+    Kokkos::View<const double*> electric_field)
+{
+    if (!has_field_coupling)
+        throw std::invalid_argument("MACEKokkos::compute_node_energies_forces_field requires field coupling.");
+
+    if (node_energies.size() != num_nodes)
+        Kokkos::realloc(node_energies, num_nodes);
+    if (node_forces.size() != xyz.size())
+        Kokkos::realloc(node_forces, xyz.size());
+    Kokkos::deep_copy(node_energies, 0.0);
+    Kokkos::deep_copy(node_forces, 0.0);
+
+    if (has_zbl)
+        zbl.compute_ZBL(
+            num_nodes, node_types, num_neigh, neigh_types,
+            atomic_numbers, r, xyz, node_energies, node_forces);
+
+    compute_R0(num_nodes, node_types, num_neigh, neigh_types, r);
+    compute_R1(num_nodes, node_types, num_neigh, neigh_types, r);
+    compute_Y(xyz);
+
+    compute_A0(num_nodes, node_types, num_neigh, neigh_types);
+    compute_A0_scaled(num_nodes, node_types, num_neigh, neigh_types, r);
+    compute_M0(num_nodes, node_types);
+    compute_H1_product(num_nodes);
+    compute_field_H1(num_nodes, electric_field);
+    compute_H1_linear_up(num_nodes);
+
+    compute_Phi1(num_nodes, num_neigh, neigh_indices);
+    compute_A1(num_nodes);
+    compute_A1_scaled(num_nodes, node_types, num_neigh, neigh_types, r);
+    compute_M1(num_nodes, node_types);
+    compute_H2(num_nodes, node_types);
+
+    compute_readouts(num_nodes, node_types);
+
+    reverse_H2(num_nodes, node_types, false);
+    reverse_M1(num_nodes, node_types);
+    reverse_A1_scaled(num_nodes, node_types, num_neigh, neigh_types, xyz, r);
+    reverse_A1(num_nodes);
+    reverse_Phi1(num_nodes, num_neigh, neigh_indices, xyz, r, false, false);
+
+    reverse_H1_linear_up(num_nodes);
+    reverse_field_H1(num_nodes, electric_field);
+    reverse_H1_product(num_nodes);
+    reverse_M0(num_nodes, node_types);
+    reverse_A0_scaled(num_nodes, node_types, num_neigh, neigh_types, xyz, r);
+    reverse_A0(num_nodes, node_types, num_neigh, neigh_types, xyz, r);
+
+}
+
+#include "mace_kokkos_response.tpp"
+
+template <typename Precision>
 void MACEKokkos<Precision>::compute_R0(
     const int num_nodes,
     Kokkos::View<const int*> node_types,
@@ -109,6 +493,8 @@ void MACEKokkos<Precision>::compute_R0(
     Kokkos::View<const int*> neigh_types,
     Kokkos::View<const double*> r)
 {
+    if (num_active_types == 0)
+        throw std::runtime_error("MACEKokkos radial cache has not been prepared.");
     if (r.size() > R0.extent(0)) {
         Kokkos::realloc(R0, r.size(), (l_max+1)*num_channels);
         Kokkos::realloc(R0_deriv, r.size(), (l_max+1)*num_channels);
@@ -140,9 +526,12 @@ void MACEKokkos<Precision>::compute_R0(
 
     const int l_max = this->l_max;
     const int num_channels = this->num_channels;
-    const auto num_types = atomic_numbers.size();
+    const auto num_types = num_active_types;
+    const auto type_to_active = this->type_to_active;
     const auto h = R0_spline_h;
+    const auto x0 = R0_spline_min;
     const auto c = R0_spline_coefficients;
+    const auto num_intervals = c.extent(1);
     auto R0 = this->R0;
     auto R0_deriv = this->R0_deriv;
 
@@ -151,12 +540,19 @@ void MACEKokkos<Precision>::compute_R0(
         Kokkos::TeamPolicy<>(r.size(), Kokkos::AUTO, 32),
         KOKKOS_LAMBDA (Kokkos::TeamPolicy<>::member_type team_member) {
             const int ij = team_member.league_rank();
-            const int type_i = node_types(i_list(ij));
-            const int type_j = neigh_types(ij);
+            const int type_i = type_to_active(node_types(i_list(ij)));
+            const int type_j = type_to_active(neigh_types(ij));
             const int type_ij = type_i*num_types+type_j;
             // compute x, x^2, x^3
-            const int n = static_cast<int>(r(ij)/h); // TODO: bounds checking?
-            const double x = r(ij) - h*n;
+            int n = static_cast<int>(Kokkos::floor((r(ij)-x0)/h));
+            double x = r(ij)-x0-h*n;
+            if (n < 0) {
+                n = 0;
+                x = 0.0;
+            } else if (n >= num_intervals) {
+                n = num_intervals-1;
+                x = h;
+            }
             const double xx = x*x;
             const double xxx = xx*x;
             const double two_x = 2*x;
@@ -188,7 +584,9 @@ void MACEKokkos<Precision>::compute_R1(
         Kokkos::realloc(R1, r.size(), Phi1_l.size()*num_channels);
         Kokkos::realloc(R1_deriv, r.size(), Phi1_l.size()*num_channels);
     }
-    radial_1.evaluate(num_nodes, node_types, num_neigh, neigh_types, r, R1, R1_deriv);
+    radial_1.evaluate(
+        num_nodes, node_types, num_neigh, neigh_types,
+        type_to_active, num_active_types, r, R1, R1_deriv);
     Kokkos::fence();
 }
 
@@ -441,7 +839,9 @@ void MACEKokkos<Precision>::compute_A0_scaled(
         Kokkos::realloc(A0_spline_values, r.size(), 1);
         Kokkos::realloc(A0_spline_derivs, r.size(), 1);
     }
-    A0_splines.evaluate(num_nodes, node_types, num_neigh, neigh_types, r, A0_spline_values, A0_spline_derivs);
+    A0_splines.evaluate(
+        num_nodes, node_types, num_neigh, neigh_types,
+        type_to_active, num_active_types, r, A0_spline_values, A0_spline_derivs);
 
     Kokkos::View<int*> first_neigh("first_neigh", num_nodes);
     Kokkos::parallel_scan("Compute first_neigh",
@@ -782,6 +1182,65 @@ void MACEKokkos<Precision>::compute_H1(
 }
 
 template <typename Precision>
+void MACEKokkos<Precision>::compute_H1_product(
+    const int num_nodes)
+{
+    if (H1.extent(0) < M0.extent(0))
+        Kokkos::realloc(H1, M0.extent(0), M0.extent(1), M0.extent(2));
+
+    auto L_max = this->L_max;
+    auto H1 = this->H1;
+    auto H1_product_weights = this->H1_product_weights;
+    auto M0 = this->M0;
+
+    Kokkos::parallel_for("MACEKokkos::compute_H1_product",
+        Kokkos::TeamPolicy<>(num_nodes*(L_max+1), Kokkos::AUTO, Kokkos::AUTO),
+        KOKKOS_LAMBDA (Kokkos::TeamPolicy<>::member_type team_member) {
+            const int i = team_member.league_rank() / (L_max+1);
+            const int l = team_member.league_rank() % (L_max+1);
+            auto M0_il = Kokkos::subview(M0, i, Kokkos::make_pair(l*l, l*(l+2)+1), Kokkos::ALL);
+            auto W_il = Kokkos::subview(H1_product_weights, l, Kokkos::ALL, Kokkos::ALL);
+            auto H1_il = Kokkos::subview(H1, i, Kokkos::make_pair(l*l, l*(l+2)+1), Kokkos::ALL);
+            KokkosBatched::TeamGemm<Kokkos::TeamPolicy<>::member_type,
+                                    KokkosBatched::Trans::NoTranspose,
+                                    KokkosBatched::Trans::NoTranspose,
+                                    KokkosBatched::Algo::Gemm::Unblocked>
+                ::invoke(team_member, 1.0, M0_il, W_il, 0.0, H1_il);
+        });
+    Kokkos::fence();
+}
+
+template <typename Precision>
+void MACEKokkos<Precision>::compute_H1_linear_up(
+    const int num_nodes)
+{
+    if (H1_pre_linear_up.extent(0) < H1.extent(0))
+        Kokkos::realloc(H1_pre_linear_up, H1.extent(0), H1.extent(1), H1.extent(2));
+    Kokkos::deep_copy(H1_pre_linear_up, H1);
+
+    auto L_max = this->L_max;
+    auto H1 = this->H1;
+    auto H1_pre_linear_up = this->H1_pre_linear_up;
+    auto H1_linear_up_weights = this->H1_linear_up_weights;
+
+    Kokkos::parallel_for("MACEKokkos::compute_H1_linear_up",
+        Kokkos::TeamPolicy<>(num_nodes*(L_max+1), Kokkos::AUTO, Kokkos::AUTO),
+        KOKKOS_LAMBDA (Kokkos::TeamPolicy<>::member_type team_member) {
+            const int i = team_member.league_rank() / (L_max+1);
+            const int l = team_member.league_rank() % (L_max+1);
+            auto H1_in_il = Kokkos::subview(H1_pre_linear_up, i, Kokkos::make_pair(l*l, l*(l+2)+1), Kokkos::ALL);
+            auto W_il = Kokkos::subview(H1_linear_up_weights, l, Kokkos::ALL, Kokkos::ALL);
+            auto H1_il = Kokkos::subview(H1, i, Kokkos::make_pair(l*l, l*(l+2)+1), Kokkos::ALL);
+            KokkosBatched::TeamGemm<Kokkos::TeamPolicy<>::member_type,
+                                    KokkosBatched::Trans::NoTranspose,
+                                    KokkosBatched::Trans::NoTranspose,
+                                    KokkosBatched::Algo::Gemm::Unblocked>
+                ::invoke(team_member, 1.0, H1_in_il, W_il, 0.0, H1_il);
+        });
+    Kokkos::fence();
+}
+
+template <typename Precision>
 void MACEKokkos<Precision>::reverse_H1(
     const int num_nodes)
 {
@@ -806,6 +1265,308 @@ void MACEKokkos<Precision>::reverse_H1(
                                     KokkosBatched::Trans::Transpose,
                                     KokkosBatched::Algo::Gemm::Unblocked>
                 ::invoke(team_member, 1.0, H1_adj_il, W_il, 0.0, M0_adj_il);
+        });
+    Kokkos::fence();
+}
+
+template <typename Precision>
+void MACEKokkos<Precision>::reverse_H1_linear_up(
+    const int num_nodes)
+{
+    if (H1_pre_linear_up.extent(0) < H1.extent(0))
+        throw std::runtime_error("MACEKokkos::reverse_H1_linear_up requires saved pre-linear-up H1.");
+
+    auto L_max = this->L_max;
+    auto H1_adj = this->H1_adj;
+    auto H1_linear_up_weights = this->H1_linear_up_weights;
+    auto H1_pre_linear_up = this->H1_pre_linear_up;
+
+    Kokkos::parallel_for("MACEKokkos::reverse_H1_linear_up",
+        Kokkos::TeamPolicy<>(num_nodes*(L_max+1), Kokkos::AUTO, Kokkos::AUTO),
+        KOKKOS_LAMBDA (Kokkos::TeamPolicy<>::member_type team_member) {
+            const int i = team_member.league_rank() / (L_max+1);
+            const int l = team_member.league_rank() % (L_max+1);
+            auto H1_adj_il = Kokkos::subview(H1_adj, i, Kokkos::make_pair(l*l, l*(l+2)+1), Kokkos::ALL);
+            auto W_il = Kokkos::subview(H1_linear_up_weights, l, Kokkos::ALL, Kokkos::ALL);
+            auto H1_pre_adj_il = Kokkos::subview(H1_pre_linear_up, i, Kokkos::make_pair(l*l, l*(l+2)+1), Kokkos::ALL);
+            KokkosBatched::TeamGemm<Kokkos::TeamPolicy<>::member_type,
+                                    KokkosBatched::Trans::NoTranspose,
+                                    KokkosBatched::Trans::Transpose,
+                                    KokkosBatched::Algo::Gemm::Unblocked>
+                ::invoke(team_member, 1.0, H1_adj_il, W_il, 0.0, H1_pre_adj_il);
+        });
+    Kokkos::deep_copy(H1_adj, H1_pre_linear_up);
+    Kokkos::fence();
+}
+
+template <typename Precision>
+void MACEKokkos<Precision>::reverse_H1_product(
+    const int num_nodes)
+{
+    if (M0_adj.extent(0) < M0.extent(0))
+        Kokkos::realloc(M0_adj, M0.extent(0), M0.extent(1), M0.extent(2));
+
+    auto L_max = this->L_max;
+    auto M0_adj = this->M0_adj;
+    auto H1_product_weights = this->H1_product_weights;
+    auto H1_adj = this->H1_adj;
+
+    Kokkos::parallel_for("MACEKokkos::reverse_H1_product",
+        Kokkos::TeamPolicy<>(num_nodes*(L_max+1), Kokkos::AUTO, Kokkos::AUTO),
+        KOKKOS_LAMBDA (Kokkos::TeamPolicy<>::member_type team_member) {
+            const int i = team_member.league_rank() / (L_max+1);
+            const int l = team_member.league_rank() % (L_max+1);
+            auto H1_adj_il = Kokkos::subview(H1_adj, i, Kokkos::make_pair(l*l, l*(l+2)+1), Kokkos::ALL);
+            auto W_il = Kokkos::subview(H1_product_weights, l, Kokkos::ALL, Kokkos::ALL);
+            auto M0_adj_il = Kokkos::subview(M0_adj, i, Kokkos::make_pair(l*l, l*(l+2)+1), Kokkos::ALL);
+            KokkosBatched::TeamGemm<Kokkos::TeamPolicy<>::member_type,
+                                    KokkosBatched::Trans::NoTranspose,
+                                    KokkosBatched::Trans::Transpose,
+                                    KokkosBatched::Algo::Gemm::Unblocked>
+                ::invoke(team_member, 1.0, H1_adj_il, W_il, 0.0, M0_adj_il);
+        });
+    Kokkos::fence();
+}
+
+template <typename Precision>
+void MACEKokkos<Precision>::compute_field_H1(
+    const int num_nodes,
+    Kokkos::View<const double*> electric_field)
+{
+    if (!has_field_coupling)
+        return;
+
+    if (L_max != 1 || num_LM != 4)
+        throw std::runtime_error("MACEField H1 coupling currently requires L_max == 1.");
+    if (electric_field.size() != 3 && electric_field.size() != 3*num_nodes)
+        throw std::runtime_error("MACEField electric_field must have shape (3,) or (num_nodes, 3).");
+    if (H1.extent(0) < num_nodes || H1.extent(1) != num_LM || H1.extent(2) != num_channels)
+        throw std::runtime_error("MACEField H1 buffer size does not match num_nodes.");
+
+    const int channel_pairs = num_channels*num_channels;
+    if (field_feats_weight.size() != 2*channel_pairs || field_linear_weight.size() != 2*channel_pairs)
+        throw std::runtime_error("MACEField field coupling weights do not match num_channels.");
+
+    if (H1_pre_field.extent(0) < H1.extent(0))
+        Kokkos::realloc(H1_pre_field, H1.extent(0), H1.extent(1), H1.extent(2));
+    Kokkos::deep_copy(H1_pre_field, H1);
+
+    if (field_delta_scalar.extent(0) < num_nodes) {
+        Kokkos::realloc(field_delta_scalar, num_nodes, num_channels);
+        Kokkos::realloc(field_delta_vector, num_nodes, num_channels, 3);
+        Kokkos::realloc(field_linear_scalar, num_nodes, num_channels);
+        Kokkos::realloc(field_linear_vector, num_nodes, num_channels, 3);
+    }
+    auto delta_scalar = this->field_delta_scalar;
+    auto delta_vector = this->field_delta_vector;
+    auto linear_scalar = this->field_linear_scalar;
+    auto linear_vector = this->field_linear_vector;
+    Kokkos::deep_copy(delta_scalar, 0.0);
+    Kokkos::deep_copy(delta_vector, 0.0);
+    Kokkos::deep_copy(linear_scalar, 0.0);
+    Kokkos::deep_copy(linear_vector, 0.0);
+
+    const double inv_sqrt_3 = 1.0/std::sqrt(3.0);
+    const bool global_field = electric_field.size() == 3;
+    const auto num_channels = this->num_channels;
+    const auto H1_pre_field = this->H1_pre_field;
+    const auto H1 = this->H1;
+    const auto field_feats_weight = this->field_feats_weight;
+    const auto field_linear_weight = this->field_linear_weight;
+    const auto field_feats_scalar_to_vector_path_weight = this->field_feats_scalar_to_vector_path_weight;
+    const auto field_feats_vector_to_scalar_path_weight = this->field_feats_vector_to_scalar_path_weight;
+    const auto field_linear_scalar_path_weight = this->field_linear_scalar_path_weight;
+    const auto field_linear_vector_path_weight = this->field_linear_vector_path_weight;
+
+    Kokkos::parallel_for("MACEKokkos::compute_field_H1", num_nodes, KOKKOS_LAMBDA (const int i) {
+        const int field_offset = global_field ? 0 : 3*i;
+        for (int u=0; u<num_channels; ++u) {
+            const Precision scalar_in = H1_pre_field(i,0,u);
+            double vector_dot_field = 0.0;
+            for (int component=0; component<3; ++component)
+                vector_dot_field += -H1_pre_field(i,1+component,u)*electric_field(field_offset+component);
+
+            for (int w=0; w<num_channels; ++w) {
+                const int weight_index = u*num_channels + w;
+                const Precision scalar_to_vector_weight =
+                    field_feats_scalar_to_vector_path_weight
+                    * field_feats_weight(weight_index)
+                    * inv_sqrt_3;
+                const Precision vector_to_scalar_weight =
+                    field_feats_vector_to_scalar_path_weight
+                    * field_feats_weight(channel_pairs + weight_index)
+                    * inv_sqrt_3;
+
+                for (int component=0; component<3; ++component)
+                    delta_vector(i,w,component) +=
+                        scalar_to_vector_weight*scalar_in*electric_field(field_offset+component);
+
+                delta_scalar(i,w) += vector_to_scalar_weight*vector_dot_field;
+            }
+        }
+
+        for (int u=0; u<num_channels; ++u) {
+            const Precision scalar_in = delta_scalar(i,u);
+            for (int w=0; w<num_channels; ++w) {
+                const int weight_index = u*num_channels + w;
+                linear_scalar(i,w) +=
+                    field_linear_scalar_path_weight
+                    * field_linear_weight(weight_index)
+                    * scalar_in;
+                for (int component=0; component<3; ++component)
+                    linear_vector(i,w,component) +=
+                        field_linear_vector_path_weight
+                        * field_linear_weight(channel_pairs + weight_index)
+                        * delta_vector(i,u,component);
+            }
+        }
+
+        for (int k=0; k<num_channels; ++k) {
+            H1(i,0,k) = H1_pre_field(i,0,k) - linear_scalar(i,k);
+            for (int component=0; component<3; ++component)
+                H1(i,1+component,k) =
+                    H1_pre_field(i,1+component,k) + linear_vector(i,k,component);
+        }
+    });
+    Kokkos::fence();
+}
+
+template <typename Precision>
+void MACEKokkos<Precision>::reverse_field_H1(
+    const int num_nodes,
+    Kokkos::View<const double*> electric_field)
+{
+    if (!has_field_coupling)
+        return;
+
+    if (electric_field.size() != 3 && electric_field.size() != 3*num_nodes)
+        throw std::runtime_error("MACEField electric_field must have shape (3,) or (num_nodes, 3).");
+    if (H1_adj.extent(0) < num_nodes || H1_pre_field.extent(0) < num_nodes)
+        throw std::runtime_error("MACEField reverse_field_H1 requires H1_adj and saved pre-field H1 buffers.");
+
+    const auto num_channels = this->num_channels;
+    const auto H1_adj = this->H1_adj;
+    const auto H1_pre_field = this->H1_pre_field;
+    const auto field_feats_weight = this->field_feats_weight;
+    const auto field_linear_weight = this->field_linear_weight;
+    const auto field_feats_scalar_to_vector_path_weight = this->field_feats_scalar_to_vector_path_weight;
+    const auto field_feats_vector_to_scalar_path_weight = this->field_feats_vector_to_scalar_path_weight;
+    const auto field_linear_scalar_path_weight = this->field_linear_scalar_path_weight;
+    const auto field_linear_vector_path_weight = this->field_linear_vector_path_weight;
+
+    const int channel_pairs = num_channels*num_channels;
+    const bool global_field = electric_field.size() == 3;
+    const int h1_lm = H1_adj.extent(1);
+    const int h1_channels = H1_adj.extent(2);
+
+    if (this->electric_field_adj.size() != electric_field.size())
+        Kokkos::realloc(this->electric_field_adj, electric_field.size());
+    auto electric_field_adj = this->electric_field_adj;
+
+    if (field_delta_scalar_adj.extent(0) < num_nodes
+        || field_delta_scalar_adj.extent(1) < num_channels)
+        Kokkos::realloc(field_delta_scalar_adj, num_nodes, num_channels);
+    if (field_delta_vector_adj.extent(0) < num_nodes
+        || field_delta_vector_adj.extent(1) < num_channels)
+        Kokkos::realloc(field_delta_vector_adj, num_nodes, num_channels, 3);
+    if (field_H1_pre_adj.extent(0) < num_nodes
+        || field_H1_pre_adj.extent(1) < h1_lm
+        || field_H1_pre_adj.extent(2) < h1_channels)
+        Kokkos::realloc(field_H1_pre_adj, num_nodes, h1_lm, h1_channels);
+
+    auto delta_scalar_adj = this->field_delta_scalar_adj;
+    auto delta_vector_adj = this->field_delta_vector_adj;
+    auto H1_pre_adj = this->field_H1_pre_adj;
+    Kokkos::deep_copy(delta_scalar_adj, 0.0);
+    Kokkos::deep_copy(delta_vector_adj, 0.0);
+    Kokkos::parallel_for(
+        "MACEKokkos::reverse_field_H1_copy_in",
+        Kokkos::MDRangePolicy<Kokkos::Rank<3,Kokkos::Iterate::Right>>(
+            {0,0,0}, {num_nodes,h1_lm,h1_channels}),
+        KOKKOS_LAMBDA (const int i, const int lm, const int channel) {
+            H1_pre_adj(i,lm,channel) = H1_adj(i,lm,channel);
+        });
+
+    const double inv_sqrt_3 = 1.0/std::sqrt(3.0);
+
+    if (global_field) {
+        Kokkos::parallel_reduce(
+            "MACEKokkos::reverse_field_H1_global",
+            num_nodes,
+            ReverseFieldH1GlobalReducer<Precision>{
+                num_channels,
+                channel_pairs,
+                inv_sqrt_3,
+                field_feats_scalar_to_vector_path_weight,
+                field_feats_vector_to_scalar_path_weight,
+                field_linear_scalar_path_weight,
+                field_linear_vector_path_weight,
+                delta_scalar_adj,
+                delta_vector_adj,
+                H1_pre_adj,
+                H1_adj,
+                H1_pre_field,
+                field_feats_weight,
+                field_linear_weight,
+                electric_field,
+                electric_field_adj});
+    } else {
+        Kokkos::deep_copy(electric_field_adj, 0.0);
+        Kokkos::parallel_for("MACEKokkos::reverse_field_H1", num_nodes, KOKKOS_LAMBDA (const int i) {
+            const int field_offset = 3*i;
+            for (int u=0; u<num_channels; ++u) {
+                for (int w=0; w<num_channels; ++w) {
+                    const int weight_index = u*num_channels + w;
+                    delta_scalar_adj(i,u) +=
+                        -field_linear_scalar_path_weight
+                        * field_linear_weight(weight_index)
+                        * H1_adj(i,0,w);
+                    for (int component=0; component<3; ++component)
+                        delta_vector_adj(i,u,component) +=
+                            field_linear_vector_path_weight
+                            * field_linear_weight(channel_pairs + weight_index)
+                            * H1_adj(i,1+component,w);
+                }
+            }
+
+            for (int u=0; u<num_channels; ++u) {
+                const Precision scalar_in = H1_pre_field(i,0,u);
+                for (int w=0; w<num_channels; ++w) {
+                    const int weight_index = u*num_channels + w;
+                    const Precision scalar_to_vector_weight =
+                        field_feats_scalar_to_vector_path_weight
+                        * field_feats_weight(weight_index)
+                        * inv_sqrt_3;
+                    const Precision vector_to_scalar_weight =
+                        field_feats_vector_to_scalar_path_weight
+                        * field_feats_weight(channel_pairs + weight_index)
+                        * inv_sqrt_3;
+                    const Precision scalar_delta_adj = delta_scalar_adj(i,w);
+
+                    for (int component=0; component<3; ++component) {
+                        const Precision vector_delta_adj = delta_vector_adj(i,w,component);
+                        H1_pre_adj(i,0,u) +=
+                            vector_delta_adj*scalar_to_vector_weight*electric_field(field_offset+component);
+                        electric_field_adj(field_offset+component) +=
+                            static_cast<double>(vector_delta_adj*scalar_to_vector_weight*scalar_in);
+
+                        H1_pre_adj(i,1+component,u) +=
+                            -scalar_delta_adj*vector_to_scalar_weight*electric_field(field_offset+component);
+                        electric_field_adj(field_offset+component) +=
+                            static_cast<double>(
+                                -scalar_delta_adj*vector_to_scalar_weight
+                                * H1_pre_field(i,1+component,u));
+                    }
+                }
+            }
+        });
+    }
+    Kokkos::parallel_for(
+        "MACEKokkos::reverse_field_H1_copy_out",
+        Kokkos::MDRangePolicy<Kokkos::Rank<3,Kokkos::Iterate::Right>>(
+            {0,0,0}, {num_nodes,h1_lm,h1_channels}),
+        KOKKOS_LAMBDA (const int i, const int lm, const int channel) {
+            H1_adj(i,lm,channel) = H1_pre_adj(i,lm,channel);
         });
     Kokkos::fence();
 }
@@ -938,7 +1699,7 @@ void MACEKokkos<Precision>::reverse_Phi1(
 {
     if (dPhi1r.extent(0) < Phi1r.extent(0))
         Kokkos::realloc(dPhi1r, Phi1r.extent(0), Phi1r.extent(1), Phi1r.extent(2));
-    if (node_forces.size() < xyz.size())
+    if (node_forces.size() != xyz.size())
         Kokkos::resize(node_forces, xyz.size());
     if (H1_adj.extent(0) < H1.extent(0))
         Kokkos::resize(H1_adj, H1.extent(0), H1.extent(1), H1.extent(2));
@@ -1129,7 +1890,9 @@ void MACEKokkos<Precision>::compute_A1_scaled(
         Kokkos::realloc(A1_spline_values, r.size(), 1);
         Kokkos::realloc(A1_spline_derivs, r.size(), 1);
     }
-    A1_splines.evaluate(num_nodes, node_types, num_neigh, neigh_types, r, A1_spline_values, A1_spline_derivs);
+    A1_splines.evaluate(
+        num_nodes, node_types, num_neigh, neigh_types,
+        type_to_active, num_active_types, r, A1_spline_values, A1_spline_derivs);
 
     // compute first_neigh
     Kokkos::View<int*> first_neigh("first_neigh", num_nodes);
@@ -1563,8 +2326,11 @@ void MACEKokkos<Precision>::load_from_json(std::string filename)
     num_lm = (l_max+1)*(l_max+1);
     L_max = file["L_max"];
     num_LM = (L_max+1)*(L_max+1);
-    atomic_numbers = toKokkosView("atomic_numbers", file["atomic_numbers"].get<std::vector<int>>());
+    atomic_numbers_host = file["atomic_numbers"].get<std::vector<int>>();
+    atomic_numbers = toKokkosView("atomic_numbers", atomic_numbers_host);
     atomic_energies = toKokkosView("atomic_energies", file["atomic_energies"].get<std::vector<double>>());
+    H0_weights_host = file["H0_weights"].get<std::vector<double>>();
+    A0_weights_host = file["A0_weights"].get<std::vector<std::vector<std::vector<double>>>>();
 
     // ZBL
     has_zbl = file["has_zbl"].get<bool>();
@@ -1576,86 +2342,98 @@ void MACEKokkos<Precision>::load_from_json(std::string filename)
             file["zbl_covalent_radii"].get<std::vector<double>>(),
             file["zbl_p"].get<int>());
 
-    // R0
-    const double spl_h = file["radial_spline_h"];
-    auto spl_values_0 = file["radial_spline_values_0"].get<std::vector<std::vector<std::vector<double>>>>();
-    auto spl_derivs_0 = file["radial_spline_derivs_0"].get<std::vector<std::vector<std::vector<double>>>>();
-    auto c = Kokkos::View<Precision****,Kokkos::LayoutRight>(
-        "c", atomic_numbers.size()*atomic_numbers.size(), spl_values_0[0][0].size()-1, 4, (l_max+1)*num_channels);
-    auto h_c = Kokkos::create_mirror_view(c);
-    for (int a=0; a<atomic_numbers.size(); ++a) {
-        for (int b=0; b<atomic_numbers.size(); ++b) {
-            const int ab = a*atomic_numbers.size()+b;
-            const int ab_unordered = (a <= b)
-                ? a*(2*atomic_numbers.size()-a-1)/2 + b
-                : b*(2*atomic_numbers.size()-b-1)/2 + a;
-            auto spl_values = spl_values_0[ab_unordered];
-            auto spl_derivs = spl_derivs_0[ab_unordered];
-            for (int i=0; i<spl_values_0[0][0].size()-1; ++i) {
-                for (int lk=0; lk<(l_max+1)*num_channels; ++lk) {
-                    h_c(ab,i,0,lk) = spl_values[lk][i];
-                    h_c(ab,i,1,lk) = spl_derivs[lk][i];
-                    h_c(ab,i,2,lk) = (-3*spl_values[lk][i] -2*spl_h*spl_derivs[lk][i]
-                                        + 3*spl_values[lk][i+1] - spl_h*spl_derivs[lk][i+1]) / (spl_h*spl_h);
-                    h_c(ab,i,3,lk) = (2*spl_values[lk][i] + spl_h*spl_derivs[lk][i]
-                                        - 2*spl_values[lk][i+1] + spl_h*spl_derivs[lk][i+1]) / (spl_h*spl_h*spl_h);
-                }
-            }
-            // add H0_weights
-            auto H0_weights = file["H0_weights"].get<std::vector<double>>();
-            for (int i=0; i<spl_values_0[0][0].size()-1; ++i) {
-                for (int lk=0; lk<(l_max+1)*num_channels; ++lk) {
-                    const int k = lk % num_channels;
-                    h_c(ab,i,0,lk) *= H0_weights[b*num_channels+k];
-                    h_c(ab,i,1,lk) *= H0_weights[b*num_channels+k];
-                    h_c(ab,i,2,lk) *= H0_weights[b*num_channels+k];
-                    h_c(ab,i,3,lk) *= H0_weights[b*num_channels+k];
-                }
-            }
-            // add A0_weights
-            auto A0_weights = file["A0_weights"].get<std::vector<std::vector<std::vector<double>>>>();
-            for (int i=0; i<spl_values_0[0][0].size()-1; ++i) {
-                for (int l=0; l<=l_max; ++l) {
-                    auto c0 = std::vector<double>(&h_c(ab,i,0,l*num_channels), &h_c(ab,i,0,l*num_channels)+num_channels);
-                    auto c1 = std::vector<double>(&h_c(ab,i,1,l*num_channels), &h_c(ab,i,1,l*num_channels)+num_channels);
-                    auto c2 = std::vector<double>(&h_c(ab,i,2,l*num_channels), &h_c(ab,i,2,l*num_channels)+num_channels);
-                    auto c3 = std::vector<double>(&h_c(ab,i,3,l*num_channels), &h_c(ab,i,3,l*num_channels)+num_channels);
-                    for (int k=0; k<num_channels; ++k) {
-                        h_c(ab,i,0,l*num_channels+k) = 0.0;
-                        h_c(ab,i,1,l*num_channels+k) = 0.0;
-                        h_c(ab,i,2,l*num_channels+k) = 0.0;
-                        h_c(ab,i,3,l*num_channels+k) = 0.0;
-                        for (int kp=0; kp<num_channels; ++kp) {
-                            h_c(ab,i,0,l*num_channels+k) += A0_weights[a][l][kp*num_channels+k]*c0[kp];
-                            h_c(ab,i,1,l*num_channels+k) += A0_weights[a][l][kp*num_channels+k]*c1[kp];
-                            h_c(ab,i,2,l*num_channels+k) += A0_weights[a][l][kp*num_channels+k]*c2[kp];
-                            h_c(ab,i,3,l*num_channels+k) += A0_weights[a][l][kp*num_channels+k]*c3[kp];
+    A0_scaled = file["A0_scaled"].get<bool>();
+    const int format_version = file.value("symmetrix_format_version", 1);
+    uses_compact_radial = format_version == 2;
+    if (uses_compact_radial) {
+        if (file.value("radial_representation", std::string()) != "compact")
+            throw std::invalid_argument("Symmetrix format version 2 requires compact radial data.");
+        compact_radial_model = std::make_unique<CompactRadialModel>(
+            file.at("compact_radial").dump(), atomic_numbers_host, r_cut);
+        if (A0_scaled != compact_radial_model->has_A0())
+            throw std::invalid_argument("Compact radial A0 network does not match A0_scaled.");
+        R0_spline_h = compact_radial_model->spline_h();
+        R0_spline_min = compact_radial_model->spline_min();
+        type_to_active = Kokkos::View<int*>("compact type_to_active", atomic_numbers.size());
+        Kokkos::deep_copy(type_to_active, -1);
+    } else if (format_version == 1) {
+        const double spl_h = file["radial_spline_h"];
+        const double spl_min = file.value("radial_spline_min", 0.0);
+        auto spl_values_0 = file["radial_spline_values_0"].get<std::vector<std::vector<std::vector<double>>>>();
+        auto spl_derivs_0 = file["radial_spline_derivs_0"].get<std::vector<std::vector<std::vector<double>>>>();
+        auto c = Kokkos::View<Precision****,Kokkos::LayoutRight>(
+            "c", atomic_numbers.size()*atomic_numbers.size(), spl_values_0[0][0].size()-1, 4, (l_max+1)*num_channels);
+        auto h_c = Kokkos::create_mirror_view(c);
+        for (int a=0; a<atomic_numbers.size(); ++a) {
+            for (int b=0; b<atomic_numbers.size(); ++b) {
+                const int ab = a*atomic_numbers.size()+b;
+                const int ab_unordered = (a <= b)
+                    ? a*(2*atomic_numbers.size()-a-1)/2+b
+                    : b*(2*atomic_numbers.size()-b-1)/2+a;
+                const auto& spl_values = spl_values_0[ab_unordered];
+                const auto& spl_derivs = spl_derivs_0[ab_unordered];
+                for (int i=0; i<spl_values_0[0][0].size()-1; ++i) {
+                    for (int lk=0; lk<(l_max+1)*num_channels; ++lk) {
+                        h_c(ab,i,0,lk) = spl_values[lk][i];
+                        h_c(ab,i,1,lk) = spl_derivs[lk][i];
+                        h_c(ab,i,2,lk) = (-3*spl_values[lk][i]-2*spl_h*spl_derivs[lk][i]
+                            +3*spl_values[lk][i+1]-spl_h*spl_derivs[lk][i+1])/(spl_h*spl_h);
+                        h_c(ab,i,3,lk) = (2*spl_values[lk][i]+spl_h*spl_derivs[lk][i]
+                            -2*spl_values[lk][i+1]+spl_h*spl_derivs[lk][i+1])/(spl_h*spl_h*spl_h);
+                    }
+                    for (int lk=0; lk<(l_max+1)*num_channels; ++lk) {
+                        const int k = lk%num_channels;
+                        for (int coefficient=0; coefficient<4; ++coefficient)
+                            h_c(ab,i,coefficient,lk) *= H0_weights_host[b*num_channels+k];
+                    }
+                    for (int l=0; l<=l_max; ++l) {
+                        auto original = std::vector<double>(4*num_channels);
+                        for (int coefficient=0; coefficient<4; ++coefficient)
+                            for (int k=0; k<num_channels; ++k)
+                                original[coefficient*num_channels+k] = h_c(ab,i,coefficient,l*num_channels+k);
+                        for (int coefficient=0; coefficient<4; ++coefficient) {
+                            for (int k=0; k<num_channels; ++k) {
+                                h_c(ab,i,coefficient,l*num_channels+k) = 0.0;
+                                for (int kp=0; kp<num_channels; ++kp)
+                                    h_c(ab,i,coefficient,l*num_channels+k) +=
+                                        A0_weights_host[a][l][kp*num_channels+k]
+                                        * original[coefficient*num_channels+kp];
+                            }
                         }
                     }
                 }
             }
         }
-    }
-    Kokkos::deep_copy(c, h_c);
-    R0_spline_h = spl_h;
-    R0_spline_coefficients = c;
+        Kokkos::deep_copy(c, h_c);
+        R0_spline_h = spl_h;
+        R0_spline_min = spl_min;
+        R0_spline_coefficients = c;
 
-    // R1
-    auto spl_values_1 = file["radial_spline_values_1"].get<std::vector<std::vector<std::vector<double>>>>();
-    auto spl_derivs_1 = file["radial_spline_derivs_1"].get<std::vector<std::vector<std::vector<double>>>>();
-    radial_1 = RadialFunctionSetKokkos<Precision>(spl_h, spl_values_1, spl_derivs_1);
+        auto spl_values_1 = file["radial_spline_values_1"].get<std::vector<std::vector<std::vector<double>>>>();
+        auto spl_derivs_1 = file["radial_spline_derivs_1"].get<std::vector<std::vector<std::vector<double>>>>();
+        radial_1 =
+            RadialFunctionSetKokkos<Precision>(spl_h, spl_values_1, spl_derivs_1, spl_min);
 
-    // A0 scaling
-    A0_scaled = file["A0_scaled"].get<bool>();
-    if (A0_scaled) {
-        const double A0_spline_h = file["A0_spline_h"];
-        auto A0_spline_values = std::vector<std::vector<std::vector<double>>>();
-        for (auto& values : file["A0_spline_values"].get<std::vector<std::vector<double>>>())
-            A0_spline_values.push_back({values});  // adds dimension to reach 3d
-        auto A0_spline_derivs = std::vector<std::vector<std::vector<double>>>();
-        for (auto& derivs : file["A0_spline_derivs"].get<std::vector<std::vector<double>>>())
-            A0_spline_derivs.push_back({derivs});  // adds dimension to reach 3d
-        A0_splines = RadialFunctionSetKokkos<double>(A0_spline_h, A0_spline_values, A0_spline_derivs);
+        if (A0_scaled) {
+            const double A0_spline_h = file["A0_spline_h"];
+            auto A0_spline_values = std::vector<std::vector<std::vector<double>>>();
+            for (auto& values : file["A0_spline_values"].get<std::vector<std::vector<double>>>())
+                A0_spline_values.push_back({values});
+            auto A0_spline_derivs = std::vector<std::vector<std::vector<double>>>();
+            for (auto& derivs : file["A0_spline_derivs"].get<std::vector<std::vector<double>>>())
+                A0_spline_derivs.push_back({derivs});
+            const double A0_spline_min = file.value("A0_spline_min", 0.0);
+            A0_splines = RadialFunctionSetKokkos<double>(
+                A0_spline_h, A0_spline_values, A0_spline_derivs, A0_spline_min);
+        }
+
+        active_types.resize(atomic_numbers.size());
+        std::iota(active_types.begin(), active_types.end(), 0);
+        active_atomic_numbers = atomic_numbers_host;
+        num_active_types = active_types.size();
+        type_to_active = toKokkosView("type_to_active", active_types);
+    } else {
+        throw std::invalid_argument("Unsupported Symmetrix model format version.");
     }
 
     // M0 weights and monomials
@@ -1744,6 +2522,178 @@ void MACEKokkos<Precision>::load_from_json(std::string filename)
         num_channels,
         num_channels);
 
+    // MACEField H1 coupling
+    has_field_coupling = file.value("has_field_coupling", false);
+    field_feats_scalar_to_vector_path_weight = 0.0;
+    field_feats_vector_to_scalar_path_weight = 0.0;
+    field_linear_scalar_path_weight = 0.0;
+    field_linear_vector_path_weight = 0.0;
+    if (has_field_coupling) {
+        auto field_couplings = file["field_couplings"];
+        if (field_couplings.size() != 1)
+            throw std::runtime_error("MACEField JSON must contain exactly one field coupling.");
+        auto coupling = field_couplings[0];
+        const auto hidden_irreps = std::to_string(num_channels)
+            + "x0e+" + std::to_string(num_channels) + "x1o";
+        if (coupling["field_feats_irreps_in1"].get<std::string>() != hidden_irreps
+            || coupling["field_feats_irreps_in2"].get<std::string>() != "1x1o"
+            || coupling["field_feats_irreps_out"].get<std::string>() != hidden_irreps
+            || coupling["field_linear_irreps_in"].get<std::string>() != hidden_irreps
+            || coupling["field_linear_irreps_out"].get<std::string>() != hidden_irreps)
+            throw std::runtime_error("Unsupported MACEField field coupling irreps.");
+        if (L_max != 1)
+            throw std::runtime_error("MACEField JSON field coupling currently requires L_max == 1.");
+
+        const auto H1_product_weights_vec =
+            file.value("H1_product_weights", std::vector<Precision>{});
+        const auto H1_linear_up_weights_vec =
+            file.value("H1_linear_up_weights", std::vector<Precision>{});
+        if (H1_product_weights_vec.size() != H1_weights.size()
+            || H1_linear_up_weights_vec.size() != H1_weights.size())
+            throw std::runtime_error("MACEField JSON must contain split H1 product and linear_up weights.");
+        set_kokkos_view(
+            H1_product_weights,
+            H1_product_weights_vec,
+            L_max+1,
+            num_channels,
+            num_channels);
+        set_kokkos_view(
+            H1_linear_up_weights,
+            H1_linear_up_weights_vec,
+            L_max+1,
+            num_channels,
+            num_channels);
+
+        const auto field_feats_weight_vec =
+            coupling["field_feats_weight"].get<std::vector<Precision>>();
+        const auto field_feats_output_mask_vec =
+            coupling["field_feats_output_mask"].get<std::vector<Precision>>();
+        const auto field_linear_weight_vec =
+            coupling["field_linear_weight"].get<std::vector<Precision>>();
+        const auto field_linear_bias_vec =
+            coupling["field_linear_bias"].get<std::vector<Precision>>();
+        const auto field_linear_output_mask_vec =
+            coupling["field_linear_output_mask"].get<std::vector<Precision>>();
+
+        const int channel_pairs = num_channels*num_channels;
+        if (field_feats_weight_vec.size() != 2*channel_pairs
+            || field_linear_weight_vec.size() != 2*channel_pairs
+            || field_feats_output_mask_vec.size() != 4*num_channels
+            || field_linear_output_mask_vec.size() != 4*num_channels
+            || !field_linear_bias_vec.empty())
+            throw std::runtime_error("MACEField JSON field coupling tensor sizes are unsupported.");
+        for (Precision mask_value : field_feats_output_mask_vec)
+            if (mask_value != static_cast<Precision>(1.0))
+                throw std::runtime_error("Unsupported MACEField field_feats output mask.");
+        for (Precision mask_value : field_linear_output_mask_vec)
+            if (mask_value != static_cast<Precision>(1.0))
+                throw std::runtime_error("Unsupported MACEField field_linear output mask.");
+
+        field_feats_weight = toKokkosView("field_feats_weight", field_feats_weight_vec);
+        field_feats_output_mask = toKokkosView("field_feats_output_mask", field_feats_output_mask_vec);
+        field_linear_weight = toKokkosView("field_linear_weight", field_linear_weight_vec);
+        field_linear_bias = toKokkosView("field_linear_bias", field_linear_bias_vec);
+        field_linear_output_mask = toKokkosView("field_linear_output_mask", field_linear_output_mask_vec);
+
+        auto field_feats_instructions = coupling["field_feats_instructions"];
+        if (field_feats_instructions.size() != 2)
+            throw std::runtime_error("MACEField field_feats must contain exactly two instructions.");
+        for (const auto& instruction : field_feats_instructions) {
+            if (instruction["connection_mode"].get<std::string>() != "uvw")
+                throw std::runtime_error("MACEField field_feats only supports uvw instructions.");
+            auto path_shape = instruction["path_shape"].get<std::vector<int>>();
+            if (path_shape != std::vector<int>{num_channels, 1, num_channels})
+                throw std::runtime_error("Unsupported MACEField field_feats path shape.");
+            const int i_in1 = instruction["i_in1"].get<int>();
+            const int i_in2 = instruction["i_in2"].get<int>();
+            const int i_out = instruction["i_out"].get<int>();
+            if (i_in1 == 0 && i_in2 == 0 && i_out == 1)
+                field_feats_scalar_to_vector_path_weight = instruction["path_weight"].get<double>();
+            else if (i_in1 == 1 && i_in2 == 0 && i_out == 0)
+                field_feats_vector_to_scalar_path_weight = instruction["path_weight"].get<double>();
+            else
+                throw std::runtime_error("Unsupported MACEField field_feats instruction.");
+        }
+
+        auto field_linear_instructions = coupling["field_linear_instructions"];
+        if (field_linear_instructions.size() != 2)
+            throw std::runtime_error("MACEField field_linear must contain exactly two instructions.");
+        for (const auto& instruction : field_linear_instructions) {
+            auto path_shape = instruction["path_shape"].get<std::vector<int>>();
+            if (path_shape != std::vector<int>{num_channels, num_channels})
+                throw std::runtime_error("Unsupported MACEField field_linear path shape.");
+            const int i_in = instruction["i_in"].get<int>();
+            const int i_out = instruction["i_out"].get<int>();
+            if (i_in == 0 && i_out == 0)
+                field_linear_scalar_path_weight = instruction["path_weight"].get<double>();
+            else if (i_in == 1 && i_out == 1)
+                field_linear_vector_path_weight = instruction["path_weight"].get<double>();
+            else
+                throw std::runtime_error("Unsupported MACEField field_linear instruction.");
+        }
+
+        field_scalar_to_vector_up_matrix =
+            Kokkos::View<Precision**,Kokkos::LayoutRight>(
+                "field_scalar_to_vector_up_matrix", num_channels, num_channels);
+        field_vector_to_scalar_up_matrix =
+            Kokkos::View<Precision**,Kokkos::LayoutRight>(
+                "field_vector_to_scalar_up_matrix", num_channels, num_channels);
+        auto h_scalar_to_vector_up =
+            Kokkos::create_mirror_view(field_scalar_to_vector_up_matrix);
+        auto h_vector_to_scalar_up =
+            Kokkos::create_mirror_view(field_vector_to_scalar_up_matrix);
+        const Precision inv_sqrt_3 = static_cast<Precision>(
+            1.0/std::sqrt(3.0));
+        auto scalar_to_vector = std::vector<Precision>(channel_pairs, 0.0);
+        auto vector_to_scalar = std::vector<Precision>(channel_pairs, 0.0);
+        for (int input=0; input<num_channels; ++input) {
+            for (int intermediate=0; intermediate<num_channels; ++intermediate) {
+                for (int field_hidden=0; field_hidden<num_channels; ++field_hidden) {
+                    scalar_to_vector[input*num_channels+intermediate] +=
+                        static_cast<Precision>(
+                            field_feats_scalar_to_vector_path_weight
+                            *field_linear_vector_path_weight)
+                        *field_feats_weight_vec[
+                            input*num_channels+field_hidden]
+                        *field_linear_weight_vec[
+                            channel_pairs+field_hidden*num_channels+intermediate]
+                        *inv_sqrt_3;
+                    vector_to_scalar[input*num_channels+intermediate] +=
+                        static_cast<Precision>(
+                            field_feats_vector_to_scalar_path_weight
+                            *field_linear_scalar_path_weight)
+                        *field_feats_weight_vec[
+                            channel_pairs+input*num_channels+field_hidden]
+                        *field_linear_weight_vec[
+                            field_hidden*num_channels+intermediate]
+                        *inv_sqrt_3;
+                }
+            }
+        }
+        for (int input=0; input<num_channels; ++input) {
+            for (int output=0; output<num_channels; ++output) {
+                Precision scalar_to_vector_up = 0.0;
+                Precision vector_to_scalar_up = 0.0;
+                for (int intermediate=0; intermediate<num_channels; ++intermediate) {
+                    scalar_to_vector_up +=
+                        scalar_to_vector[input*num_channels+intermediate]
+                        *H1_linear_up_weights_vec[
+                            (num_channels+intermediate)*num_channels+output];
+                    vector_to_scalar_up +=
+                        vector_to_scalar[input*num_channels+intermediate]
+                        *H1_linear_up_weights_vec[
+                            intermediate*num_channels+output];
+                }
+                h_scalar_to_vector_up(input,output) = scalar_to_vector_up;
+                h_vector_to_scalar_up(input,output) = vector_to_scalar_up;
+            }
+        }
+        Kokkos::deep_copy(
+            field_scalar_to_vector_up_matrix, h_scalar_to_vector_up);
+        Kokkos::deep_copy(
+            field_vector_to_scalar_up_matrix, h_vector_to_scalar_up);
+    }
+
     // Phi1
     Phi1_l = toKokkosView("Phi1_l", file["Phi1_l"].get<std::vector<int>>());
     Phi1_l1 = toKokkosView("Phi1_l1", file["Phi1_l1"].get<std::vector<int>>());
@@ -1811,7 +2761,7 @@ void MACEKokkos<Precision>::load_from_json(std::string filename)
 
     // A1 scaling
     A1_scaled = file["A1_scaled"].get<bool>();
-    if (A1_scaled) {
+    if (A1_scaled && !uses_compact_radial) {
         const double A1_spline_h = file["A1_spline_h"];
         auto A1_spline_values = std::vector<std::vector<std::vector<double>>>();
         for (auto& values : file["A1_spline_values"].get<std::vector<std::vector<double>>>())
@@ -1819,8 +2769,12 @@ void MACEKokkos<Precision>::load_from_json(std::string filename)
         auto A1_spline_derivs = std::vector<std::vector<std::vector<double>>>();
         for (auto& derivs : file["A1_spline_derivs"].get<std::vector<std::vector<double>>>())
             A1_spline_derivs.push_back({derivs});  // adds dimension to reach 3d
-        A1_splines = RadialFunctionSetKokkos<double>(A1_spline_h, A1_spline_values, A1_spline_derivs);
+        const double A1_spline_min = file.value("A1_spline_min", 0.0);
+        A1_splines = RadialFunctionSetKokkos<double>(
+            A1_spline_h, A1_spline_values, A1_spline_derivs, A1_spline_min);
     }
+    if (uses_compact_radial && A1_scaled != compact_radial_model->has_A1())
+        throw std::invalid_argument("Compact radial A1 network does not match A1_scaled.");
 
     // M1 weights and monomials
     auto M1_weights = file["M1_weights"].get<std::map<std::string,std::map<std::string,std::vector<double>>>>();

--- a/libsymmetrix/source/mace_kokkos.hpp
+++ b/libsymmetrix/source/mace_kokkos.hpp
@@ -2,9 +2,11 @@
 #include <string>
 #include <vector>
 #include <span>
+#include <array>
 
 #include "Kokkos_UnorderedMap.hpp"
 
+#include "compact_radial.hpp"
 #include "cubic_spline_kokkos.hpp"
 #include "cubic_spline_set_kokkos.hpp"
 #include "multilayer_perceptron_kokkos.hpp"
@@ -29,6 +31,9 @@ int l_max, num_lm;
 int L_max, num_LM;
 Kokkos::View<int*> atomic_numbers;
 Kokkos::View<double*> atomic_energies;
+std::vector<int> atomic_numbers_host;
+std::vector<int> active_atomic_numbers;
+void prepare_active_types(std::vector<int> node_types);
 
 // Node energies and forces
 Kokkos::View<double*> node_energies, node_forces;
@@ -39,13 +44,29 @@ void compute_node_energies_forces(const int num_nodes,
                                   Kokkos::View<const int*> neigh_types,
                                   Kokkos::View<const double*> xyz,
                                   Kokkos::View<const double*> r);
+void compute_node_energies_forces_field(const int num_nodes,
+                                        Kokkos::View<const int*> node_types,
+                                        Kokkos::View<const int*> num_neigh,
+                                        Kokkos::View<const int*> neigh_indices,
+                                        Kokkos::View<const int*> neigh_types,
+                                        Kokkos::View<const double*> xyz,
+                                        Kokkos::View<const double*> r,
+                                        Kokkos::View<const double*> electric_field);
 
 // ZBL
 bool has_zbl;
 ZBLKokkos zbl;
 
 // R0
+bool uses_compact_radial = false;
+std::unique_ptr<CompactRadialModel> compact_radial_model;
+std::vector<int> active_types;
+Kokkos::View<int*> type_to_active;
+int num_active_types = 0;
+std::vector<double> H0_weights_host;
+std::vector<std::vector<std::vector<double>>> A0_weights_host;
 double R0_spline_h;
+double R0_spline_min = 0.0;
 Kokkos::View<const Precision****,Kokkos::LayoutRight> R0_spline_coefficients;
 Kokkos::View<Precision**,Kokkos::LayoutRight> R0, R0_deriv;
 void compute_R0(const int num_nodes,
@@ -113,10 +134,57 @@ void compute_M0(const int num_nodes, Kokkos::View<const int*> node_types);
 void reverse_M0(const int num_nodes, Kokkos::View<const int*> node_types);
 
 // H1
-Kokkos::View<Precision***,Kokkos::LayoutRight> H1, H1_adj;
-Kokkos::View<Precision***,Kokkos::LayoutRight> H1_weights;
+Kokkos::View<Precision***,Kokkos::LayoutRight> H1, H1_adj, H1_pre_linear_up;
+Kokkos::View<Precision***,Kokkos::LayoutRight> H1_weights, H1_product_weights, H1_linear_up_weights;
 void compute_H1(const int num_nodes);
 void reverse_H1(const int num_nodes);
+void compute_H1_product(const int num_nodes);
+void compute_H1_linear_up(const int num_nodes);
+void reverse_H1_linear_up(const int num_nodes);
+void reverse_H1_product(const int num_nodes);
+
+// MACEField coupling after H1 product
+bool has_field_coupling;
+Kokkos::View<Precision***,Kokkos::LayoutRight> H1_pre_field;
+Kokkos::View<Precision**,Kokkos::LayoutRight> field_delta_scalar;
+Kokkos::View<Precision***,Kokkos::LayoutRight> field_delta_vector;
+Kokkos::View<Precision**,Kokkos::LayoutRight> field_linear_scalar;
+Kokkos::View<Precision***,Kokkos::LayoutRight> field_linear_vector;
+Kokkos::View<Precision*> field_feats_weight;
+Kokkos::View<Precision*> field_feats_output_mask;
+Kokkos::View<Precision*> field_linear_weight;
+Kokkos::View<Precision*> field_linear_bias;
+Kokkos::View<Precision*> field_linear_output_mask;
+Kokkos::View<Precision**,Kokkos::LayoutRight> field_scalar_to_vector_up_matrix;
+Kokkos::View<Precision**,Kokkos::LayoutRight> field_vector_to_scalar_up_matrix;
+Kokkos::View<double*> electric_field_adj;
+Kokkos::View<double*> electric_field_hessian;
+Kokkos::View<double*> electric_field_force_derivative;
+Kokkos::View<Precision**,Kokkos::LayoutRight> field_delta_scalar_adj;
+Kokkos::View<Precision***,Kokkos::LayoutRight> field_delta_vector_adj;
+Kokkos::View<Precision***,Kokkos::LayoutRight> field_H1_pre_adj;
+double field_feats_scalar_to_vector_path_weight;
+double field_feats_vector_to_scalar_path_weight;
+double field_linear_scalar_path_weight;
+double field_linear_vector_path_weight;
+void compute_field_H1(const int num_nodes, Kokkos::View<const double*> electric_field);
+void reverse_field_H1(const int num_nodes, Kokkos::View<const double*> electric_field);
+void compute_electric_field_hessian(const int num_nodes,
+                                    Kokkos::View<const int*> node_types,
+                                    Kokkos::View<const int*> num_neigh,
+                                    Kokkos::View<const int*> neigh_indices,
+                                    Kokkos::View<const int*> neigh_types,
+                                    Kokkos::View<const double*> xyz,
+                                    Kokkos::View<const double*> r,
+                                    Kokkos::View<const double*> electric_field);
+void compute_electric_field_force_derivative(const int num_nodes,
+                                             Kokkos::View<const int*> node_types,
+                                             Kokkos::View<const int*> num_neigh,
+                                             Kokkos::View<const int*> neigh_indices,
+                                             Kokkos::View<const int*> neigh_types,
+                                             Kokkos::View<const double*> xyz,
+                                             Kokkos::View<const double*> r,
+                                             Kokkos::View<const double*> electric_field);
 
 // Phi1
 int num_lelm1lm2, num_lme;

--- a/libsymmetrix/source/mace_kokkos_response.tpp
+++ b/libsymmetrix/source/mace_kokkos_response.tpp
@@ -1,0 +1,799 @@
+template <typename Precision>
+void MACEKokkos<Precision>::compute_electric_field_hessian(
+    const int num_nodes,
+    Kokkos::View<const int*> node_types,
+    Kokkos::View<const int*> num_neigh,
+    Kokkos::View<const int*> neigh_indices,
+    Kokkos::View<const int*> neigh_types,
+    Kokkos::View<const double*> xyz,
+    Kokkos::View<const double*> r,
+    Kokkos::View<const double*> electric_field)
+{
+    if (!has_field_coupling)
+        throw std::invalid_argument(
+            "MACEKokkos::compute_electric_field_hessian requires field coupling.");
+    if (electric_field.size() != 3)
+        throw std::invalid_argument(
+            "MACEKokkos::compute_electric_field_hessian requires a graph-level electric field.");
+    if (L_max != 1 || num_LM != 4)
+        throw std::invalid_argument(
+            "MACEKokkos analytic field response currently requires L_max == 1.");
+
+    // Keep energy, force, and polarization state at the requested field while
+    // replacing the three perturbed full evaluations with an analytic pass.
+    compute_node_energies_forces_field(
+        num_nodes, node_types, num_neigh, neigh_indices, neigh_types,
+        xyz, r, electric_field);
+
+    if (electric_field_hessian.size() != 9)
+        Kokkos::realloc(electric_field_hessian, 9);
+    if (electric_field_force_derivative.size() != 3*xyz.size())
+        Kokkos::realloc(electric_field_force_derivative, 3*xyz.size());
+    Kokkos::deep_copy(electric_field_hessian, 0.0);
+    Kokkos::deep_copy(electric_field_force_derivative, 0.0);
+
+    Kokkos::View<int*> first_neigh("MACEField response first_neigh", num_nodes);
+    Kokkos::parallel_scan(
+        "MACEField response first_neigh",
+        num_nodes,
+        KOKKOS_LAMBDA (const int i, int& update, const bool final) {
+            if (final)
+                first_neigh(i) = update;
+            update += num_neigh(i);
+        });
+    Kokkos::fence();
+
+    const int channels = num_channels;
+    const int lm_count = num_lm;
+    const int LM_count = num_LM;
+    const int lmax = l_max;
+    const int Lmax = L_max;
+    const int phi_rows = num_lelm1lm2;
+    const int phi_outputs = num_lme;
+    const auto response_hessian = electric_field_hessian;
+    const auto response_forces = electric_field_force_derivative;
+    const int polynomial_nodes = M1_poly_coeff.extent(1);
+
+    Kokkos::View<Precision***,Kokkos::LayoutRight> H1_dot(
+        "MACEField H1_dot", num_nodes, LM_count, channels);
+    Kokkos::View<Precision***,Kokkos::LayoutRight> Phi1r_dot(
+        "MACEField Phi1r_dot", num_nodes, phi_rows, channels);
+    Kokkos::View<Precision***,Kokkos::LayoutRight> Phi1_dot(
+        "MACEField Phi1_dot", num_nodes, phi_outputs, channels);
+    Kokkos::View<Precision***,Kokkos::LayoutRight> A1_dot(
+        "MACEField A1_dot", num_nodes, lm_count, channels);
+    Kokkos::View<Precision**,Kokkos::LayoutRight> M1_dot(
+        "MACEField M1_dot", num_nodes, channels);
+    Kokkos::View<Precision***,Kokkos::LayoutRight> M1_value_dot(
+        "MACEField M1 value_dot", num_nodes, polynomial_nodes, channels);
+    Kokkos::View<Precision***,Kokkos::LayoutRight> M1_gradient(
+        "MACEField M1 gradient", num_nodes, polynomial_nodes, channels);
+    Kokkos::View<Precision***,Kokkos::LayoutRight> M1_gradient_dot(
+        "MACEField M1 gradient_dot", num_nodes, polynomial_nodes, channels);
+    Kokkos::View<double**,Kokkos::LayoutRight> H2_dot(
+        "MACEField H2_dot", num_nodes, channels);
+    Kokkos::View<double*> readout_output(
+        "MACEField directional readout", num_nodes);
+    Kokkos::View<double**,Kokkos::LayoutRight> H2_adj_local(
+        "MACEField H2_adj", num_nodes, channels);
+    Kokkos::View<double**,Kokkos::LayoutRight> H2_adj_dot(
+        "MACEField H2_adj_dot", num_nodes, channels);
+    Kokkos::View<Precision***,Kokkos::LayoutRight> H1_adj_local(
+        "MACEField H1_adj", num_nodes, LM_count, channels);
+    Kokkos::View<Precision***,Kokkos::LayoutRight> H1_adj_dot(
+        "MACEField H1_adj_dot", num_nodes, LM_count, channels);
+    Kokkos::View<Precision**,Kokkos::LayoutRight> M1_adj_local(
+        "MACEField M1_adj", num_nodes, channels);
+    Kokkos::View<Precision**,Kokkos::LayoutRight> M1_adj_dot(
+        "MACEField M1_adj_dot", num_nodes, channels);
+    Kokkos::View<Precision***,Kokkos::LayoutRight> A1_adj_local(
+        "MACEField A1_adj", num_nodes, lm_count, channels);
+    Kokkos::View<Precision***,Kokkos::LayoutRight> A1_adj_dot(
+        "MACEField A1_adj_dot", num_nodes, lm_count, channels);
+    Kokkos::View<Precision***,Kokkos::LayoutRight> dPhi1_local(
+        "MACEField dPhi1", num_nodes, phi_outputs, channels);
+    Kokkos::View<Precision***,Kokkos::LayoutRight> dPhi1_dot(
+        "MACEField dPhi1_dot", num_nodes, phi_outputs, channels);
+    Kokkos::View<Precision***,Kokkos::LayoutRight> dPhi1r_local(
+        "MACEField dPhi1r", num_nodes, phi_rows, channels);
+    Kokkos::View<Precision***,Kokkos::LayoutRight> dPhi1r_dot(
+        "MACEField dPhi1r_dot", num_nodes, phi_rows, channels);
+    Kokkos::View<Precision***,Kokkos::LayoutRight> H1_product_adj_dot(
+        "MACEField product adjoint tangent", num_nodes, LM_count, channels);
+    Kokkos::View<Precision***,Kokkos::LayoutRight> M0_adj_dot(
+        "MACEField M0 adjoint tangent", num_nodes, LM_count, channels);
+    Kokkos::View<Precision***,Kokkos::LayoutRight> A0_adj_dot(
+        "MACEField A0 adjoint tangent", num_nodes, lm_count, channels);
+
+    for (int seed=0; seed<3; ++seed) {
+        const auto scalar_to_vector_up = field_scalar_to_vector_up_matrix;
+        const auto vector_to_scalar_up = field_vector_to_scalar_up_matrix;
+        const auto H1_before_field = H1_pre_field;
+        const auto H1_up_weights = H1_linear_up_weights;
+        Kokkos::parallel_for(
+            "MACEField analytic field and linear-up tangent",
+            Kokkos::MDRangePolicy<Kokkos::Rank<3,Kokkos::Iterate::Right>>(
+                {0,0,0}, {num_nodes,LM_count,channels}),
+            KOKKOS_LAMBDA (const int i, const int lm, const int output) {
+                Precision value = 0.0;
+                if (lm == 0) {
+                    for (int input=0; input<channels; ++input)
+                        value += vector_to_scalar_up(input,output)
+                            *H1_before_field(i,1+seed,input);
+                } else if (lm == 1+seed) {
+                    for (int input=0; input<channels; ++input)
+                        value += scalar_to_vector_up(input,output)
+                            *H1_before_field(i,0,input);
+                }
+                H1_dot(i,lm,output) = value;
+            });
+
+        Kokkos::deep_copy(Phi1_dot, 0.0);
+        const auto phi_lm1 = Phi1_lm1;
+        const auto phi_lm2 = Phi1_lm2;
+        const auto phi_path = Phi1_lel1l2;
+        const auto radial1 = R1;
+        const auto harmonics = Y;
+        Kokkos::parallel_for(
+            "MACEField analytic Phi1r tangent",
+            Kokkos::TeamPolicy<>(num_nodes*phi_rows, Kokkos::AUTO, 32),
+            KOKKOS_LAMBDA (Kokkos::TeamPolicy<>::member_type team) {
+                const int i = team.league_rank()/phi_rows;
+                const int row = team.league_rank()%phi_rows;
+                const int edge_begin = first_neigh(i);
+                const int lm1 = phi_lm1(row);
+                const int lm2 = phi_lm2(row);
+                const int path = phi_path(row);
+                Kokkos::parallel_for(
+                    Kokkos::TeamVectorRange(team, channels),
+                    [=] (const int channel) {
+                        Precision value = 0.0;
+                        for (int j=0; j<num_neigh(i); ++j) {
+                            const int edge = edge_begin+j;
+                            value += radial1(edge,path*channels+channel)
+                                *harmonics(edge*lm_count+lm1)
+                                *H1_dot(neigh_indices(edge),lm2,channel);
+                        }
+                        Phi1r_dot(i,row,channel) = value;
+                    });
+            });
+
+        const auto phi_lme = Phi1_lme;
+        const auto phi_row = Phi1_lelm1lm2;
+        const auto phi_cg = Phi1_clebsch_gordan;
+        Kokkos::parallel_for(
+            "MACEField analytic Phi1 tangent",
+            Kokkos::TeamPolicy<>(num_nodes, Kokkos::AUTO, 32),
+            KOKKOS_LAMBDA (Kokkos::TeamPolicy<>::member_type team) {
+                const int i = team.league_rank();
+                for (int p=0; p<phi_cg.extent(0); ++p) {
+                    Kokkos::parallel_for(
+                        Kokkos::TeamVectorRange(team, channels),
+                        [=] (const int channel) {
+                            Phi1_dot(i,phi_lme(p),channel) += phi_cg(p)
+                                *Phi1r_dot(i,phi_row(p),channel);
+                        });
+                }
+            });
+
+        const auto phi_l = Phi1_l;
+        const auto A1_matrix = A1_weights;
+        Kokkos::parallel_for(
+            "MACEField analytic A1 tangent",
+            Kokkos::TeamPolicy<>(num_nodes*(lmax+1), Kokkos::AUTO),
+            KOKKOS_LAMBDA (Kokkos::TeamPolicy<>::member_type team) {
+                const int i = team.league_rank()/(lmax+1);
+                const int l = team.league_rank()%(lmax+1);
+                int lme = 0;
+                int multiplicity = 0;
+                for (int p=0; p<phi_l.extent(0); ++p) {
+                    if (phi_l(p) < l)
+                        lme += 2*phi_l(p)+1;
+                    if (phi_l(p) == l)
+                        ++multiplicity;
+                }
+                auto input = Kokkos::View<Precision**,Kokkos::LayoutRight,
+                    Kokkos::MemoryUnmanaged>(
+                        &Phi1_dot(i,lme,0), 2*l+1, multiplicity*channels);
+                auto output = Kokkos::subview(
+                    A1_dot, i, Kokkos::make_pair(l*l,l*(l+2)+1), Kokkos::ALL);
+                KokkosBatched::TeamGemm<
+                    Kokkos::TeamPolicy<>::member_type,
+                    KokkosBatched::Trans::NoTranspose,
+                    KokkosBatched::Trans::NoTranspose,
+                    KokkosBatched::Algo::Gemm::Blocked>::invoke(
+                        team, 1.0, input, A1_matrix(l), 0.0, output);
+            });
+
+        const auto A1_scale_values = A1_spline_values;
+        if (A1_scaled) {
+            Kokkos::parallel_for(
+                "MACEField analytic A1 tangent scaling",
+                Kokkos::TeamPolicy<>(num_nodes, Kokkos::AUTO),
+                KOKKOS_LAMBDA (Kokkos::TeamPolicy<>::member_type team) {
+                    const int i = team.league_rank();
+                    double scale;
+                    Kokkos::parallel_reduce(
+                        Kokkos::TeamThreadRange(team, num_neigh(i)),
+                        [=] (const int j, double& sum) {
+                            sum += A1_scale_values(first_neigh(i)+j,0);
+                        }, scale);
+                    scale += 1.0;
+                    Kokkos::parallel_for(
+                        Kokkos::TeamThreadRange(team, lm_count*channels),
+                        [=] (const int index) {
+                            A1_dot(i,index/channels,index%channels) /= scale;
+                        });
+                });
+        }
+
+        Kokkos::deep_copy(M1_dot, 0.0);
+        const auto M1_values = M1_poly_values;
+        const auto M1_spec = M1_poly_spec;
+        const auto M1_coeff = M1_poly_coeff;
+        Kokkos::parallel_for(
+            "MACEField analytic M1 directional graph",
+            Kokkos::TeamPolicy<>(num_nodes, Kokkos::AUTO, 32),
+            KOKKOS_LAMBDA (Kokkos::TeamPolicy<>::member_type team) {
+                const int i = team.league_rank();
+                Kokkos::parallel_for(
+                    Kokkos::TeamVectorMDRange<
+                        Kokkos::Rank<2,Kokkos::Iterate::Right>,
+                        Kokkos::TeamPolicy<>::member_type>(
+                            team, lm_count, channels),
+                    [=] (const int lm, const int channel) {
+                        M1_value_dot(i,lm,channel) = A1_dot(i,lm,channel);
+                        Kokkos::atomic_add(
+                            &M1_dot(i,channel),
+                            M1_coeff(node_types(i),lm,channel)
+                                *M1_value_dot(i,lm,channel));
+                    });
+                team.team_barrier();
+                for (int p=0; p<M1_spec.extent(0); ++p) {
+                    const int p0 = M1_spec(p,0);
+                    const int p1 = M1_spec(p,1);
+                    Kokkos::parallel_for(
+                        Kokkos::TeamVectorRange(team, channels),
+                        [=] (const int channel) {
+                            const int node = lm_count+p;
+                            M1_value_dot(i,node,channel) =
+                                M1_value_dot(i,p0,channel)*M1_values(i,p1,channel)
+                                +M1_values(i,p0,channel)*M1_value_dot(i,p1,channel);
+                            M1_dot(i,channel) +=
+                                M1_coeff(node_types(i),node,channel)
+                                *M1_value_dot(i,node,channel);
+                        });
+                }
+                team.team_barrier();
+                Kokkos::parallel_for(
+                    Kokkos::TeamVectorMDRange<
+                        Kokkos::Rank<2,Kokkos::Iterate::Right>,
+                        Kokkos::TeamPolicy<>::member_type>(
+                            team, polynomial_nodes, channels),
+                    [=] (const int node, const int channel) {
+                        M1_gradient(i,node,channel) =
+                            M1_coeff(node_types(i),node,channel);
+                        M1_gradient_dot(i,node,channel) = 0.0;
+                    });
+                team.team_barrier();
+                for (int p=M1_spec.extent(0)-1; p>=0; --p) {
+                    const int p0 = M1_spec(p,0);
+                    const int p1 = M1_spec(p,1);
+                    const int node = lm_count+p;
+                    Kokkos::parallel_for(
+                        Kokkos::TeamVectorRange(team, channels),
+                        [=] (const int channel) {
+                            const Precision adjoint = M1_gradient(i,node,channel);
+                            const Precision adjoint_dot =
+                                M1_gradient_dot(i,node,channel);
+                            M1_gradient_dot(i,p0,channel) +=
+                                adjoint_dot*M1_values(i,p1,channel)
+                                +adjoint*M1_value_dot(i,p1,channel);
+                            M1_gradient_dot(i,p1,channel) +=
+                                adjoint_dot*M1_values(i,p0,channel)
+                                +adjoint*M1_value_dot(i,p0,channel);
+                            M1_gradient(i,p0,channel) +=
+                                adjoint*M1_values(i,p1,channel);
+                            M1_gradient(i,p1,channel) +=
+                                adjoint*M1_values(i,p0,channel);
+                        });
+                }
+            });
+
+        const auto H2_from_H1 = H2_weights_for_H1;
+        const auto H2_from_M1 = H2_weights_for_M1;
+        Kokkos::parallel_for(
+            "MACEField analytic H2 tangent",
+            Kokkos::MDRangePolicy<Kokkos::Rank<2,Kokkos::Iterate::Right>>(
+                {0,0}, {num_nodes,channels}),
+            KOKKOS_LAMBDA (const int i, const int output) {
+                double value = 0.0;
+                for (int input=0; input<channels; ++input) {
+                    value += H2_from_H1(node_types(i),input*channels+output)
+                        *static_cast<double>(H1_dot(i,0,input));
+                    value += H2_from_M1(input*channels+output)
+                        *static_cast<double>(M1_dot(i,input));
+                }
+                H2_dot(i,output) = value;
+            });
+
+        auto H2_input = Kokkos::subview(H2, Kokkos::make_pair(0,num_nodes), Kokkos::ALL);
+        readout_2.evaluate_gradient_directional(
+            H2_input, H2_dot, readout_output, H2_adj_local, H2_adj_dot);
+
+        Kokkos::deep_copy(H1_adj_local, 0.0);
+        Kokkos::deep_copy(H1_adj_dot, 0.0);
+        const auto readout1 = readout_1_weights;
+        Kokkos::parallel_for(
+            "MACEField analytic H2 reverse tangent",
+            Kokkos::MDRangePolicy<Kokkos::Rank<2,Kokkos::Iterate::Right>>(
+                {0,0}, {num_nodes,channels}),
+            KOKKOS_LAMBDA (const int i, const int input) {
+                Precision h1_adjoint = static_cast<Precision>(readout1(input));
+                Precision h1_adjoint_dot = 0.0;
+                Precision m1_adjoint = 0.0;
+                Precision m1_adjoint_dot = 0.0;
+                for (int output=0; output<channels; ++output) {
+                    const double h1_weight =
+                        H2_from_H1(node_types(i),input*channels+output);
+                    const double m1_weight = H2_from_M1(input*channels+output);
+                    h1_adjoint += static_cast<Precision>(
+                        h1_weight*H2_adj_local(i,output));
+                    h1_adjoint_dot += static_cast<Precision>(
+                        h1_weight*H2_adj_dot(i,output));
+                    m1_adjoint += static_cast<Precision>(
+                        m1_weight*H2_adj_local(i,output));
+                    m1_adjoint_dot += static_cast<Precision>(
+                        m1_weight*H2_adj_dot(i,output));
+                }
+                H1_adj_local(i,0,input) = h1_adjoint;
+                H1_adj_dot(i,0,input) = h1_adjoint_dot;
+                M1_adj_local(i,input) = m1_adjoint;
+                M1_adj_dot(i,input) = m1_adjoint_dot;
+            });
+
+        Kokkos::parallel_for(
+            "MACEField analytic M1 reverse tangent",
+            Kokkos::MDRangePolicy<Kokkos::Rank<3,Kokkos::Iterate::Right>>(
+                {0,0,0}, {num_nodes,lm_count,channels}),
+            KOKKOS_LAMBDA (const int i, const int lm, const int channel) {
+                const Precision gradient = M1_gradient(i,lm,channel);
+                A1_adj_local(i,lm,channel) =
+                    gradient*M1_adj_local(i,channel);
+                A1_adj_dot(i,lm,channel) =
+                    M1_gradient_dot(i,lm,channel)*M1_adj_local(i,channel)
+                    +gradient*M1_adj_dot(i,channel);
+            });
+
+        const auto A1_base = A1;
+        const auto A1_scale_derivs = A1_spline_derivs;
+        if (A1_scaled) {
+            Kokkos::parallel_for(
+                "MACEField analytic A1 scaled reverse tangent",
+                Kokkos::TeamPolicy<>(num_nodes, Kokkos::AUTO),
+                KOKKOS_LAMBDA (Kokkos::TeamPolicy<>::member_type team) {
+                    const int i = team.league_rank();
+                    double scale;
+                    Kokkos::parallel_reduce(
+                        Kokkos::TeamThreadRange(team, num_neigh(i)),
+                        [=] (const int j, double& sum) {
+                            sum += A1_scale_values(first_neigh(i)+j,0);
+                        }, scale);
+                    scale += 1.0;
+                    double contraction;
+                    Kokkos::parallel_reduce(
+                        Kokkos::TeamThreadRange(team, lm_count*channels),
+                        [=] (const int index, double& sum) {
+                            const int lm = index/channels;
+                            const int channel = index%channels;
+                            sum += static_cast<double>(A1_adj_dot(i,lm,channel))
+                                *static_cast<double>(A1_base(i,lm,channel));
+                            sum += static_cast<double>(A1_adj_local(i,lm,channel))
+                                *static_cast<double>(A1_dot(i,lm,channel));
+                        }, contraction);
+                    Kokkos::parallel_for(
+                        Kokkos::TeamThreadRange(team, num_neigh(i)),
+                        [=] (const int j) {
+                            const int edge = first_neigh(i)+j;
+                            const double factor = contraction/scale
+                                *A1_scale_derivs(edge,0)/r(edge);
+                            response_forces(seed*xyz.size()+3*edge) +=
+                                factor*xyz(3*edge);
+                            response_forces(seed*xyz.size()+3*edge+1) +=
+                                factor*xyz(3*edge+1);
+                            response_forces(seed*xyz.size()+3*edge+2) +=
+                                factor*xyz(3*edge+2);
+                        });
+                    Kokkos::parallel_for(
+                        Kokkos::TeamThreadRange(team, lm_count*channels),
+                        [=] (const int index) {
+                            const int lm = index/channels;
+                            const int channel = index%channels;
+                            A1_adj_local(i,lm,channel) /= scale;
+                            A1_adj_dot(i,lm,channel) /= scale;
+                        });
+                });
+        }
+
+        const auto A1_matrix_trans = A1_weights_trans;
+        Kokkos::parallel_for(
+            "MACEField analytic A1 reverse",
+            Kokkos::TeamPolicy<>(num_nodes*(lmax+1), Kokkos::AUTO),
+            KOKKOS_LAMBDA (Kokkos::TeamPolicy<>::member_type team) {
+                const int i = team.league_rank()/(lmax+1);
+                const int l = team.league_rank()%(lmax+1);
+                int lme = 0;
+                int multiplicity = 0;
+                for (int p=0; p<phi_l.extent(0); ++p) {
+                    if (phi_l(p) < l)
+                        lme += 2*phi_l(p)+1;
+                    if (phi_l(p) == l)
+                        ++multiplicity;
+                }
+                auto base_input = Kokkos::subview(
+                    A1_adj_local, i,
+                    Kokkos::make_pair(l*l,l*l+2*l+1), Kokkos::ALL);
+                auto dot_input = Kokkos::subview(
+                    A1_adj_dot, i,
+                    Kokkos::make_pair(l*l,l*l+2*l+1), Kokkos::ALL);
+                auto base_output = Kokkos::View<Precision**,Kokkos::LayoutRight,
+                    Kokkos::MemoryUnmanaged>(
+                        &dPhi1_local(i,lme,0), 2*l+1, multiplicity*channels);
+                auto dot_output = Kokkos::View<Precision**,Kokkos::LayoutRight,
+                    Kokkos::MemoryUnmanaged>(
+                        &dPhi1_dot(i,lme,0), 2*l+1, multiplicity*channels);
+                KokkosBatched::TeamGemm<
+                    Kokkos::TeamPolicy<>::member_type,
+                    KokkosBatched::Trans::NoTranspose,
+                    KokkosBatched::Trans::NoTranspose,
+                    KokkosBatched::Algo::Gemm::Blocked>::invoke(
+                        team, 1.0, base_input, A1_matrix_trans(l),
+                        0.0, base_output);
+                team.team_barrier();
+                KokkosBatched::TeamGemm<
+                    Kokkos::TeamPolicy<>::member_type,
+                    KokkosBatched::Trans::NoTranspose,
+                    KokkosBatched::Trans::NoTranspose,
+                    KokkosBatched::Algo::Gemm::Blocked>::invoke(
+                        team, 1.0, dot_input, A1_matrix_trans(l),
+                        0.0, dot_output);
+            });
+
+        Kokkos::deep_copy(dPhi1r_local, 0.0);
+        Kokkos::deep_copy(dPhi1r_dot, 0.0);
+        Kokkos::parallel_for(
+            "MACEField analytic CG reverse tangent",
+            Kokkos::TeamPolicy<>(num_nodes, Kokkos::AUTO, 32),
+            KOKKOS_LAMBDA (Kokkos::TeamPolicy<>::member_type team) {
+                const int i = team.league_rank();
+                for (int p=0; p<phi_cg.extent(0); ++p) {
+                    Kokkos::parallel_for(
+                        Kokkos::TeamVectorRange(team, channels),
+                        [=] (const int channel) {
+                            const int row = phi_row(p);
+                            const int output = phi_lme(p);
+                            dPhi1r_local(i,row,channel) +=
+                                phi_cg(p)*dPhi1_local(i,output,channel);
+                            dPhi1r_dot(i,row,channel) +=
+                                phi_cg(p)*dPhi1_dot(i,output,channel);
+                        });
+                }
+            });
+
+        const auto radial1_deriv = R1_deriv;
+        const auto harmonics_grad = Y_grad;
+        const auto H1_base = H1;
+        {
+            const Kokkos::TeamPolicy<> phi_reverse_policy(
+                num_nodes, Kokkos::AUTO, 32);
+            Kokkos::parallel_for(
+                "MACEField analytic Phi1 reverse tangent",
+                phi_reverse_policy,
+                KOKKOS_LAMBDA (Kokkos::TeamPolicy<>::member_type team) {
+                const int i = team.league_rank();
+                const int edge_begin = first_neigh(i);
+                for (int j=0; j<num_neigh(i); ++j) {
+                    const int edge = edge_begin+j;
+                    const int neighbor = neigh_indices(edge);
+                    const double inverse_radius = 1.0/r(edge);
+                    double force_x, force_y, force_z;
+                    Kokkos::parallel_reduce(
+                        Kokkos::TeamThreadRange(team, phi_rows),
+                        [=] (const int row,
+                             double& local_x,
+                             double& local_y,
+                             double& local_z) {
+                            const int lm1 = phi_lm1(row);
+                            const int lm2 = phi_lm2(row);
+                            const int path = phi_path(row);
+                            const Precision y = harmonics(edge*lm_count+lm1);
+                            double row_x, row_y, row_z;
+                            Kokkos::parallel_reduce(
+                                Kokkos::ThreadVectorRange(team, channels),
+                                [=] (const int channel,
+                                     double& channel_x,
+                                     double& channel_y,
+                                     double& channel_z) {
+                                    const Precision radial =
+                                        radial1(edge,path*channels+channel);
+                                    const Precision radial_derivative =
+                                        radial1_deriv(edge,path*channels+channel);
+                                    const Precision base_feature =
+                                        H1_base(neighbor,lm2,channel);
+                                    const Precision feature_dot =
+                                        H1_dot(neighbor,lm2,channel);
+                                    const Precision base_adjoint =
+                                        dPhi1r_local(i,row,channel);
+                                    const Precision adjoint_dot =
+                                        dPhi1r_dot(i,row,channel);
+                                    const double radial_base = static_cast<double>(
+                                        radial_derivative*y*base_feature);
+                                    const double radial_dot = static_cast<double>(
+                                        radial_derivative*y*feature_dot);
+                                    const double angular_base = static_cast<double>(
+                                        radial*base_feature);
+                                    const double angular_dot = static_cast<double>(
+                                        radial*feature_dot);
+                                    const double base_adj = static_cast<double>(base_adjoint);
+                                    const double dot_adj = static_cast<double>(adjoint_dot);
+                                    channel_x -= dot_adj*(
+                                        radial_base*xyz(3*edge)*inverse_radius
+                                        +angular_base*harmonics_grad(3*edge*lm_count+lm1));
+                                    channel_x -= base_adj*(
+                                        radial_dot*xyz(3*edge)*inverse_radius
+                                        +angular_dot*harmonics_grad(3*edge*lm_count+lm1));
+                                    channel_y -= dot_adj*(
+                                        radial_base*xyz(3*edge+1)*inverse_radius
+                                        +angular_base*harmonics_grad((3*edge+1)*lm_count+lm1));
+                                    channel_y -= base_adj*(
+                                        radial_dot*xyz(3*edge+1)*inverse_radius
+                                        +angular_dot*harmonics_grad((3*edge+1)*lm_count+lm1));
+                                    channel_z -= dot_adj*(
+                                        radial_base*xyz(3*edge+2)*inverse_radius
+                                        +angular_base*harmonics_grad((3*edge+2)*lm_count+lm1));
+                                    channel_z -= base_adj*(
+                                        radial_dot*xyz(3*edge+2)*inverse_radius
+                                        +angular_dot*harmonics_grad((3*edge+2)*lm_count+lm1));
+                                    const Precision source_factor = radial*y;
+                                    Kokkos::atomic_add(
+                                        &H1_adj_local(neighbor,lm2,channel),
+                                        source_factor*base_adjoint);
+                                    Kokkos::atomic_add(
+                                        &H1_adj_dot(neighbor,lm2,channel),
+                                        source_factor*adjoint_dot);
+                                }, row_x, row_y, row_z);
+                            local_x += row_x;
+                            local_y += row_y;
+                            local_z += row_z;
+                        }, force_x, force_y, force_z);
+                    Kokkos::single(Kokkos::PerTeam(team), [=]() {
+                        response_forces(seed*xyz.size()+3*edge) += force_x;
+                        response_forces(seed*xyz.size()+3*edge+1) += force_y;
+                        response_forces(seed*xyz.size()+3*edge+2) += force_z;
+                    });
+                }
+                });
+        }
+
+        Kokkos::parallel_reduce(
+            "MACEField analytic field reverse tangent",
+            num_nodes*channels,
+            AnalyticFieldReverseReducer<Precision>{
+                channels,
+                seed,
+                H1_adj_local,
+                H1_adj_dot,
+                H1_before_field,
+                H1_product_adj_dot,
+                H1_up_weights,
+                scalar_to_vector_up,
+                vector_to_scalar_up,
+                electric_field,
+                response_hessian
+            });
+
+        const auto product_weights = H1_product_weights;
+        Kokkos::parallel_for(
+            "MACEField analytic H1 product reverse tangent",
+            Kokkos::TeamPolicy<>(num_nodes*(Lmax+1), Kokkos::AUTO),
+            KOKKOS_LAMBDA (Kokkos::TeamPolicy<>::member_type team) {
+                const int i = team.league_rank()/(Lmax+1);
+                const int l = team.league_rank()%(Lmax+1);
+                auto input = Kokkos::subview(
+                    H1_product_adj_dot, i,
+                    Kokkos::make_pair(l*l,l*(l+2)+1), Kokkos::ALL);
+                auto weights = Kokkos::subview(
+                    product_weights, l, Kokkos::ALL, Kokkos::ALL);
+                auto output = Kokkos::subview(
+                    M0_adj_dot, i,
+                    Kokkos::make_pair(l*l,l*(l+2)+1), Kokkos::ALL);
+                KokkosBatched::TeamGemm<
+                    Kokkos::TeamPolicy<>::member_type,
+                    KokkosBatched::Trans::NoTranspose,
+                    KokkosBatched::Trans::Transpose,
+                    KokkosBatched::Algo::Gemm::Unblocked>::invoke(
+                        team, 1.0, input, weights, 0.0, output);
+            });
+
+        Kokkos::deep_copy(A0_adj_dot, 0.0);
+        const auto M0_specs = M0_poly_spec;
+        const auto M0_coeffs = M0_poly_coeff;
+        const auto M0_values = M0_poly_values;
+        for (int LM=0; LM<LM_count; ++LM) {
+            const auto spec = M0_specs(LM);
+            const auto coefficients = M0_coeffs(LM);
+            const auto values = M0_values(LM);
+            const int graph_nodes = coefficients.extent(1);
+            Kokkos::View<Precision***,Kokkos::LayoutRight> graph_adj_dot(
+                "MACEField M0 graph adjoint tangent",
+                num_nodes, graph_nodes, channels);
+            Kokkos::parallel_for(
+                "MACEField analytic M0 reverse tangent",
+                Kokkos::TeamPolicy<>(num_nodes, Kokkos::AUTO, 32),
+                KOKKOS_LAMBDA (Kokkos::TeamPolicy<>::member_type team) {
+                    const int i = team.league_rank();
+                    Kokkos::parallel_for(
+                        Kokkos::TeamVectorMDRange<
+                            Kokkos::Rank<2,Kokkos::Iterate::Right>,
+                            Kokkos::TeamPolicy<>::member_type>(
+                                team, graph_nodes, channels),
+                        [=] (const int node, const int channel) {
+                            graph_adj_dot(i,node,channel) =
+                                coefficients(node_types(i),node,channel)
+                                *M0_adj_dot(i,LM,channel);
+                        });
+                    team.team_barrier();
+                    for (int p=spec.extent(0)-1; p>=0; --p) {
+                        const int p0 = spec(p,0);
+                        const int p1 = spec(p,1);
+                        const int node = lm_count+p;
+                        Kokkos::parallel_for(
+                            Kokkos::TeamVectorRange(team, channels),
+                            [=] (const int channel) {
+                                const Precision adjoint =
+                                    graph_adj_dot(i,node,channel);
+                                graph_adj_dot(i,p0,channel) +=
+                                    adjoint*values(i,p1,channel);
+                                graph_adj_dot(i,p1,channel) +=
+                                    adjoint*values(i,p0,channel);
+                            });
+                    }
+                    team.team_barrier();
+                    Kokkos::parallel_for(
+                        Kokkos::TeamVectorMDRange<
+                            Kokkos::Rank<2,Kokkos::Iterate::Right>,
+                            Kokkos::TeamPolicy<>::member_type>(
+                                team, lm_count, channels),
+                        [=] (const int lm, const int channel) {
+                            Kokkos::atomic_add(
+                                &A0_adj_dot(i,lm,channel),
+                                graph_adj_dot(i,lm,channel));
+                        });
+                });
+        }
+
+        const auto A0_base = A0;
+        const auto A0_scale_values = A0_spline_values;
+        const auto A0_scale_derivs = A0_spline_derivs;
+        if (A0_scaled) {
+            Kokkos::parallel_for(
+                "MACEField analytic A0 scaled reverse tangent",
+                Kokkos::TeamPolicy<>(num_nodes, Kokkos::AUTO),
+                KOKKOS_LAMBDA (Kokkos::TeamPolicy<>::member_type team) {
+                    const int i = team.league_rank();
+                    double scale;
+                    Kokkos::parallel_reduce(
+                        Kokkos::TeamThreadRange(team, num_neigh(i)),
+                        [=] (const int j, double& sum) {
+                            sum += A0_scale_values(first_neigh(i)+j,0);
+                        }, scale);
+                    scale += 1.0;
+                    double contraction;
+                    Kokkos::parallel_reduce(
+                        Kokkos::TeamThreadRange(team, lm_count*channels),
+                        [=] (const int index, double& sum) {
+                            const int lm = index/channels;
+                            const int channel = index%channels;
+                            sum += static_cast<double>(A0_adj_dot(i,lm,channel))
+                                *static_cast<double>(A0_base(i,lm,channel));
+                        }, contraction);
+                    Kokkos::parallel_for(
+                        Kokkos::TeamThreadRange(team, num_neigh(i)),
+                        [=] (const int j) {
+                            const int edge = first_neigh(i)+j;
+                            const double factor = contraction/scale
+                                *A0_scale_derivs(edge,0)/r(edge);
+                            response_forces(seed*xyz.size()+3*edge) +=
+                                factor*xyz(3*edge);
+                            response_forces(seed*xyz.size()+3*edge+1) +=
+                                factor*xyz(3*edge+1);
+                            response_forces(seed*xyz.size()+3*edge+2) +=
+                                factor*xyz(3*edge+2);
+                        });
+                    Kokkos::parallel_for(
+                        Kokkos::TeamThreadRange(team, lm_count*channels),
+                        [=] (const int index) {
+                            A0_adj_dot(i,index/channels,index%channels) /= scale;
+                        });
+                });
+        }
+
+        const auto radial0 = R0;
+        const auto radial0_deriv = R0_deriv;
+        {
+            const Kokkos::TeamPolicy<> A0_reverse_policy(
+                num_nodes, Kokkos::AUTO, 32);
+            Kokkos::parallel_for(
+                "MACEField analytic A0 reverse tangent",
+                A0_reverse_policy,
+                KOKKOS_LAMBDA (Kokkos::TeamPolicy<>::member_type team) {
+                const int i = team.league_rank();
+                const int edge_begin = first_neigh(i);
+                for (int j=0; j<num_neigh(i); ++j) {
+                    const int edge = edge_begin+j;
+                    const double inverse_radius = 1.0/r(edge);
+                    double force_x, force_y, force_z;
+                    Kokkos::parallel_reduce(
+                        Kokkos::TeamThreadRange(team, lmax+1),
+                        [=] (const int l,
+                             double& local_x,
+                             double& local_y,
+                             double& local_z) {
+                            double l_x, l_y, l_z;
+                            Kokkos::parallel_reduce(
+                                Kokkos::ThreadVectorRange(team, channels),
+                                [=] (const int channel,
+                                     double& channel_x,
+                                     double& channel_y,
+                                     double& channel_z) {
+                                    for (int lm=l*l; lm<(l+1)*(l+1); ++lm) {
+                                        const double adjoint = static_cast<double>(
+                                            A0_adj_dot(i,lm,channel));
+                                        const double radial = static_cast<double>(
+                                            radial0_deriv(edge,l*channels+channel))
+                                            *static_cast<double>(
+                                                harmonics(edge*lm_count+lm))
+                                            *adjoint;
+                                        const double angular = static_cast<double>(
+                                            radial0(edge,l*channels+channel))*adjoint;
+                                        channel_x -= radial*xyz(3*edge)*inverse_radius
+                                            +angular*harmonics_grad(3*edge*lm_count+lm);
+                                        channel_y -= radial*xyz(3*edge+1)*inverse_radius
+                                            +angular*harmonics_grad((3*edge+1)*lm_count+lm);
+                                        channel_z -= radial*xyz(3*edge+2)*inverse_radius
+                                            +angular*harmonics_grad((3*edge+2)*lm_count+lm);
+                                    }
+                                }, l_x, l_y, l_z);
+                            local_x += l_x;
+                            local_y += l_y;
+                            local_z += l_z;
+                        }, force_x, force_y, force_z);
+                    Kokkos::single(Kokkos::PerTeam(team), [=]() {
+                        response_forces(seed*xyz.size()+3*edge) += force_x;
+                        response_forces(seed*xyz.size()+3*edge+1) += force_y;
+                        response_forces(seed*xyz.size()+3*edge+2) += force_z;
+                    });
+                }
+                });
+        }
+        Kokkos::fence();
+    }
+
+    Kokkos::fence();
+}
+
+template <typename Precision>
+void MACEKokkos<Precision>::compute_electric_field_force_derivative(
+    const int num_nodes,
+    Kokkos::View<const int*> node_types,
+    Kokkos::View<const int*> num_neigh,
+    Kokkos::View<const int*> neigh_indices,
+    Kokkos::View<const int*> neigh_types,
+    Kokkos::View<const double*> xyz,
+    Kokkos::View<const double*> r,
+    Kokkos::View<const double*> electric_field)
+{
+    compute_electric_field_hessian(
+        num_nodes, node_types, num_neigh, neigh_indices, neigh_types,
+        xyz, r, electric_field);
+}

--- a/libsymmetrix/source/multilayer_perceptron.cpp
+++ b/libsymmetrix/source/multilayer_perceptron.cpp
@@ -149,6 +149,93 @@ auto  MultilayerPerceptron::evaluate_gradient(
     return {node_values.back(), node_derivs[0]};
 }
 
+auto MultilayerPerceptron::evaluate_gradient_directional(
+    std::vector<double> input,
+    std::vector<double> input_dot)
+    -> std::tuple<std::vector<double>,std::vector<double>,std::vector<double>>
+{
+    auto values = std::vector<std::vector<double>>(shape.size());
+    auto value_dots = std::vector<std::vector<double>>(shape.size());
+    auto pre_activation_dots = std::vector<std::vector<double>>(shape.size());
+    auto activation_derivs = std::vector<std::vector<double>>(shape.size());
+    auto activation_second_derivs = std::vector<std::vector<double>>(shape.size());
+    for (int l=0; l<shape.size(); ++l) {
+        values[l].resize(shape[l], 0.0);
+        value_dots[l].resize(shape[l], 0.0);
+        pre_activation_dots[l].resize(shape[l], 0.0);
+        activation_derivs[l].resize(shape[l], 0.0);
+        activation_second_derivs[l].resize(shape[l], 0.0);
+    }
+
+    std::copy(input.begin(), input.end(), values[0].begin());
+    std::copy(input_dot.begin(), input_dot.end(), value_dots[0].begin());
+
+    for (int l=0; l<shape.size()-2; ++l) {
+        for (int j=0; j<shape[l+1]; ++j) {
+            double z = 0.0;
+            double z_dot = 0.0;
+            for (int i=0; i<shape[l]; ++i) {
+                const double weight = weights[l][j*shape[l]+i];
+                z += weight*values[l][i];
+                z_dot += weight*value_dots[l][i];
+            }
+            const double sigmoid = 1.0/(1.0+std::exp(-z));
+            const double sigmoid_deriv = sigmoid*(1.0-sigmoid);
+            const double sigmoid_second_deriv = sigmoid_deriv*(1.0-2.0*sigmoid);
+            values[l+1][j] = activation_scale_factor*z*sigmoid;
+            value_dots[l+1][j] =
+                activation_scale_factor*(sigmoid + z*sigmoid_deriv)*z_dot;
+            pre_activation_dots[l+1][j] = z_dot;
+            activation_derivs[l+1][j] =
+                activation_scale_factor*(sigmoid + z*sigmoid_deriv);
+            activation_second_derivs[l+1][j] =
+                activation_scale_factor*(2.0*sigmoid_deriv + z*sigmoid_second_deriv);
+        }
+    }
+
+    const int output_size = shape.back();
+    const int final_input_size = shape.end()[-2];
+    auto output = std::vector<double>(output_size, 0.0);
+    for (int o=0; o<output_size; ++o) {
+        for (int i=0; i<final_input_size; ++i)
+            output[o] += weights.back()[o*final_input_size+i] * values.end()[-2][i];
+    }
+
+    auto jac_next = weights.back();
+    auto jac_next_dot = std::vector<double>(jac_next.size(), 0.0);
+    for (int l=shape.size()-3; l>=0; --l) {
+        auto jac_z = std::vector<double>(output_size*shape[l+1], 0.0);
+        auto jac_z_dot = std::vector<double>(output_size*shape[l+1], 0.0);
+        for (int o=0; o<output_size; ++o) {
+            for (int j=0; j<shape[l+1]; ++j) {
+                const int index = o*shape[l+1]+j;
+                jac_z[index] = jac_next[index]*activation_derivs[l+1][j];
+                jac_z_dot[index] =
+                    jac_next_dot[index]*activation_derivs[l+1][j]
+                    + jac_next[index]
+                    * activation_second_derivs[l+1][j]
+                    * pre_activation_dots[l+1][j];
+            }
+        }
+
+        auto jac_prev = std::vector<double>(output_size*shape[l], 0.0);
+        auto jac_prev_dot = std::vector<double>(output_size*shape[l], 0.0);
+        for (int o=0; o<output_size; ++o) {
+            for (int i=0; i<shape[l]; ++i) {
+                for (int j=0; j<shape[l+1]; ++j) {
+                    const double weight = weights[l][j*shape[l]+i];
+                    jac_prev[o*shape[l]+i] += jac_z[o*shape[l+1]+j] * weight;
+                    jac_prev_dot[o*shape[l]+i] += jac_z_dot[o*shape[l+1]+j] * weight;
+                }
+            }
+        }
+        jac_next = std::move(jac_prev);
+        jac_next_dot = std::move(jac_prev_dot);
+    }
+
+    return {output, jac_next, jac_next_dot};
+}
+
 auto MultilayerPerceptron::evaluate_batch(
     std::vector<double> input,
     const int batch_size

--- a/libsymmetrix/source/multilayer_perceptron.hpp
+++ b/libsymmetrix/source/multilayer_perceptron.hpp
@@ -15,6 +15,10 @@ MultilayerPerceptron(
 
 auto evaluate(std::vector<double> input) -> std::vector<double>;
 auto evaluate_gradient(std::vector<double> input) -> std::tuple<std::vector<double>,std::vector<double>>;
+auto evaluate_gradient_directional(
+        std::vector<double> input,
+        std::vector<double> input_dot)
+        -> std::tuple<std::vector<double>,std::vector<double>,std::vector<double>>;
 auto evaluate_batch(std::vector<double> input, const int batch_size) -> std::vector<double>;
 auto evaluate_gradient_batch(std::vector<double> input, const int batch_size) -> std::tuple<std::vector<double>,std::vector<double>>;
 

--- a/libsymmetrix/source/multilayer_perceptron_kokkos.cpp
+++ b/libsymmetrix/source/multilayer_perceptron_kokkos.cpp
@@ -1,3 +1,5 @@
+#include <stdexcept>
+
 #include "KokkosBlas.hpp"
 
 #include "multilayer_perceptron_kokkos.hpp"
@@ -37,6 +39,14 @@ MultilayerPerceptronKokkos::MultilayerPerceptronKokkos(
     this->node_derivatives = Kokkos::View<
         Kokkos::View<double**,Kokkos::LayoutRight>*,Kokkos::SharedSpace>(
             Kokkos::view_alloc("node_derivatives", Kokkos::SequentialHostInit), shape.size());
+
+    this->node_value_dots = Kokkos::View<
+        Kokkos::View<double**,Kokkos::LayoutRight>*,Kokkos::SharedSpace>(
+            Kokkos::view_alloc("node_value_dots", Kokkos::SequentialHostInit), shape.size());
+
+    this->node_derivative_dots = Kokkos::View<
+        Kokkos::View<double**,Kokkos::LayoutRight>*,Kokkos::SharedSpace>(
+            Kokkos::view_alloc("node_derivative_dots", Kokkos::SequentialHostInit), shape.size());
 }
 
 MultilayerPerceptronKokkos::~MultilayerPerceptronKokkos()
@@ -46,6 +56,8 @@ MultilayerPerceptronKokkos::~MultilayerPerceptronKokkos()
     weights = Kokkos::View<Kokkos::View<double**,Kokkos::LayoutRight>*,Kokkos::SharedSpace>();
     node_values = Kokkos::View<Kokkos::View<double**,Kokkos::LayoutRight>*,Kokkos::SharedSpace>();
     node_derivatives = Kokkos::View<Kokkos::View<double**,Kokkos::LayoutRight>*,Kokkos::SharedSpace>();
+    node_value_dots = Kokkos::View<Kokkos::View<double**,Kokkos::LayoutRight>*,Kokkos::SharedSpace>();
+    node_derivative_dots = Kokkos::View<Kokkos::View<double**,Kokkos::LayoutRight>*,Kokkos::SharedSpace>();
 }
 
 void MultilayerPerceptronKokkos::evaluate(
@@ -169,4 +181,142 @@ void MultilayerPerceptronKokkos::evaluate_gradient(
     Kokkos::fence();
     Kokkos::deep_copy(f, Kokkos::subview(node_values(shape.size()-1), Kokkos::ALL, 0));
     Kokkos::deep_copy(g, node_derivatives(0));
+}
+
+void MultilayerPerceptronKokkos::evaluate_gradient_directional(
+    Kokkos::View<const double**,Kokkos::LayoutRight> x,
+    Kokkos::View<const double**,Kokkos::LayoutRight> x_dot,
+    Kokkos::View<double*,Kokkos::LayoutRight> f,
+    Kokkos::View<double**,Kokkos::LayoutRight> g,
+    Kokkos::View<double**,Kokkos::LayoutRight> g_dot)
+{
+    const int batch_size = x.extent(0);
+    if (x_dot.extent(0) != x.extent(0) || x_dot.extent(1) != x.extent(1))
+        throw std::invalid_argument(
+            "MultilayerPerceptronKokkos directional input shape mismatch.");
+    if (shape(shape.size()-1) != 1)
+        throw std::invalid_argument(
+            "MultilayerPerceptronKokkos directional gradients require scalar output.");
+
+    for (int l=0; l<shape.size(); ++l) {
+        if (node_values(l).extent(0) != batch_size
+            || node_values(l).extent(1) != shape(l))
+            Kokkos::realloc(Kokkos::WithoutInitializing,
+                            node_values(l), batch_size, shape(l));
+        if (node_derivatives(l).extent(0) != batch_size
+            || node_derivatives(l).extent(1) != shape(l))
+            Kokkos::realloc(Kokkos::WithoutInitializing,
+                            node_derivatives(l), batch_size, shape(l));
+        if (node_value_dots(l).extent(0) != batch_size
+            || node_value_dots(l).extent(1) != shape(l))
+            Kokkos::realloc(Kokkos::WithoutInitializing,
+                            node_value_dots(l), batch_size, shape(l));
+        if (node_derivative_dots(l).extent(0) != batch_size
+            || node_derivative_dots(l).extent(1) != shape(l))
+            Kokkos::realloc(Kokkos::WithoutInitializing,
+                            node_derivative_dots(l), batch_size, shape(l));
+        Kokkos::deep_copy(node_derivatives(l), 0.0);
+        Kokkos::deep_copy(node_derivative_dots(l), 0.0);
+    }
+    Kokkos::deep_copy(node_values(0), x);
+    Kokkos::deep_copy(node_value_dots(0), x_dot);
+
+    const auto activation_scale = this->activation_scale;
+    const auto shape = this->shape;
+    const auto weights = this->weights;
+    const auto values = this->node_values;
+    const auto value_dots = this->node_value_dots;
+    const auto derivatives = this->node_derivatives;
+    const auto derivative_dots = this->node_derivative_dots;
+
+    Kokkos::parallel_for(
+        "MultilayerPerceptronKokkos::evaluate_gradient_directional",
+        Kokkos::TeamPolicy<>(batch_size, Kokkos::AUTO),
+        KOKKOS_CLASS_LAMBDA (Kokkos::TeamPolicy<>::member_type team_member) {
+            const int batch = team_member.league_rank();
+
+            for (int l=0; l<shape.size()-1; ++l) {
+                Kokkos::parallel_for(
+                    Kokkos::TeamThreadRange(team_member, weights(l).extent(0)),
+                    [=] (const int output) {
+                        double z = 0.0;
+                        double z_dot = 0.0;
+                        for (int input=0; input<weights(l).extent(1); ++input) {
+                            const double weight = weights(l)(output,input);
+                            z += weight*values(l)(batch,input);
+                            z_dot += weight*value_dots(l)(batch,input);
+                        }
+                        if (l == shape.size()-2) {
+                            values(l+1)(batch,output) = z;
+                            value_dots(l+1)(batch,output) = z_dot;
+                        } else {
+                            const double sigmoid = 1.0/(1.0+Kokkos::exp(-z));
+                            const double activation_derivative = activation_scale
+                                *(sigmoid + z*sigmoid*(1.0-sigmoid));
+                            values(l+1)(batch,output) = activation_scale*z*sigmoid;
+                            value_dots(l+1)(batch,output) =
+                                activation_derivative*z_dot;
+                        }
+                    });
+                team_member.team_barrier();
+            }
+
+            Kokkos::parallel_for(
+                Kokkos::TeamThreadRange(
+                    team_member, derivatives(shape.size()-2).extent(1)),
+                [=] (const int input) {
+                    derivatives(shape.size()-2)(batch,input) =
+                        weights(shape.size()-2)(0,input);
+                    derivative_dots(shape.size()-2)(batch,input) = 0.0;
+                });
+            team_member.team_barrier();
+
+            for (int l=shape.size()-3; l>=0; --l) {
+                Kokkos::parallel_for(
+                    Kokkos::TeamThreadRange(team_member, weights(l).extent(0)),
+                    [=] (const int output) {
+                        double z = 0.0;
+                        double z_dot = 0.0;
+                        for (int input=0; input<weights(l).extent(1); ++input) {
+                            const double weight = weights(l)(output,input);
+                            z += weight*values(l)(batch,input);
+                            z_dot += weight*value_dots(l)(batch,input);
+                        }
+                        const double sigmoid = 1.0/(1.0+Kokkos::exp(-z));
+                        const double sigmoid_derivative = sigmoid*(1.0-sigmoid);
+                        const double activation_derivative = activation_scale
+                            *(sigmoid + z*sigmoid_derivative);
+                        const double activation_second_derivative = activation_scale
+                            *(2.0*sigmoid_derivative
+                              +z*sigmoid_derivative*(1.0-2.0*sigmoid));
+                        derivative_dots(l+1)(batch,output) =
+                            derivative_dots(l+1)(batch,output)*activation_derivative
+                            +derivatives(l+1)(batch,output)
+                                *activation_second_derivative*z_dot;
+                        derivatives(l+1)(batch,output) *= activation_derivative;
+                    });
+                team_member.team_barrier();
+                Kokkos::parallel_for(
+                    Kokkos::TeamThreadRange(team_member, weights(l).extent(1)),
+                    [=] (const int input) {
+                        double derivative = 0.0;
+                        double derivative_dot = 0.0;
+                        for (int output=0; output<weights(l).extent(0); ++output) {
+                            derivative += weights(l)(output,input)
+                                *derivatives(l+1)(batch,output);
+                            derivative_dot += weights(l)(output,input)
+                                *derivative_dots(l+1)(batch,output);
+                        }
+                        derivatives(l)(batch,input) = derivative;
+                        derivative_dots(l)(batch,input) = derivative_dot;
+                    });
+                team_member.team_barrier();
+            }
+        });
+
+    Kokkos::deep_copy(f,
+        Kokkos::subview(node_values(shape.size()-1), Kokkos::ALL, 0));
+    Kokkos::deep_copy(g, node_derivatives(0));
+    Kokkos::deep_copy(g_dot, node_derivative_dots(0));
+    Kokkos::fence();
 }

--- a/libsymmetrix/source/multilayer_perceptron_kokkos.hpp
+++ b/libsymmetrix/source/multilayer_perceptron_kokkos.hpp
@@ -15,6 +15,12 @@ MultilayerPerceptronKokkos(
 
 void evaluate(Kokkos::View<const double**,Kokkos::LayoutRight> x, Kokkos::View<double*,Kokkos::LayoutRight> f);
 void evaluate_gradient(Kokkos::View<const double**,Kokkos::LayoutRight> x, Kokkos::View<double*,Kokkos::LayoutRight> f, Kokkos::View<double**,Kokkos::LayoutRight> g);
+void evaluate_gradient_directional(
+    Kokkos::View<const double**,Kokkos::LayoutRight> x,
+    Kokkos::View<const double**,Kokkos::LayoutRight> x_dot,
+    Kokkos::View<double*,Kokkos::LayoutRight> f,
+    Kokkos::View<double**,Kokkos::LayoutRight> g,
+    Kokkos::View<double**,Kokkos::LayoutRight> g_dot);
 
 private:
 
@@ -24,5 +30,7 @@ double activation_scale;
 
 Kokkos::View<Kokkos::View<double**,Kokkos::LayoutRight>*,Kokkos::SharedSpace> node_values;
 Kokkos::View<Kokkos::View<double**,Kokkos::LayoutRight>*,Kokkos::SharedSpace> node_derivatives;
+Kokkos::View<Kokkos::View<double**,Kokkos::LayoutRight>*,Kokkos::SharedSpace> node_value_dots;
+Kokkos::View<Kokkos::View<double**,Kokkos::LayoutRight>*,Kokkos::SharedSpace> node_derivative_dots;
 
 };

--- a/libsymmetrix/source/multivariate_polynomial.cpp
+++ b/libsymmetrix/source/multivariate_polynomial.cpp
@@ -126,6 +126,51 @@ auto MultivariatePolynomial::evaluate_gradient(
     return {f, g};
 }
 
+auto MultivariatePolynomial::evaluate_gradient_directional(
+    const std::vector<double>& x,
+    const std::vector<double>& x_dot)
+    -> std::tuple<double,std::vector<double>,std::vector<double>>
+{
+    initialize_forward_pass(x);
+    auto node_value_dots = std::vector<double>(nodes.size(), 0.0);
+    for (int i=0; i<num_variables; ++i)
+        node_value_dots[i] = x_dot[i];
+
+    for (int i=0; i<edges.size(); ++i) {
+        const auto [i0, i1] = edges[i];
+        const int output_node = num_variables+i;
+        node_values[output_node] = node_values[i0] * node_values[i1];
+        node_value_dots[output_node] =
+            node_value_dots[i0] * node_values[i1]
+            + node_values[i0] * node_value_dots[i1];
+    }
+
+    auto f = cblas_ddot(node_coefficients.size(),
+                        node_coefficients.data(), 1,
+                        node_values.data(), 1);
+
+    initialize_backward_pass();
+    auto node_adjoints_dots = std::vector<double>(nodes.size(), 0.0);
+    for (int i=edges.size()-1; i>=0; --i) {
+        const auto [i0, i1] = edges[i];
+        const int output_node = num_variables+i;
+        node_adjoints[i0] += node_adjoints[output_node]*node_values[i1];
+        node_adjoints[i1] += node_adjoints[output_node]*node_values[i0];
+        node_adjoints_dots[i0] +=
+            node_adjoints_dots[output_node]*node_values[i1]
+            + node_adjoints[output_node]*node_value_dots[i1];
+        node_adjoints_dots[i1] +=
+            node_adjoints_dots[output_node]*node_values[i0]
+            + node_adjoints[output_node]*node_value_dots[i0];
+    }
+
+    auto g = extract_gradient_from_graph();
+    auto g_dot = std::vector<double>(num_variables, 0.0);
+    for (int i=0; i<num_variables; ++i)
+        g_dot[i] = node_adjoints_dots[i];
+    return {f, g, g_dot};
+}
+
 auto MultivariatePolynomial::evaluate_batch(
     const std::vector<double>& x,
     const int batch_size)

--- a/libsymmetrix/source/multivariate_polynomial.hpp
+++ b/libsymmetrix/source/multivariate_polynomial.hpp
@@ -13,9 +13,13 @@ MultivariatePolynomial(int num_variables,
                        std::vector<double> coefficients,
                        std::vector<std::vector<int>> monomials);
 
-auto evaluate(const std::vector<double>& x) -> double;
-auto evaluate_gradient(const std::vector<double>& x) -> std::tuple<double,std::vector<double>>;
-auto evaluate_batch(const std::vector<double>& x, const int batch_size) -> std::tuple<std::vector<double>,std::vector<double>>;
+    auto evaluate(const std::vector<double>& x) -> double;
+    auto evaluate_gradient(const std::vector<double>& x) -> std::tuple<double,std::vector<double>>;
+    auto evaluate_gradient_directional(
+        const std::vector<double>& x,
+        const std::vector<double>& x_dot)
+        -> std::tuple<double,std::vector<double>,std::vector<double>>;
+    auto evaluate_batch(const std::vector<double>& x, const int batch_size) -> std::tuple<std::vector<double>,std::vector<double>>;
 
 // polynomial specification
 int num_variables;

--- a/libsymmetrix/source/radial_function_set_kokkos.cpp
+++ b/libsymmetrix/source/radial_function_set_kokkos.cpp
@@ -12,10 +12,12 @@ template <typename Precision>
 RadialFunctionSetKokkos<Precision>::RadialFunctionSetKokkos(
     double h,
     std::vector<std::vector<std::vector<double>>> node_values,
-    std::vector<std::vector<std::vector<double>>> node_derivatives)
+    std::vector<std::vector<std::vector<double>>> node_derivatives,
+    double x0)
 {
     // TODO: sanitize input
     this->h = h;
+    this->x0 = x0;
     num_edge_types = node_values.size();
     num_functions = node_values[0].size();
     num_nodes = node_values[0][0].size();
@@ -50,12 +52,16 @@ void RadialFunctionSetKokkos<Precision>::evaluate(
     Kokkos::View<const int*> node_types,
     Kokkos::View<const int*> num_neigh,
     Kokkos::View<const int*> neigh_types,
+    Kokkos::View<const int*> type_to_active,
+    int num_active_types,
     Kokkos::View<const double*> r,
     Kokkos::View<Precision**,Kokkos::LayoutRight> R,
     Kokkos::View<Precision**,Kokkos::LayoutRight> R_deriv) const
 {
     const auto h = this->h;
+    const auto x0 = this->x0;
     const auto num_functions = this->num_functions;
+    const auto num_intervals = this->num_nodes-1;
     const auto c = this->coefficients;
 
     Kokkos::parallel_for(
@@ -127,12 +133,16 @@ void RadialFunctionSetKokkos<Precision>::evaluate(
     Kokkos::View<const int*> node_types,
     Kokkos::View<const int*> num_neigh,
     Kokkos::View<const int*> neigh_types,
+    Kokkos::View<const int*> type_to_active,
+    int num_active_types,
     Kokkos::View<const double*> r,
     Kokkos::View<Precision**,Kokkos::LayoutRight> R,
     Kokkos::View<Precision**,Kokkos::LayoutRight> R_deriv) const
 {
     const auto h = this->h;
+    const auto x0 = this->x0;
     const auto num_functions = this->num_functions;
+    const auto num_intervals = this->num_nodes-1;
     const auto c = this->coefficients;
 
     // TODO: shouldn't need all this
@@ -159,8 +169,6 @@ void RadialFunctionSetKokkos<Precision>::evaluate(
         });
     Kokkos::fence();
 
-    const int num_unique_types = (std::sqrt(8*num_edge_types+1)-1)/2;
-
     Kokkos::parallel_for(
         "RadialFunctionSetKokkos::evaluate",
         // TODO: empirically, this vector_length appears to be the best choice,
@@ -171,14 +179,21 @@ void RadialFunctionSetKokkos<Precision>::evaluate(
         KOKKOS_LAMBDA (Kokkos::TeamPolicy<>::member_type team_member) {
             const int ij = team_member.league_rank();
             // determine edge type
-            const int type_i = node_types(i_list(ij));
-            const int type_j = neigh_types(ij);
+            const int type_i = type_to_active(node_types(i_list(ij)));
+            const int type_j = type_to_active(neigh_types(ij));
             const int type_ij = (type_i <= type_j)
-                ? type_i*(2*num_unique_types-type_i-1)/2 + type_j
-                : type_j*(2*num_unique_types-type_j-1)/2 + type_i;
+                ? type_i*(2*num_active_types-type_i-1)/2 + type_j
+                : type_j*(2*num_active_types-type_j-1)/2 + type_i;
             // compute x, x^2, x^3
-            const int n = static_cast<int>(r(ij)/h); // TODO: bounds checking?
-            const double x = r(ij) - h*n;
+            int n = static_cast<int>(Kokkos::floor((r(ij)-x0)/h));
+            double x = r(ij)-x0-h*n;
+            if (n < 0) {
+                n = 0;
+                x = 0.0;
+            } else if (n >= num_intervals) {
+                n = num_intervals-1;
+                x = h;
+            }
             const double xx = x*x;
             const double xxx = xx*x;
             const double two_x = 2*x;

--- a/libsymmetrix/source/radial_function_set_kokkos.hpp
+++ b/libsymmetrix/source/radial_function_set_kokkos.hpp
@@ -13,12 +13,15 @@ public:
     RadialFunctionSetKokkos(
         double h,
         std::vector<std::vector<std::vector<double>>> node_values,
-        std::vector<std::vector<std::vector<double>>> node_derivatives);
+        std::vector<std::vector<std::vector<double>>> node_derivatives,
+        double x0 = 0.0);
     void evaluate(
         const int num_nodes,
         Kokkos::View<const int*> node_types,
         Kokkos::View<const int*> num_neigh,
         Kokkos::View<const int*> neigh_types,
+        Kokkos::View<const int*> type_to_active,
+        int num_active_types,
         Kokkos::View<const double*> r,
         Kokkos::View<Precision**,Kokkos::LayoutRight> R,
         Kokkos::View<Precision**,Kokkos::LayoutRight> R_deriv) const;
@@ -26,6 +29,7 @@ public:
 private:
 
     double h;
+    double x0;
     int num_edge_types;
     int num_functions;
     int num_nodes;

--- a/libsymmetrix/source/tools_kokkos.cpp
+++ b/libsymmetrix/source/tools_kokkos.cpp
@@ -10,7 +10,6 @@
 void _init_kokkos()
 {
     Kokkos::InitializationSettings settings;
-    settings.set_num_threads(1);
     settings.set_disable_warnings(true);
     settings.set_map_device_id_by("random");
     Kokkos::initialize(settings);

--- a/pair_symmetrix/README.md
+++ b/pair_symmetrix/README.md
@@ -11,10 +11,30 @@ You will need a Python environment with a compatible `mace` module installed.
 The appropriate LAMMPS pair style commands are
 ```
 pair_style    symmetrix/mace
-pair_coeff    * * my-mace-1-8.json H O
+pair_coeff    * * my-mace-universal.json H O
 ```
 where the final `H O` assumes that `H` and `O` correspond to LAMMPS
-types `1` and `2`, respectively.
+types `1` and `2`, respectively. A compact universal JSON can be reused by a
+different input with another element mapping; active radial tables are built
+once during `pair_coeff` for that mapping.
+
+Compact universal files use Symmetrix format version 2 and require an updated
+pair style. Existing unversioned version 1 JSON remains supported. When an
+artifact must also work with an older Symmetrix/LAMMPS installation, generate
+it with `symmetrix_extract_mace --radial-format pair-splines` and an explicit
+element subset.
+
+For MACEField JSON models, use the Kokkos pair style with an explicit
+uniform electric field:
+```
+pair_style    symmetrix/mace/kk electric_field 0.01 0.0 0.0
+pair_coeff    * * my-macefield-universal.json Al N
+```
+Equivalently, LAMMPS can add the `/kk` suffix when launched with `-sf kk`.
+The field is currently a static graph-level vector in the active LAMMPS
+unit system. Per-atom fields, time-dependent fields, field-response
+properties, non-Kokkos MACEField LAMMPS runs, and atomic virials are not
+yet supported.
 
 ### Building LAMMPS
 

--- a/pair_symmetrix/pair_symmetrix_mace.cpp
+++ b/pair_symmetrix/pair_symmetrix_mace.cpp
@@ -115,6 +115,8 @@ void PairSymmetrixMACE::settings(int narg, char **arg)
 void PairSymmetrixMACE::coeff(int narg, char **arg)
 {
   if (!allocated) allocate();
+  if (narg != atom->ntypes + 3)
+    error->all(FLERR, "Incorrect args for pair coefficients");
 
   utils::logmesg(lmp, "Loading MACE model from \'{}\' ... ", arg[2]);
   mace = std::make_unique<MACE>(arg[2]);
@@ -137,6 +139,7 @@ void PairSymmetrixMACE::coeff(int narg, char **arg)
                    i-2, arg[i], mace_index);
     mace_types.push_back(mace_index);
   }
+  mace->prepare_active_types(mace_types);
 
   // set message size
   if (mode == "mpi_message_passing") {

--- a/pair_symmetrix/pair_symmetrix_mace_kokkos.cpp
+++ b/pair_symmetrix/pair_symmetrix_mace_kokkos.cpp
@@ -32,6 +32,7 @@
 #include "neigh_request.h"
 
 #include <algorithm>
+#include <stdexcept>
 
 using namespace LAMMPS_NS;
 
@@ -48,6 +49,7 @@ PairSymmetrixMACEKokkos<DeviceType, Precision>::PairSymmetrixMACEKokkos(LAMMPS *
   no_virial_fdotr_compute = 1;
   comm_forward = 0;  // possibly changed below
   comm_reverse = 0;  // possibly changed below
+  electric_field_set = false;
 
   kokkosable = 1;
   reverse_comm_device = 1;
@@ -110,14 +112,35 @@ void PairSymmetrixMACEKokkos<DeviceType, Precision>::allocate()
 template<class DeviceType, typename Precision>
 void PairSymmetrixMACEKokkos<DeviceType, Precision>::settings(int narg, char **arg)
 {
-  if (narg == 0) {
-    mode = (comm->nprocs == 1) ? "no_domain_decomposition" : "mpi_message_passing";
-  } else if (narg == 1) {
-    mode = std::string(arg[0]);
-    if (mode != "no_domain_decomposition" and mode != "mpi_message_passing" and mode != "no_mpi_message_passing")
-      error->all(FLERR, "The command \'pair_style symmetrix/mace/kk {}\' is invalid", mode);
-  } else {
-    error->all(FLERR, "Too many pair_style arguments for symmetrix/mace/kk");
+  mode = (comm->nprocs == 1) ? "no_domain_decomposition" : "mpi_message_passing";
+  electric_field_set = false;
+
+  for (int i=0; i<narg; ++i) {
+    const std::string token(arg[i]);
+    if (token == "no_domain_decomposition" || token == "mpi_message_passing" || token == "no_mpi_message_passing") {
+      mode = token;
+    } else if (token == "electric_field") {
+      if (i+3 >= narg)
+        error->all(FLERR, "pair_style symmetrix/mace/kk electric_field requires three components");
+      std::array<double,3> field_values;
+      try {
+        field_values[0] = std::stod(arg[i+1]);
+        field_values[1] = std::stod(arg[i+2]);
+        field_values[2] = std::stod(arg[i+3]);
+      } catch (const std::exception&) {
+        error->all(FLERR, "pair_style symmetrix/mace/kk electric_field components must be numeric");
+      }
+      electric_field = Kokkos::View<double*>("symmetrix_mace_electric_field", 3);
+      auto h_electric_field = Kokkos::create_mirror_view(electric_field);
+      h_electric_field(0) = field_values[0];
+      h_electric_field(1) = field_values[1];
+      h_electric_field(2) = field_values[2];
+      Kokkos::deep_copy(electric_field, h_electric_field);
+      electric_field_set = true;
+      i += 3;
+    } else {
+      error->all(FLERR, "The command \'pair_style symmetrix/mace/kk {}\' is invalid", token);
+    }
   }
 
   if (mode == "no_domain_decomposition" and comm->nprocs != 1)
@@ -132,15 +155,21 @@ template<class DeviceType, typename Precision>
 void PairSymmetrixMACEKokkos<DeviceType, Precision>::coeff(int narg, char **arg)
 {
   if (!allocated) allocate();
+  if (narg != atom->ntypes + 3)
+    error->all(FLERR, "Incorrect args for pair coefficients");
 
   utils::logmesg(lmp, "Loading MACEKokkos model from \'{}\' ... ", arg[2]);
   mace = std::make_unique<MACEKokkos<Precision>>(arg[2]);
   utils::logmesg(lmp, "success\n");
+  if (mace->has_field_coupling && !electric_field_set)
+    error->all(FLERR, "MACEField models require pair_style symmetrix/mace/kk electric_field Ex Ey Ez");
 
   // extract atomic numbers from pair_coeff
-  mace_types = Kokkos::View<int*>("mace_types", mace->atomic_numbers.size());
-  auto h_mace_types = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), mace_types);
+  mace_types = Kokkos::View<int*>("mace_types", atom->ntypes);
+  auto h_mace_types = Kokkos::create_mirror_view(mace_types);
   auto h_mace_atomic_numbers = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), mace->atomic_numbers);
+  auto active_mace_types = std::vector<int>();
+  active_mace_types.reserve(atom->ntypes);
   for (int i=3; i<narg; ++i) {
     // find atomic number for element in arg[i]
     auto iter1 = std::find(periodic_table.begin(), periodic_table.end(), arg[i]);
@@ -152,10 +181,14 @@ void PairSymmetrixMACEKokkos<DeviceType, Precision>::coeff(int narg, char **arg)
     for (int j=0; j<mace->atomic_numbers.size(); ++j)
         if (h_mace_atomic_numbers(j) == atomic_number)
             mace_index = j;
+    if (mace_index < 0)
+      error->all(FLERR, "Problem matching LAMMPS types to MACEKokkos types.");
     utils::logmesg(lmp, "  mapping LAMMPS type {} ({}) to MACEKokkos type {}\n",
                    i-2, arg[i], mace_index);
     h_mace_types(i-3) = mace_index;
+    active_mace_types.push_back(mace_index);
   }
+  mace->prepare_active_types(active_mace_types);
   Kokkos::deep_copy(mace_types, h_mace_types);
 
   // set message size
@@ -487,7 +520,11 @@ void PairSymmetrixMACEKokkos<DeviceType, Precision>::compute_no_domain_decomposi
       }
   });
 
-  mace->compute_node_energies_forces(num_nodes, node_types, num_neigh, neigh_indices, neigh_types, xyz, r);
+  if (mace->has_field_coupling)
+    mace->compute_node_energies_forces_field(
+      num_nodes, node_types, num_neigh, neigh_indices, neigh_types, xyz, r, electric_field);
+  else
+    mace->compute_node_energies_forces(num_nodes, node_types, num_neigh, neigh_indices, neigh_types, xyz, r);
 
   if (eflag_global) {
     auto node_energies = mace->node_energies;
@@ -710,11 +747,15 @@ void PairSymmetrixMACEKokkos<DeviceType, Precision>::compute_mpi_message_passing
   mace->compute_A0(num_nodes, node_types, num_neigh, neigh_types);
   mace->compute_A0_scaled(num_nodes, node_types, num_neigh, neigh_types, r);
   mace->compute_M0(num_nodes, node_types);
-  mace->compute_H1(num_nodes);
+  if (mace->has_field_coupling)
+    mace->compute_H1_product(num_nodes);
+  else
+    mace->compute_H1(num_nodes);
 
   // sort H1 contributions by i (rather than ii)
-  if (H1.extent(0) < k_list->inum+atom->nghost)
-    Kokkos::realloc(H1, (k_list->inum+atom->nghost), mace->num_LM, mace->num_channels);
+  const int num_h1_nodes = k_list->inum + atom->nghost;
+  if (H1.extent(0) < num_h1_nodes)
+    Kokkos::realloc(H1, num_h1_nodes, mace->num_LM, mace->num_channels);
   auto num_LM = mace->num_LM;
   auto num_channels = mace->num_channels;
   auto mace_H1 = mace->H1;
@@ -729,6 +770,10 @@ void PairSymmetrixMACEKokkos<DeviceType, Precision>::compute_mpi_message_passing
   comm->forward_comm(this);
   Kokkos::fence();
   mace->H1 = H1;
+  if (mace->has_field_coupling) {
+    mace->compute_field_H1(num_h1_nodes, electric_field);
+    mace->compute_H1_linear_up(num_h1_nodes);
+  }
 
   mace->compute_R1(num_nodes, node_types, num_neigh, neigh_types, r);
   mace->compute_Phi1(num_nodes, num_neigh, neigh_indices);
@@ -745,12 +790,19 @@ void PairSymmetrixMACEKokkos<DeviceType, Precision>::compute_mpi_message_passing
   mace->reverse_A1(num_nodes);
   mace->reverse_Phi1(num_nodes, num_neigh, neigh_indices, xyz, r, false, false);
 
+  if (mace->has_field_coupling) {
+    mace->reverse_H1_linear_up(num_h1_nodes);
+    mace->reverse_field_H1(num_h1_nodes, electric_field);
+  }
   H1_adj = mace->H1_adj;
   Kokkos::fence();
   comm->reverse_comm(this);
   Kokkos::fence();
 
-  mace->reverse_H1(num_nodes);
+  if (mace->has_field_coupling)
+    mace->reverse_H1_product(num_nodes);
+  else
+    mace->reverse_H1(num_nodes);
   mace->reverse_M0(num_nodes, node_types);
   mace->reverse_A0_scaled(num_nodes, node_types, num_neigh, neigh_types, xyz, r);
   mace->reverse_A0(num_nodes, node_types, num_neigh, neigh_types, xyz, r);
@@ -1061,7 +1113,13 @@ void PairSymmetrixMACEKokkos<DeviceType, Precision>::compute_no_mpi_message_pass
   mace->compute_A0(num_local_nodes+num_ghost_nodes, node_types, num_neigh, neigh_types);
   mace->compute_A0_scaled(num_local_nodes+num_ghost_nodes, node_types, num_neigh, neigh_types, r);
   mace->compute_M0(num_local_nodes+num_ghost_nodes, node_types);
-  mace->compute_H1(num_local_nodes+num_ghost_nodes);
+  if (mace->has_field_coupling) {
+    mace->compute_H1_product(num_local_nodes+num_ghost_nodes);
+    mace->compute_field_H1(num_local_nodes+num_ghost_nodes, electric_field);
+    mace->compute_H1_linear_up(num_local_nodes+num_ghost_nodes);
+  } else {
+    mace->compute_H1(num_local_nodes+num_ghost_nodes);
+  }
 
   mace->compute_R1(num_local_nodes, node_types, num_neigh, neigh_types, r);
   mace->compute_Phi1(num_local_nodes, num_neigh, neigh_ii_indices);
@@ -1078,7 +1136,13 @@ void PairSymmetrixMACEKokkos<DeviceType, Precision>::compute_no_mpi_message_pass
   mace->reverse_A1(num_local_nodes);
   mace->reverse_Phi1(num_local_nodes, num_neigh, neigh_ii_indices, xyz, r, false, false);
 
-  mace->reverse_H1(num_local_nodes+num_ghost_nodes);
+  if (mace->has_field_coupling) {
+    mace->reverse_H1_linear_up(num_local_nodes+num_ghost_nodes);
+    mace->reverse_field_H1(num_local_nodes+num_ghost_nodes, electric_field);
+    mace->reverse_H1_product(num_local_nodes+num_ghost_nodes);
+  } else {
+    mace->reverse_H1(num_local_nodes+num_ghost_nodes);
+  }
   mace->reverse_M0(num_local_nodes+num_ghost_nodes, node_types);
   mace->reverse_A0_scaled(num_local_nodes+num_ghost_nodes, node_types, num_neigh, neigh_types, xyz, r);
   mace->reverse_A0(num_local_nodes+num_ghost_nodes, node_types, num_neigh, neigh_types, xyz, r);

--- a/pair_symmetrix/pair_symmetrix_mace_kokkos.h
+++ b/pair_symmetrix/pair_symmetrix_mace_kokkos.h
@@ -69,8 +69,10 @@ class PairSymmetrixMACEKokkos : public Pair, public KokkosBase {
 
  protected:
   std::string mode;
+  bool electric_field_set;
   std::unique_ptr<MACEKokkos<Precision>> mace;
   Kokkos::View<int*> mace_types;
+  Kokkos::View<double*> electric_field;
   Kokkos::View<Precision***,Kokkos::LayoutRight> H1, H1_adj;
 
   // neighbor list variables

--- a/pair_symmetrix/test/test_pair_symmetrix_macefield.py
+++ b/pair_symmetrix/test/test_pair_symmetrix_macefield.py
@@ -1,0 +1,196 @@
+import hashlib
+import json
+import os
+from pathlib import Path
+from urllib.error import URLError
+from urllib.request import urlretrieve
+
+import numpy as np
+import pytest
+
+try:
+    from lammps import lammps
+except ImportError as exc:
+    pytest.skip(
+        f"LAMMPS Python module is not available: {exc}", allow_module_level=True
+    )
+
+try:
+    from ase.build import bulk
+    from ase.neighborlist import neighbor_list
+    from symmetrix import symmetrix as native_symmetrix
+    from symmetrix.extract_mace_data import extract_mace_data
+except ImportError as exc:
+    pytest.skip(
+        f"MACEField test dependencies are not available: {exc}", allow_module_level=True
+    )
+
+
+MODEL_FILENAME = "MACEField-MH-0-omat-dielectric.model"
+MODEL_URL = (
+    "https://github.com/mdi-group/mace-field/releases/download/1.0.2/" + MODEL_FILENAME
+)
+MODEL_SHA256 = "f92e043aaf2cd8879919db8452503553fe7b608cb749d8d169dd96d4aa094aa2"
+
+
+def skip_or_fail(message):
+    if os.environ.get("CI"):
+        pytest.fail(message)
+    pytest.skip(message)
+
+
+def file_sha256(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as model_file:
+        for chunk in iter(lambda: model_file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def macefield_model_path():
+    override = os.environ.get("SYMMETRIX_MACEFIELD_MODEL")
+    if override:
+        path = Path(override).expanduser()
+        if not path.exists():
+            skip_or_fail(f"SYMMETRIX_MACEFIELD_MODEL points to a missing file: {path}")
+        return path
+
+    cache_root = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
+    path = cache_root / "symmetrix" / "test-models" / MODEL_FILENAME
+    if path.exists():
+        if file_sha256(path) == MODEL_SHA256:
+            return path
+        path.unlink()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        urlretrieve(MODEL_URL, path)
+    except (OSError, URLError) as exc:
+        if path.exists():
+            path.unlink()
+        skip_or_fail(f"Could not download MACEField example model: {exc}")
+    if file_sha256(path) != MODEL_SHA256:
+        path.unlink()
+        skip_or_fail(f"Downloaded MACEField model failed SHA-256 verification: {path}")
+    return path
+
+
+@pytest.fixture(scope="module")
+def macefield_json_path(tmp_path_factory):
+    output_path = tmp_path_factory.mktemp("lammps-macefield-json") / "macefield.json"
+    data = extract_mace_data(
+        macefield_model_path(),
+        species=[7, 8, 12, 13],
+        head="mp-dielectric",
+    )
+    output_path.write_text(json.dumps(data))
+    return output_path
+
+
+@pytest.mark.parametrize(
+    "pair_style",
+    [
+        "symmetrix/mace/kk electric_field 0.01 0.0 0.0 no_domain_decomposition",
+        "symmetrix/mace/kk electric_field 0.01 0.0 0.0 no_mpi_message_passing",
+    ],
+)
+@pytest.mark.parametrize(
+    "formula, crystal, lattice_kwargs, symbols, masses",
+    [
+        (
+            "AlN",
+            "wurtzite",
+            {"a": 3.112, "c": 4.982},
+            ("Al", "N"),
+            (26.9815385, 14.0067),
+        ),
+        ("MgO", "rocksalt", {"a": 4.21}, ("Mg", "O"), (24.305, 15.999)),
+    ],
+    ids=("AlN", "MgO"),
+)
+def test_lammps_kokkos_macefield_energy_forces_match_native(
+    macefield_json_path,
+    pair_style,
+    formula,
+    crystal,
+    lattice_kwargs,
+    symbols,
+    masses,
+):
+    atoms = bulk(formula, crystal, **lattice_kwargs)
+    atoms.set_pbc(False)
+    atoms.center(vacuum=6.0)
+    electric_field = np.array([0.01, 0.0, 0.0], dtype=np.float64)
+
+    native = native_symmetrix.MACE(str(macefield_json_path))
+    atomic_numbers = atoms.get_atomic_numbers().tolist()
+    mace_atomic_numbers = native.atomic_numbers
+    i_list, j_list, r, xyz = neighbor_list("ijdD", atoms, native.r_cut)
+    num_nodes = len(atoms)
+    node_types = np.asarray(
+        [mace_atomic_numbers.index(atomic_numbers[i]) for i in range(num_nodes)],
+        dtype=np.int32,
+    )
+    num_neigh = np.asarray(np.bincount(j_list, minlength=num_nodes), dtype=np.int32)
+    neigh_types = np.asarray(
+        [mace_atomic_numbers.index(atomic_numbers[j]) for j in j_list], dtype=np.int32
+    )
+    neigh_indices = np.asarray(j_list, dtype=np.int32)
+    native.compute_node_energies_forces_field(
+        num_nodes,
+        node_types,
+        num_neigh,
+        neigh_indices,
+        neigh_types,
+        xyz.reshape(-1),
+        r,
+        electric_field,
+    )
+
+    expected_energy = np.sum(native.node_energies)
+    pair_forces = np.asarray(native.node_forces).reshape((-1, 3))[: len(i_list), :]
+    expected_forces = np.zeros((num_nodes, 3))
+    for component in range(3):
+        expected_forces[:, component] = np.bincount(
+            j_list, weights=pair_forces[:, component], minlength=num_nodes
+        ) - np.bincount(i_list, weights=pair_forces[:, component], minlength=num_nodes)
+
+    cell_lengths = atoms.cell.lengths()
+    create_atoms = "\n".join(
+        "            create_atoms    {} single {:.12f} {:.12f} {:.12f} units box".format(
+            symbols.index(symbol) + 1,
+            *position,
+        )
+        for symbol, position in zip(atoms.get_chemical_symbols(), atoms.positions)
+    )
+
+    lmp = lammps(cmdargs=["-screen", "none", "-k", "on", "-sf", "kk"])
+    try:
+        lmp.commands_string(
+            f"""
+            clear
+            units           metal
+            boundary        f f f
+            atom_style      atomic
+            atom_modify     map yes sort 0 0
+            newton          on
+
+            region          box block 0.0 {cell_lengths[0]} 0.0 {cell_lengths[1]} 0.0 {cell_lengths[2]}
+            create_box      2 box
+{create_atoms}
+            mass            1 {masses[0]}
+            mass            2 {masses[1]}
+
+            pair_style      {pair_style}
+            pair_coeff      * * {macefield_json_path} {symbols[0]} {symbols[1]}
+
+            run 0
+            """
+        )
+
+        actual_energy = lmp.get_thermo("pe")
+        actual_forces = lmp.numpy.extract_atom("f", nelem=num_nodes, dim=3).copy()
+    finally:
+        lmp.close()
+
+    assert actual_energy == pytest.approx(expected_energy, abs=1e-6)
+    assert np.allclose(actual_forces, expected_forces, atol=1e-5, rtol=1e-5)

--- a/symmetrix/README.md
+++ b/symmetrix/README.md
@@ -42,11 +42,60 @@ pip install ".[mace]"
 Then use:
 
 ```
-symmetrix_extract_mace --model my-mace.model --atomic-numbers 1 8
+symmetrix_extract_mace --model my-mace.model
 ```
 from the command line to extract a `.json` file from a Torch-based model.
-The result will be `my-mace-1-8.json`, and this model is only suitable
-for simulations involving H and O.
+The default compact output is `my-mace-universal.json`. It retains every
+element in the checkpoint and can be reused across compositions without
+conversion. At runtime, Symmetrix materializes radial splines only for the
+elements present in the current structure.
+
+To make a smaller compact artifact, select a subset explicitly:
+```
+symmetrix_extract_mace --model my-mace.model --atomic-numbers 1 8
+```
+This produces `my-mace-1-8.json`, which is suitable only for H/O structures.
+
+For multi-head models, choose the head explicitly:
+```
+symmetrix_extract_mace --model my-mace.model --head mp-dielectric
+```
+
+Compact files use Symmetrix format version 2. The spline resolution used for
+the transient active-composition cache defaults to 256 nodes and can be set
+with `--num-spline-points`. To generate the previous pair-table format, provide
+an explicit element list and request it directly:
+```
+symmetrix_extract_mace --model my-mace.model \
+    --atomic-numbers 1 8 \
+    --radial-format pair-splines
+```
+
+#### Backward compatibility
+
+Existing unversioned JSON artifacts remain supported and are interpreted as
+format version 1. Compact version 2 is the new converter default, including
+when an explicit species subset is provided. Older Symmetrix installations
+cannot read version 2 artifacts.
+
+To generate version 1 data for an older reader or for code that consumes the
+legacy `radial_spline_*` keys, request pair splines explicitly. The equivalent
+Python API is:
+
+```python
+from symmetrix.extract_mace_data import extract_mace_data
+
+data = extract_mace_data(
+    "my-mace.model",
+    species=[1, 8],
+    radial_format="pair-splines",
+)
+```
+
+An explicit species subset is strongly recommended for version 1 output
+because persisted pair tables scale quadratically with the number of retained
+elements. Updated Symmetrix readers support both unversioned version 1 and
+compact version 2 files.
 
 ### ASE Calculator
 
@@ -54,5 +103,191 @@ One can import the ASE calculator with
 ```
 from symmetrix import Symmetrix
 ```
+MACEField `.json` models can be evaluated with `use_kokkos=True` when
+Symmetrix is built with Kokkos support. In the ASE calculator this path
+supports field-aware energies, forces, polarization, Born effective charges,
+and polarizability for graph-level electric fields with either `dtype="float64"`
+or `dtype="float32"`. Double precision is recommended when response accuracy is
+more important than throughput.
 See [the source code](source/symmetrix/calculator.py) and [this test](test/test_symmetrix_calc.py)
 for additional details.
+
+### ASE Calculator with MACEField models
+
+MACEField models must be converted to Symmetrix JSON before they are passed to
+`Symmetrix`. Passing an original PyTorch MACEField `.model` checkpoint directly
+to the ASE calculator raises an error instead of silently delegating back to
+PyTorch.
+
+The `mace` extra above installs upstream MACE for standard checkpoints. To
+extract a MACEField checkpoint, install the MACEField implementation that
+defines the serialized model type:
+```
+pip install "mace-torch @ git+https://github.com/mdi-group/mace-field.git@1.0.2"
+```
+
+For the MACEField dielectric models, retain the dielectric head. One universal
+JSON can then be used for AlN, MgO, or any other composition whose elements are
+supported by the checkpoint:
+```
+symmetrix_extract_mace --model MACEField-MH-0-omat-dielectric.model \
+    --head mp-dielectric \
+    --output macefield-dielectric-universal.json
+```
+
+The output JSON is the file used by the ASE calculator. It can run through the
+double-precision native serial evaluator or through the field-aware Kokkos
+evaluator with `dtype="float64"` or `dtype="float32"`. Float32 field energies,
+forces, and analytical responses are supported with reduced numerical accuracy.
+
+The native field coupling currently supports first-layer scalar and vector
+features (`L_max=1`) with any channel count. The extractor rejects higher-order
+MACEField layouts rather than writing JSON that the native evaluators cannot
+load.
+
+The original PyTorch checkpoint does not need to be trained or saved in double
+precision. `symmetrix_extract_mace` loads the checkpoint and extracts the
+Symmetrix JSON data in double precision, so a float32-trained MACEField model
+can be converted once and evaluated using either Kokkos precision. Extraction
+in double precision does not recover precision absent from the original
+checkpoint, but it avoids further loss when `dtype="float64"` is selected.
+
+```python
+import numpy as np
+from ase.build import bulk
+from symmetrix import Symmetrix
+
+atoms = bulk("AlN", "wurtzite", a=3.112, c=4.982)
+atoms.info["electric_field"] = np.array([0.01, -0.02, 0.03])
+
+atoms.calc = Symmetrix(
+    "macefield-dielectric-universal.json",
+    use_kokkos=False,
+    dtype="float64",
+)
+
+energy = atoms.get_potential_energy()
+forces = atoms.get_forces()
+polarization = atoms.calc.get_property("polarization", atoms)
+becs = atoms.calc.get_property("becs", atoms)
+polarizability = atoms.calc.get_property("polarizability", atoms)
+```
+
+The calculator updates its active radial cache when the composition changes,
+so the same calculator instance can be assigned to a different supported
+structure. Evaluator instances are stateful and should not be used by
+concurrent host calls.
+
+The response properties are computed selectively. A plain
+`atoms.get_potential_energy()` or `atoms.get_forces()` call does not compute or
+cache BECs or polarizability, which avoids second-derivative overhead during
+molecular dynamics. Request response properties explicitly with
+`atoms.calc.get_property(...)`, or with ASE's multi-property API:
+```python
+results = atoms.get_properties(["energy", "forces", "polarization"])
+```
+
+Set the electric field the same way as in the upstream MACEField ASE
+calculator. Use a three-component vector in V/A:
+```python
+calc = Symmetrix(
+    "macefield.json",
+    electric_field=np.array([0.01, 0.0, 0.0]),
+    use_kokkos=False,
+    dtype="float64",
+)
+```
+
+The calculator-level field is a global override for every calculation. It can
+also be changed after construction, which is useful for finite-field dynamics:
+```python
+atoms.calc = calc
+calc.electric_field = [0.0, 0.0, Ez_t]
+```
+
+If no calculator-level override is set, Symmetrix reads the field from the ASE
+structure, following the upstream MACEField priority order:
+```python
+atoms.info["electric_field"] = [0.0, 0.0, 0.02]
+```
+or, for datasets that store the reference key:
+```python
+atoms.info["REF_electric_field"] = [0.0, 0.0, 0.02]
+```
+
+If none of these are set, Symmetrix uses a zero electric field.
+
+The MACEField response properties follow the upstream ASE calculator shapes:
+
+- `polarization`: shape `(3,)`
+- `becs`: shape `(natoms, 9)`, with the polarization and Cartesian components
+  flattened for each atom
+- `polarizability`: shape `(9,)`
+
+The native implementation computes polarization from the electric-field adjoint,
+polarizability from the analytic graph-field Hessian, and BECs from the analytic
+field derivative of forces. Finite differences are used in tests as an oracle,
+not in the production ASE path.
+
+Symmetrix also exposes upstream-compatible `node_energy`. ASE `energies` include
+the atomic reference terms, while `node_energy` subtracts those atomic reference
+energies to match the upstream MACEField calculator.
+
+### Combining MACEField with another ASE potential
+
+`FieldContributionCalculator` exposes the exact field-dependent part of a
+MACEField model. For every additive property `Q`, it evaluates the same model at
+the requested and zero electric fields and returns `Q(E) - Q(0)`. The correction
+therefore vanishes exactly at zero field while retaining polarization, BECs, and
+polarizability from the field-aware model.
+
+```python
+from symmetrix import FieldContributionCalculator, Symmetrix
+
+field_model = Symmetrix(
+    "macefield-dielectric.json",
+    use_kokkos=True,
+    dtype="float64",
+)
+atoms.calc = FieldContributionCalculator(field_model)
+
+field_energy = atoms.get_potential_energy()
+field_forces = atoms.get_forces()
+field_stress = atoms.get_stress()
+```
+
+`FieldAwareCalculator` adds that correction to any field-independent ASE
+calculator. The baseline supplies the zero-field energy landscape, forces,
+phonons, and elastic response, while MACEField supplies the finite-field
+coupling and electrical response.
+
+```python
+from mace.calculators import MACECalculator
+from symmetrix import FieldAwareCalculator, Symmetrix
+
+base = MACECalculator(model_paths=["more-accurate-mechanical.model"])
+field_model = Symmetrix(
+    "macefield-dielectric.json",
+    use_kokkos=True,
+    dtype="float64",
+)
+atoms.calc = FieldAwareCalculator(
+    base,
+    field_model,
+    electric_field=[0.01, -0.02, 0.03],
+)
+
+total_energy = atoms.get_potential_energy()
+total_forces = atoms.get_forces()
+total_stress = atoms.get_stress()
+born_effective_charges = atoms.calc.get_property("becs", atoms)
+
+# The override remains mutable for finite-field simulations.
+atoms.calc.electric_field = [0.02, -0.02, 0.03]
+```
+
+At nonzero field, an exact correction needs two MACEField evaluations for each
+new geometry, plus one baseline evaluation. The zero-field MACEField result is
+cached across field-only changes, and zero-field additive requests skip the
+MACEField evaluation entirely. The baseline must not contain its own electric
+field coupling, otherwise that coupling would be counted twice.

--- a/symmetrix/source/cpp/mace.cpp
+++ b/symmetrix/source/cpp/mace.cpp
@@ -6,24 +6,72 @@
 #include "mace.hpp"
 
 namespace py = pybind11;
+using ContiguousIntArray =
+    py::array_t<int, py::array::c_style | py::array::forcecast>;
+using ContiguousDoubleArray =
+    py::array_t<double, py::array::c_style | py::array::forcecast>;
+
+namespace {
+
+void prepare_active_types(
+    MACE& self,
+    const ContiguousIntArray& node_types,
+    const ContiguousIntArray& neigh_types)
+{
+    auto types = std::vector<int>();
+    types.reserve(self.atomic_numbers.size());
+    auto seen = std::vector<unsigned char>(self.atomic_numbers.size(), 0);
+    const auto append = [&] (const ContiguousIntArray& input) {
+        for (py::ssize_t index=0; index<input.size(); ++index) {
+            const int type = input.data()[index];
+            if (type < 0 || type >= static_cast<int>(seen.size())) {
+                types.push_back(type);
+            } else if (!seen[type]) {
+                seen[type] = 1;
+                types.push_back(type);
+            }
+        }
+    };
+    append(node_types);
+    append(neigh_types);
+    self.prepare_active_types(types);
+}
+
+}  // namespace
 
 void bind_mace(py::module_ &m)
 {
     py::class_<MACE>(m, "MACE")
         .def(py::init<std::string>())
         .def_readonly("atomic_numbers", &MACE::atomic_numbers)
+        .def_readonly("atomic_energies", &MACE::atomic_energies)
+        .def_readonly("active_atomic_numbers", &MACE::active_atomic_numbers)
+        .def("prepare_active_types",
+            [] (MACE& self, ContiguousIntArray node_types) {
+                self.prepare_active_types(
+                    std::span<const int>(node_types.data(), node_types.size()));
+            })
         .def_readonly("r_cut", &MACE::r_cut)
         .def_readwrite("node_forces", &MACE::node_forces)
         .def_readwrite("node_energies", &MACE::node_energies)
         .def_readwrite("H0_weights", &MACE::H0_weights)
         .def_readwrite("R0", &MACE::R0)
+        .def_readonly("R0_deriv", &MACE::R0_deriv)
         .def_readwrite("R1", &MACE::R1)
+        .def_readonly("R1_deriv", &MACE::R1_deriv)
         .def_readwrite("A0", &MACE::A0)
         .def_readwrite("A0_adj", &MACE::A0_adj)
         .def_readwrite("M0", &MACE::M0)
         .def_readwrite("M0_adj", &MACE::M0_adj)
         .def_readwrite("H1", &MACE::H1)
         .def_readwrite("H1_adj", &MACE::H1_adj)
+        .def_readwrite("has_field_coupling", &MACE::has_field_coupling)
+        .def_readwrite("H1_pre_field", &MACE::H1_pre_field)
+        .def_readwrite("field_feats_weight", &MACE::field_feats_weight)
+        .def_readwrite("field_linear_weight", &MACE::field_linear_weight)
+        .def_readwrite("electric_field_adj", &MACE::electric_field_adj)
+        .def_readwrite("electric_field_hessian", &MACE::electric_field_hessian)
+        .def_readwrite("electric_field_force_derivative", &MACE::electric_field_force_derivative)
         .def_readwrite("Phi1", &MACE::Phi1)
         .def_readwrite("Phi1_adj", &MACE::dPhi1)
         .def_readwrite("A1", &MACE::A1)
@@ -34,12 +82,13 @@ void bind_mace(py::module_ &m)
         .def_readwrite("H2_adj", &MACE::H2_adj)
         .def("compute_node_energies_forces",
             [](MACE& self, const int num_nodes,
-                           py::array_t<int> node_types,
-                           py::array_t<int> num_neigh,
-                           py::array_t<int> neigh_indices,
-                           py::array_t<int> neigh_types,
-                           py::array_t<double> xyz,
-                           py::array_t<double> r) {
+                           ContiguousIntArray node_types,
+                           ContiguousIntArray num_neigh,
+                           ContiguousIntArray neigh_indices,
+                           ContiguousIntArray neigh_types,
+                           ContiguousDoubleArray xyz,
+                           ContiguousDoubleArray r) {
+                prepare_active_types(self, node_types, neigh_types);
                 self.compute_node_energies_forces(
                            num_nodes,
                            std::span<const int>(node_types.data(), node_types.size()),
@@ -49,13 +98,74 @@ void bind_mace(py::module_ &m)
                            std::span<const double>(xyz.data(), xyz.size()),
                            std::span<const double>(r.data(), r.size()));
             })
+        .def("compute_node_energies_forces_field",
+            [](MACE& self, const int num_nodes,
+                           ContiguousIntArray node_types,
+                           ContiguousIntArray num_neigh,
+                           ContiguousIntArray neigh_indices,
+                           ContiguousIntArray neigh_types,
+                           ContiguousDoubleArray xyz,
+                           ContiguousDoubleArray r,
+                           ContiguousDoubleArray electric_field) {
+                prepare_active_types(self, node_types, neigh_types);
+                self.compute_node_energies_forces_field(
+                           num_nodes,
+                           std::span<const int>(node_types.data(), node_types.size()),
+                           std::span<const int>(num_neigh.data(), num_neigh.size()),
+                           std::span<const int>(neigh_indices.data(), neigh_indices.size()),
+                           std::span<const int>(neigh_types.data(), neigh_types.size()),
+                           std::span<const double>(xyz.data(), xyz.size()),
+                           std::span<const double>(r.data(), r.size()),
+                           std::span<const double>(electric_field.data(), electric_field.size()));
+            })
+        .def("compute_electric_field_hessian",
+            [](MACE& self, const int num_nodes,
+                           ContiguousIntArray node_types,
+                           ContiguousIntArray num_neigh,
+                           ContiguousIntArray neigh_indices,
+                           ContiguousIntArray neigh_types,
+                           ContiguousDoubleArray xyz,
+                           ContiguousDoubleArray r,
+                           ContiguousDoubleArray electric_field) {
+                prepare_active_types(self, node_types, neigh_types);
+                self.compute_electric_field_hessian(
+                           num_nodes,
+                           std::span<const int>(node_types.data(), node_types.size()),
+                           std::span<const int>(num_neigh.data(), num_neigh.size()),
+                           std::span<const int>(neigh_indices.data(), neigh_indices.size()),
+                           std::span<const int>(neigh_types.data(), neigh_types.size()),
+                           std::span<const double>(xyz.data(), xyz.size()),
+                           std::span<const double>(r.data(), r.size()),
+                           std::span<const double>(electric_field.data(), electric_field.size()));
+            })
+        .def("compute_electric_field_force_derivative",
+            [](MACE& self, const int num_nodes,
+                           ContiguousIntArray node_types,
+                           ContiguousIntArray num_neigh,
+                           ContiguousIntArray neigh_indices,
+                           ContiguousIntArray neigh_types,
+                           ContiguousDoubleArray xyz,
+                           ContiguousDoubleArray r,
+                           ContiguousDoubleArray electric_field) {
+                prepare_active_types(self, node_types, neigh_types);
+                self.compute_electric_field_force_derivative(
+                           num_nodes,
+                           std::span<const int>(node_types.data(), node_types.size()),
+                           std::span<const int>(num_neigh.data(), num_neigh.size()),
+                           std::span<const int>(neigh_indices.data(), neigh_indices.size()),
+                           std::span<const int>(neigh_types.data(), neigh_types.size()),
+                           std::span<const double>(xyz.data(), xyz.size()),
+                           std::span<const double>(r.data(), r.size()),
+                           std::span<const double>(electric_field.data(), electric_field.size()));
+            })
         .def("compute_R0",
             [] (MACE& self,
                     const int num_nodes,
-                    py::array_t<int> node_types,
-                    py::array_t<int> num_neigh,
-                    py::array_t<int> neigh_types,
-                    py::array_t<double> r) {
+                    ContiguousIntArray node_types,
+                    ContiguousIntArray num_neigh,
+                    ContiguousIntArray neigh_types,
+                    ContiguousDoubleArray r) {
+                prepare_active_types(self, node_types, neigh_types);
                 self.compute_R0(
                     num_nodes,
                     std::span<const int>(node_types.data(), node_types.size()),
@@ -66,10 +176,11 @@ void bind_mace(py::module_ &m)
         .def("compute_R1",
             [] (MACE& self,
                     const int num_nodes,
-                    py::array_t<int> node_types,
-                    py::array_t<int> num_neigh,
-                    py::array_t<int> neigh_types,
-                    py::array_t<double> r) {
+                    ContiguousIntArray node_types,
+                    ContiguousIntArray num_neigh,
+                    ContiguousIntArray neigh_types,
+                    ContiguousDoubleArray r) {
+                prepare_active_types(self, node_types, neigh_types);
                 self.compute_R1(
                     num_nodes,
                     std::span<const int>(node_types.data(), node_types.size()),
@@ -78,15 +189,15 @@ void bind_mace(py::module_ &m)
                     std::span<const double>(r.data(), r.size()));
             })
         .def("compute_Y",
-            [](MACE& self, py::array_t<double> xyz) {
+            [](MACE& self, ContiguousDoubleArray xyz) {
                 self.compute_Y(std::span<const double>(xyz.data(), xyz.size()));
             })
         .def("compute_A0",
             [](MACE& self,
                     const int num_nodes,
-                    py::array_t<int> node_types,
-                    py::array_t<int> num_neigh,
-                    py::array_t<int> neigh_types) {
+                    ContiguousIntArray node_types,
+                    ContiguousIntArray num_neigh,
+                    ContiguousIntArray neigh_types) {
                 self.compute_A0(
                     num_nodes,
                     std::span<const int>(node_types.data(), node_types.size()),
@@ -95,11 +206,11 @@ void bind_mace(py::module_ &m)
             })
         .def("reverse_A0",
             [](MACE& self, const int num_nodes,
-                           py::array_t<int> node_types,
-                           py::array_t<int> num_neigh,
-                           py::array_t<int> neigh_types,
-                           py::array_t<double> xyz,
-                           py::array_t<double> r) {
+                           ContiguousIntArray node_types,
+                           ContiguousIntArray num_neigh,
+                           ContiguousIntArray neigh_types,
+                           ContiguousDoubleArray xyz,
+                           ContiguousDoubleArray r) {
                 self.reverse_A0(num_nodes,
                                 std::span<const int>(node_types.data(), node_types.size()),
                                 std::span<const int>(num_neigh.data(), num_neigh.size()),
@@ -110,10 +221,11 @@ void bind_mace(py::module_ &m)
         .def("compute_A0_scaled",
             [](MACE& self,
                     const int num_nodes,
-                    py::array_t<int> node_types,
-                    py::array_t<int> num_neigh,
-                    py::array_t<int> neigh_types,
-                    py::array_t<double> r) {
+                    ContiguousIntArray node_types,
+                    ContiguousIntArray num_neigh,
+                    ContiguousIntArray neigh_types,
+                    ContiguousDoubleArray r) {
+                prepare_active_types(self, node_types, neigh_types);
                 self.compute_A0_scaled(
                     num_nodes,
                     std::span<const int>(node_types.data(), node_types.size()),
@@ -124,11 +236,12 @@ void bind_mace(py::module_ &m)
         .def("reverse_A0_scaled",
             [](MACE& self,
                     const int num_nodes,
-                    py::array_t<int> node_types,
-                    py::array_t<int> num_neigh,
-                    py::array_t<int> neigh_types,
-                    py::array_t<double> xyz,
-                    py::array_t<double> r) {
+                    ContiguousIntArray node_types,
+                    ContiguousIntArray num_neigh,
+                    ContiguousIntArray neigh_types,
+                    ContiguousDoubleArray xyz,
+                    ContiguousDoubleArray r) {
+                prepare_active_types(self, node_types, neigh_types);
                 self.reverse_A0_scaled(
                     num_nodes,
                     std::span<const int>(node_types.data(), node_types.size()),
@@ -139,32 +252,44 @@ void bind_mace(py::module_ &m)
             })
         .def("compute_M0",
             [](MACE& self, const int num_nodes,
-                           py::array_t<int> node_types) {
+                           ContiguousIntArray node_types) {
                 self.compute_M0(num_nodes,
                                 std::span<const int>(node_types.data(), node_types.size()));
             })
         .def("reverse_M0",
             [](MACE& self, const int num_nodes,
-                           py::array_t<int> node_types) {
+                           ContiguousIntArray node_types) {
                 self.reverse_M0(num_nodes,
                                 std::span<const int>(node_types.data(), node_types.size()));
             })
         .def("compute_H1", &MACE::compute_H1)
         .def("reverse_H1", &MACE::reverse_H1)
+        .def("compute_field_H1",
+            [](MACE& self, const int num_nodes, ContiguousDoubleArray electric_field) {
+                self.compute_field_H1(
+                    num_nodes,
+                    std::span<const double>(electric_field.data(), electric_field.size()));
+            })
+        .def("reverse_field_H1",
+            [](MACE& self, const int num_nodes, ContiguousDoubleArray electric_field) {
+                self.reverse_field_H1(
+                    num_nodes,
+                    std::span<const double>(electric_field.data(), electric_field.size()));
+            })
         .def("compute_Phi1",
             [](MACE& self, const int num_nodes,
-                           py::array_t<int> num_neigh,
-                           py::array_t<int> neigh_indices) {
+                           ContiguousIntArray num_neigh,
+                           ContiguousIntArray neigh_indices) {
                 self.compute_Phi1(num_nodes,
                                   std::span<const int>(num_neigh.data(), num_neigh.size()),
                                   std::span<const int>(neigh_indices.data(), neigh_indices.size()));
             })
         .def("reverse_Phi1",
             [](MACE& self, const int num_nodes,
-                           py::array_t<int> num_neigh,
-                           py::array_t<int> neigh_indices,
-                           py::array_t<double> xyz,
-                           py::array_t<double> r,
+                           ContiguousIntArray num_neigh,
+                           ContiguousIntArray neigh_indices,
+                           ContiguousDoubleArray xyz,
+                           ContiguousDoubleArray r,
                            bool zero_dxyz,
                            bool zero_H1_adj) {
                 self.reverse_Phi1(num_nodes,
@@ -180,10 +305,11 @@ void bind_mace(py::module_ &m)
         .def("compute_A1_scaled",
             [](MACE& self,
                     const int num_nodes,
-                    py::array_t<int> node_types,
-                    py::array_t<int> num_neigh,
-                    py::array_t<int> neigh_types,
-                    py::array_t<double> r) {
+                    ContiguousIntArray node_types,
+                    ContiguousIntArray num_neigh,
+                    ContiguousIntArray neigh_types,
+                    ContiguousDoubleArray r) {
+                prepare_active_types(self, node_types, neigh_types);
                 self.compute_A1_scaled(
                     num_nodes,
                     std::span<const int>(node_types.data(), node_types.size()),
@@ -194,11 +320,12 @@ void bind_mace(py::module_ &m)
         .def("reverse_A1_scaled",
             [](MACE& self,
                     const int num_nodes,
-                    py::array_t<int> node_types,
-                    py::array_t<int> num_neigh,
-                    py::array_t<int> neigh_types,
-                    py::array_t<double> xyz,
-                    py::array_t<double> r) {
+                    ContiguousIntArray node_types,
+                    ContiguousIntArray num_neigh,
+                    ContiguousIntArray neigh_types,
+                    ContiguousDoubleArray xyz,
+                    ContiguousDoubleArray r) {
+                prepare_active_types(self, node_types, neigh_types);
                 self.reverse_A1_scaled(
                     num_nodes,
                     std::span<const int>(node_types.data(), node_types.size()),
@@ -209,26 +336,26 @@ void bind_mace(py::module_ &m)
             })
         .def("compute_M1",
             [](MACE& self, const int num_nodes,
-                           py::array_t<int> node_types) {
+                           ContiguousIntArray node_types) {
                 self.compute_M1(num_nodes,
                                 std::span<const int>(node_types.data(), node_types.size()));
             })
 
         .def("reverse_M1",
             [](MACE& self, const int num_nodes,
-                           py::array_t<int> node_types) {
+                           ContiguousIntArray node_types) {
                 self.reverse_M1(num_nodes,
                                 std::span<const int>(node_types.data(), node_types.size()));
             })
         .def("compute_H2",
             [](MACE& self, const int num_nodes,
-                           py::array_t<int> node_types) {
+                           ContiguousIntArray node_types) {
                 self.compute_H2(num_nodes,
                                 std::span<const int>(node_types.data(), node_types.size()));
             })
         .def("reverse_H2",
             [](MACE& self, const int num_nodes,
-                           py::array_t<int> node_types,
+                           ContiguousIntArray node_types,
                            bool zero_H1_adj) {
                 self.reverse_H2(num_nodes,
                                 std::span<const int>(node_types.data(), node_types.size()),
@@ -236,7 +363,7 @@ void bind_mace(py::module_ &m)
             })
         .def("compute_readouts",
             [](MACE& self, const int num_nodes,
-                           py::array_t<int> node_types) {
+                           ContiguousIntArray node_types) {
                 self.compute_readouts(num_nodes,
                                       std::span<const int>(node_types.data(), node_types.size()));
             });

--- a/symmetrix/source/cpp/mace_kokkos.cpp
+++ b/symmetrix/source/cpp/mace_kokkos.cpp
@@ -7,15 +7,68 @@
 #include "mace_kokkos.hpp"
 
 namespace py = pybind11;
+using ContiguousIntArray =
+    py::array_t<int, py::array::c_style | py::array::forcecast>;
+using ContiguousDoubleArray =
+    py::array_t<double, py::array::c_style | py::array::forcecast>;
+
+template <typename Precision>
+void prepare_active_types(
+    MACEKokkos<Precision>& self,
+    const ContiguousIntArray& node_types)
+{
+    self.prepare_active_types(std::vector<int>(
+        node_types.data(), node_types.data()+node_types.size()));
+}
+
+template <typename Precision>
+void prepare_active_types(
+    MACEKokkos<Precision>& self,
+    const ContiguousIntArray& node_types,
+    const ContiguousIntArray& neigh_types)
+{
+    auto types = std::vector<int>();
+    types.reserve(self.atomic_numbers.size());
+    auto seen = std::vector<unsigned char>(self.atomic_numbers.size(), 0);
+    const auto append = [&] (const ContiguousIntArray& input) {
+        for (py::ssize_t index=0; index<input.size(); ++index) {
+            const int type = input.data()[index];
+            if (type < 0 || type >= static_cast<int>(seen.size())) {
+                types.push_back(type);
+            } else if (!seen[type]) {
+                seen[type] = 1;
+                types.push_back(type);
+            }
+        }
+    };
+    append(node_types);
+    append(neigh_types);
+    self.prepare_active_types(std::move(types));
+}
 
 template <typename Precision>
 void bind_mace_kokkos(py::module_ &m, const char* class_name)
 {
+    using ContiguousPrecisionArray =
+        py::array_t<Precision, py::array::c_style | py::array::forcecast>;
+
     py::class_<MACEKokkos<Precision>>(m, class_name)
         .def(py::init<std::string>())
         .def_property_readonly("atomic_numbers",
             [] (MACEKokkos<Precision>& self) {
                 return view2vector(self.atomic_numbers);
+            })
+        .def_property_readonly("atomic_energies",
+            [] (MACEKokkos<Precision>& self) {
+                return view2vector(self.atomic_energies);
+            })
+        .def_property_readonly("active_atomic_numbers",
+            [] (MACEKokkos<Precision>& self) {
+                return self.active_atomic_numbers;
+            })
+        .def("prepare_active_types",
+            [] (MACEKokkos<Precision>& self, ContiguousIntArray node_types) {
+                prepare_active_types(self, node_types);
             })
         .def_readonly("r_cut", &MACEKokkos<Precision>::r_cut)
         // node energies
@@ -23,7 +76,7 @@ void bind_mace_kokkos(py::module_ &m, const char* class_name)
             [] (MACEKokkos<Precision>& self) {
                 return view2vector(self.node_energies);
             },
-            [] (MACEKokkos<Precision>& self, py::array_t<double> node_energies) {
+            [] (MACEKokkos<Precision>& self, ContiguousDoubleArray node_energies) {
                 set_kokkos_view(self.node_energies, node_energies);
             })
         // partial forces
@@ -31,19 +84,33 @@ void bind_mace_kokkos(py::module_ &m, const char* class_name)
             [] (MACEKokkos<Precision>& self) {
                 return view2vector(self.node_forces);
             },
-            [] (MACEKokkos<Precision>& self, py::array_t<double> node_forces) {
+            [] (MACEKokkos<Precision>& self, ContiguousDoubleArray node_forces) {
                 set_kokkos_view(self.node_forces, node_forces);
+            })
+        .def_readonly("has_field_coupling", &MACEKokkos<Precision>::has_field_coupling)
+        .def_property_readonly("electric_field_adj",
+            [] (MACEKokkos<Precision>& self) {
+                return view2vector(self.electric_field_adj);
+            })
+        .def_property_readonly("electric_field_hessian",
+            [] (MACEKokkos<Precision>& self) {
+                return view2vector(self.electric_field_hessian);
+            })
+        .def_property_readonly("electric_field_force_derivative",
+            [] (MACEKokkos<Precision>& self) {
+                return view2vector(self.electric_field_force_derivative);
             })
         // node energies and forces
         .def("compute_node_energies_forces",
             [] (MACEKokkos<Precision>& self,
                     const int num_nodes,
-                    py::array_t<int> node_types,
-                    py::array_t<int> num_neigh,
-                    py::array_t<int> neigh_indices,
-                    py::array_t<int> neigh_types,
-                    py::array_t<double> xyz,
-                    py::array_t<double> r) {
+                    ContiguousIntArray node_types,
+                    ContiguousIntArray num_neigh,
+                    ContiguousIntArray neigh_indices,
+                    ContiguousIntArray neigh_types,
+                    ContiguousDoubleArray xyz,
+                    ContiguousDoubleArray r) {
+                prepare_active_types(self, node_types, neigh_types);
                 self.compute_node_energies_forces(
                     num_nodes,
                     create_kokkos_view("node_types", node_types),
@@ -53,22 +120,86 @@ void bind_mace_kokkos(py::module_ &m, const char* class_name)
                     create_kokkos_view("xyz", xyz),
                     create_kokkos_view("r", r));
             })
+        .def("compute_node_energies_forces_field",
+            [] (MACEKokkos<Precision>& self,
+                    const int num_nodes,
+                    ContiguousIntArray node_types,
+                    ContiguousIntArray num_neigh,
+                    ContiguousIntArray neigh_indices,
+                    ContiguousIntArray neigh_types,
+                    ContiguousDoubleArray xyz,
+                    ContiguousDoubleArray r,
+                    ContiguousDoubleArray electric_field) {
+                prepare_active_types(self, node_types, neigh_types);
+                self.compute_node_energies_forces_field(
+                    num_nodes,
+                    create_kokkos_view("node_types", node_types),
+                    create_kokkos_view("num_neigh", num_neigh),
+                    create_kokkos_view("neigh_indices", neigh_indices),
+                    create_kokkos_view("neigh_types", neigh_types),
+                    create_kokkos_view("xyz", xyz),
+                    create_kokkos_view("r", r),
+                    create_kokkos_view("electric_field", electric_field));
+            })
+        .def("compute_electric_field_hessian",
+            [] (MACEKokkos<Precision>& self,
+                    const int num_nodes,
+                    ContiguousIntArray node_types,
+                    ContiguousIntArray num_neigh,
+                    ContiguousIntArray neigh_indices,
+                    ContiguousIntArray neigh_types,
+                    ContiguousDoubleArray xyz,
+                    ContiguousDoubleArray r,
+                    ContiguousDoubleArray electric_field) {
+                prepare_active_types(self, node_types, neigh_types);
+                self.compute_electric_field_hessian(
+                    num_nodes,
+                    create_kokkos_view("node_types", node_types),
+                    create_kokkos_view("num_neigh", num_neigh),
+                    create_kokkos_view("neigh_indices", neigh_indices),
+                    create_kokkos_view("neigh_types", neigh_types),
+                    create_kokkos_view("xyz", xyz),
+                    create_kokkos_view("r", r),
+                    create_kokkos_view("electric_field", electric_field));
+            })
+        .def("compute_electric_field_force_derivative",
+            [] (MACEKokkos<Precision>& self,
+                    const int num_nodes,
+                    ContiguousIntArray node_types,
+                    ContiguousIntArray num_neigh,
+                    ContiguousIntArray neigh_indices,
+                    ContiguousIntArray neigh_types,
+                    ContiguousDoubleArray xyz,
+                    ContiguousDoubleArray r,
+                    ContiguousDoubleArray electric_field) {
+                prepare_active_types(self, node_types, neigh_types);
+                self.compute_electric_field_force_derivative(
+                    num_nodes,
+                    create_kokkos_view("node_types", node_types),
+                    create_kokkos_view("num_neigh", num_neigh),
+                    create_kokkos_view("neigh_indices", neigh_indices),
+                    create_kokkos_view("neigh_types", neigh_types),
+                    create_kokkos_view("xyz", xyz),
+                    create_kokkos_view("r", r),
+                    create_kokkos_view("electric_field", electric_field));
+            })
         // R0
         .def_property("R0",
             [] (MACEKokkos<Precision>& self) {
                 return view2vector(self.R0);
             },
-            [] (MACEKokkos<Precision>& self, py::array_t<Precision> R0) {
+            [] (MACEKokkos<Precision>& self, ContiguousPrecisionArray R0) {
                 const int total_num_neigh = R0.size()/((self.l_max+1)*self.num_channels);
                 set_kokkos_view(self.R0, R0, total_num_neigh, (self.l_max+1)*self.num_channels);
             })
         .def("compute_R0",
             [](MACEKokkos<Precision>& self,
                     const int num_nodes,
-                    py::array_t<int> node_types,
-                    py::array_t<int> num_neigh,
-                    py::array_t<int> neigh_types,
-                    py::array_t<double> r) {
+                    ContiguousIntArray node_types,
+                    ContiguousIntArray num_neigh,
+                    ContiguousIntArray neigh_types,
+                    ContiguousDoubleArray r) {
+                prepare_active_types(self, node_types, neigh_types);
                 self.compute_R0(
                     num_nodes,
                     create_kokkos_view("node_types", node_types),
@@ -81,7 +212,7 @@ void bind_mace_kokkos(py::module_ &m, const char* class_name)
             [] (MACEKokkos<Precision>& self) {
                 return view2vector(self.R1);
             },
-            [] (MACEKokkos<Precision>& self, py::array_t<Precision> R1) {
+            [] (MACEKokkos<Precision>& self, ContiguousPrecisionArray R1) {
                 const int num_le = self.Phi1_l.size();
                 const int total_num_neigh = R1.size()/(num_le*self.num_channels);
                 set_kokkos_view(self.R1, R1, total_num_neigh, num_le*self.num_channels);
@@ -89,10 +220,11 @@ void bind_mace_kokkos(py::module_ &m, const char* class_name)
         .def("compute_R1",
             [](MACEKokkos<Precision>& self,
                     const int num_nodes,
-                    py::array_t<int> node_types,
-                    py::array_t<int> num_neigh,
-                    py::array_t<int> neigh_types,
-                    py::array_t<double> r) {
+                    ContiguousIntArray node_types,
+                    ContiguousIntArray num_neigh,
+                    ContiguousIntArray neigh_types,
+                    ContiguousDoubleArray r) {
+                prepare_active_types(self, node_types, neigh_types);
                 self.compute_R1(
                     num_nodes,
                     create_kokkos_view("node_types", node_types),
@@ -103,7 +235,7 @@ void bind_mace_kokkos(py::module_ &m, const char* class_name)
         // Y
         .def("compute_Y",
             [] (MACEKokkos<Precision>& self,
-                    py::array_t<double> xyz) {
+                    ContiguousDoubleArray xyz) {
                 self.compute_Y(
                     create_kokkos_view("xyz", xyz));
             })
@@ -112,7 +244,7 @@ void bind_mace_kokkos(py::module_ &m, const char* class_name)
             [] (MACEKokkos<Precision>& self) {
                 return view2vector(self.A0);
             },
-            [] (MACEKokkos<Precision>& self, py::array_t<Precision> A0) {
+            [] (MACEKokkos<Precision>& self, ContiguousPrecisionArray A0) {
                 const int num_nodes = A0.size()/(self.num_lm*self.num_channels);
                 set_kokkos_view(self.A0, A0, num_nodes, self.num_lm, self.num_channels);
             })
@@ -120,16 +252,16 @@ void bind_mace_kokkos(py::module_ &m, const char* class_name)
             [] (MACEKokkos<Precision>& self) {
                 return view2vector(self.A0_adj);
             },
-            [] (MACEKokkos<Precision>& self, py::array_t<Precision> A0_adj) {
+            [] (MACEKokkos<Precision>& self, ContiguousPrecisionArray A0_adj) {
                 const int num_nodes = A0_adj.size()/(self.num_lm*self.num_channels);
                 set_kokkos_view(self.A0_adj, A0_adj, num_nodes, self.num_lm, self.num_channels);
             })
         .def("compute_A0",
             [] (MACEKokkos<Precision>& self,
                     int num_nodes,
-                    py::array_t<int> node_types,
-                    py::array_t<int> num_neigh,
-                    py::array_t<int> neigh_types) {
+                    ContiguousIntArray node_types,
+                    ContiguousIntArray num_neigh,
+                    ContiguousIntArray neigh_types) {
                 self.compute_A0(
                     num_nodes,
                     create_kokkos_view("node_types", node_types),
@@ -139,11 +271,11 @@ void bind_mace_kokkos(py::module_ &m, const char* class_name)
         .def("reverse_A0",
             [] (MACEKokkos<Precision>& self,
                     int num_nodes,
-                    py::array_t<int> node_types,
-                    py::array_t<int> num_neigh,
-                    py::array_t<int> neigh_types,
-                    py::array_t<double> xyz,
-                    py::array_t<double> r) {
+                    ContiguousIntArray node_types,
+                    ContiguousIntArray num_neigh,
+                    ContiguousIntArray neigh_types,
+                    ContiguousDoubleArray xyz,
+                    ContiguousDoubleArray r) {
                 self.reverse_A0(
                     num_nodes,
                     create_kokkos_view("node_types", node_types),
@@ -155,10 +287,11 @@ void bind_mace_kokkos(py::module_ &m, const char* class_name)
         .def("compute_A0_scaled",
             [](MACEKokkos<Precision>& self,
                     const int num_nodes,
-                    py::array_t<int> node_types,
-                    py::array_t<int> num_neigh,
-                    py::array_t<int> neigh_types,
-                    py::array_t<double> r) {
+                    ContiguousIntArray node_types,
+                    ContiguousIntArray num_neigh,
+                    ContiguousIntArray neigh_types,
+                    ContiguousDoubleArray r) {
+                prepare_active_types(self, node_types, neigh_types);
                 self.compute_A0_scaled(
                     num_nodes,
                     create_kokkos_view("node_types", node_types),
@@ -169,11 +302,12 @@ void bind_mace_kokkos(py::module_ &m, const char* class_name)
         .def("reverse_A0_scaled",
             [](MACEKokkos<Precision>& self,
                     const int num_nodes,
-                    py::array_t<int> node_types,
-                    py::array_t<int> num_neigh,
-                    py::array_t<int> neigh_types,
-                    py::array_t<double> xyz,
-                    py::array_t<double> r) {
+                    ContiguousIntArray node_types,
+                    ContiguousIntArray num_neigh,
+                    ContiguousIntArray neigh_types,
+                    ContiguousDoubleArray xyz,
+                    ContiguousDoubleArray r) {
+                prepare_active_types(self, node_types, neigh_types);
                 self.reverse_A0_scaled(
                     num_nodes,
                     create_kokkos_view("node_types", node_types),
@@ -187,7 +321,7 @@ void bind_mace_kokkos(py::module_ &m, const char* class_name)
             [] (MACEKokkos<Precision>& self) {
                 return view2vector(self.M0);
             },
-            [] (MACEKokkos<Precision>& self, py::array_t<Precision> M0) {
+            [] (MACEKokkos<Precision>& self, ContiguousPrecisionArray M0) {
                 const int num_nodes = M0.size()/(self.num_LM*self.num_channels);
                 set_kokkos_view(self.M0, M0, num_nodes, self.num_LM, self.num_channels);
             })
@@ -195,14 +329,14 @@ void bind_mace_kokkos(py::module_ &m, const char* class_name)
             [] (MACEKokkos<Precision>& self) {
                 return view2vector(self.M0_adj);
             },
-            [] (MACEKokkos<Precision>& self, py::array_t<Precision> M0_adj) {
+            [] (MACEKokkos<Precision>& self, ContiguousPrecisionArray M0_adj) {
                 const int num_nodes = M0_adj.size()/(self.num_LM*self.num_channels);
                 set_kokkos_view(self.M0_adj, M0_adj, num_nodes, self.num_LM, self.num_channels);
             })
         .def("compute_M0",
             [] (MACEKokkos<Precision>& self,
                     int num_nodes,
-                    py::array_t<int> node_types) {
+                    ContiguousIntArray node_types) {
                 self.compute_M0(
                     num_nodes,
                     create_kokkos_view("node_types", node_types));
@@ -210,7 +344,7 @@ void bind_mace_kokkos(py::module_ &m, const char* class_name)
         .def("reverse_M0",
             [] (MACEKokkos<Precision>& self,
                     int num_nodes,
-                    py::array_t<int> node_types) {
+                    ContiguousIntArray node_types) {
                 self.reverse_M0(
                     num_nodes,
                     create_kokkos_view("node_types", node_types));
@@ -220,7 +354,7 @@ void bind_mace_kokkos(py::module_ &m, const char* class_name)
             [] (MACEKokkos<Precision>& self) {
                 return view2vector(self.H1);
             },
-            [] (MACEKokkos<Precision>& self, py::array_t<Precision> H1) {
+            [] (MACEKokkos<Precision>& self, ContiguousPrecisionArray H1) {
                 const int num_nodes = H1.size()/(self.num_LM*self.num_channels);
                 set_kokkos_view(self.H1, H1, num_nodes, self.num_LM, self.num_channels);
             })
@@ -228,18 +362,38 @@ void bind_mace_kokkos(py::module_ &m, const char* class_name)
             [] (MACEKokkos<Precision>& self) {
                 return view2vector(self.H1_adj);
             },
-            [] (MACEKokkos<Precision>& self, py::array_t<Precision> H1_adj) {
+            [] (MACEKokkos<Precision>& self, ContiguousPrecisionArray H1_adj) {
                 const int num_nodes = H1_adj.size()/(self.num_LM*self.num_channels);
                 set_kokkos_view(self.H1_adj, H1_adj, num_nodes, self.num_LM, self.num_channels);
             })
         .def("compute_H1", &MACEKokkos<Precision>::compute_H1)
         .def("reverse_H1", &MACEKokkos<Precision>::reverse_H1)
+        .def("compute_H1_product", &MACEKokkos<Precision>::compute_H1_product)
+        .def("compute_H1_linear_up", &MACEKokkos<Precision>::compute_H1_linear_up)
+        .def("reverse_H1_linear_up", &MACEKokkos<Precision>::reverse_H1_linear_up)
+        .def("reverse_H1_product", &MACEKokkos<Precision>::reverse_H1_product)
+        .def("compute_field_H1",
+            [] (MACEKokkos<Precision>& self,
+                    const int num_nodes,
+                    ContiguousDoubleArray electric_field) {
+                self.compute_field_H1(
+                    num_nodes,
+                    create_kokkos_view("electric_field", electric_field));
+            })
+        .def("reverse_field_H1",
+            [] (MACEKokkos<Precision>& self,
+                    const int num_nodes,
+                    ContiguousDoubleArray electric_field) {
+                self.reverse_field_H1(
+                    num_nodes,
+                    create_kokkos_view("electric_field", electric_field));
+            })
         // Phi1
         .def_property("Phi1",
             [] (MACEKokkos<Precision>& self) {
                 return view2vector(self.Phi1);
             },
-            [] (MACEKokkos<Precision>& self, py::array_t<Precision> Phi1) {
+            [] (MACEKokkos<Precision>& self, ContiguousPrecisionArray Phi1) {
                 const int num_nodes = Phi1.size()/(self.num_lme*self.num_channels);
                 set_kokkos_view(self.Phi1, Phi1, num_nodes, self.num_lme, self.num_channels);
             })
@@ -247,15 +401,15 @@ void bind_mace_kokkos(py::module_ &m, const char* class_name)
             [] (MACEKokkos<Precision>& self) {
                 return view2vector(self.dPhi1);
             },
-            [] (MACEKokkos<Precision>& self, py::array_t<Precision> dPhi1) {
+            [] (MACEKokkos<Precision>& self, ContiguousPrecisionArray dPhi1) {
                 const int num_nodes = dPhi1.size()/(self.num_lme*self.num_channels);
                 set_kokkos_view(self.dPhi1, dPhi1, num_nodes, self.num_lme, self.num_channels);
             })
         .def("compute_Phi1",
             [] (MACEKokkos<Precision>& self,
                     const int num_nodes,
-                    py::array_t<int> num_neigh,
-                    py::array_t<int> neigh_types) {
+                    ContiguousIntArray num_neigh,
+                    ContiguousIntArray neigh_types) {
                 self.compute_Phi1(
                     num_nodes,
                     create_kokkos_view("num_neigh", num_neigh),
@@ -264,10 +418,10 @@ void bind_mace_kokkos(py::module_ &m, const char* class_name)
         .def("reverse_Phi1",
             [] (MACEKokkos<Precision>& self,
                     const int num_nodes,
-                    py::array_t<int> num_neigh,
-                    py::array_t<int> neigh_indices,
-                    py::array_t<double> xyz,
-                    py::array_t<double> r,
+                    ContiguousIntArray num_neigh,
+                    ContiguousIntArray neigh_indices,
+                    ContiguousDoubleArray xyz,
+                    ContiguousDoubleArray r,
                     bool zero_dxyz,
                     bool zero_H1_adj) {
                 self.reverse_Phi1(
@@ -284,7 +438,7 @@ void bind_mace_kokkos(py::module_ &m, const char* class_name)
             [] (MACEKokkos<Precision>& self) {
                 return view2vector(self.A1);
             },
-            [] (MACEKokkos<Precision>& self, py::array_t<Precision> A1) {
+            [] (MACEKokkos<Precision>& self, ContiguousPrecisionArray A1) {
                 const int num_nodes = A1.size()/(self.num_lm*self.num_channels);
                 set_kokkos_view(self.A1, A1, num_nodes, self.num_lm, self.num_channels);
             })
@@ -292,7 +446,7 @@ void bind_mace_kokkos(py::module_ &m, const char* class_name)
             [] (MACEKokkos<Precision>& self) {
                 return view2vector(self.A1_adj);
             },
-            [] (MACEKokkos<Precision>& self, py::array_t<Precision> A1_adj) {
+            [] (MACEKokkos<Precision>& self, ContiguousPrecisionArray A1_adj) {
                 const int num_nodes = A1_adj.size()/(self.num_lm*self.num_channels);
                 set_kokkos_view(self.A1_adj, A1_adj, num_nodes, self.num_lm, self.num_channels);
             })
@@ -307,10 +461,11 @@ void bind_mace_kokkos(py::module_ &m, const char* class_name)
         .def("compute_A1_scaled",
             [](MACEKokkos<Precision>& self,
                     const int num_nodes,
-                    py::array_t<int> node_types,
-                    py::array_t<int> num_neigh,
-                    py::array_t<int> neigh_types,
-                    py::array_t<double> r) {
+                    ContiguousIntArray node_types,
+                    ContiguousIntArray num_neigh,
+                    ContiguousIntArray neigh_types,
+                    ContiguousDoubleArray r) {
+                prepare_active_types(self, node_types, neigh_types);
                 self.compute_A1_scaled(
                     num_nodes,
                     create_kokkos_view("node_types", node_types),
@@ -321,11 +476,12 @@ void bind_mace_kokkos(py::module_ &m, const char* class_name)
         .def("reverse_A1_scaled",
             [](MACEKokkos<Precision>& self,
                     const int num_nodes,
-                    py::array_t<int> node_types,
-                    py::array_t<int> num_neigh,
-                    py::array_t<int> neigh_types,
-                    py::array_t<double> xyz,
-                    py::array_t<double> r) {
+                    ContiguousIntArray node_types,
+                    ContiguousIntArray num_neigh,
+                    ContiguousIntArray neigh_types,
+                    ContiguousDoubleArray xyz,
+                    ContiguousDoubleArray r) {
+                prepare_active_types(self, node_types, neigh_types);
                 self.reverse_A1_scaled(
                     num_nodes,
                     create_kokkos_view("node_types", node_types),
@@ -339,7 +495,7 @@ void bind_mace_kokkos(py::module_ &m, const char* class_name)
             [] (MACEKokkos<Precision>& self) {
                 return view2vector(self.M1);
             },
-            [] (MACEKokkos<Precision>& self, py::array_t<Precision> M1) {
+            [] (MACEKokkos<Precision>& self, ContiguousPrecisionArray M1) {
                 const int num_nodes = M1.size()/(self.num_channels);
                 set_kokkos_view(self.M1, M1, num_nodes, self.num_channels);
             })
@@ -347,14 +503,14 @@ void bind_mace_kokkos(py::module_ &m, const char* class_name)
             [] (MACEKokkos<Precision>& self) {
                 return view2vector(self.M1_adj);
             },
-            [] (MACEKokkos<Precision>& self, py::array_t<Precision> M1_adj) {
+            [] (MACEKokkos<Precision>& self, ContiguousPrecisionArray M1_adj) {
                 const int num_nodes = M1_adj.size()/(self.num_channels);
                 set_kokkos_view(self.M1_adj, M1_adj, num_nodes, self.num_channels);
             })
         .def("compute_M1",
             [] (MACEKokkos<Precision>& self,
                     int num_nodes,
-                    py::array_t<int> node_types) {
+                    ContiguousIntArray node_types) {
                 self.compute_M1(
                     num_nodes,
                     create_kokkos_view("node_types", node_types));
@@ -362,7 +518,7 @@ void bind_mace_kokkos(py::module_ &m, const char* class_name)
         .def("reverse_M1",
             [] (MACEKokkos<Precision>& self,
                     int num_nodes,
-                    py::array_t<int> node_types) {
+                    ContiguousIntArray node_types) {
                 self.reverse_M1(
                     num_nodes,
                     create_kokkos_view("node_types", node_types));
@@ -372,7 +528,7 @@ void bind_mace_kokkos(py::module_ &m, const char* class_name)
             [] (MACEKokkos<Precision>& self) {
                 return view2vector(self.H2);
             },
-            [] (MACEKokkos<Precision>& self, py::array_t<double> H2) {
+            [] (MACEKokkos<Precision>& self, ContiguousDoubleArray H2) {
                 const int num_nodes = H2.size()/self.num_channels;
                 set_kokkos_view(self.H2, H2, num_nodes, self.num_channels);
             })
@@ -380,14 +536,14 @@ void bind_mace_kokkos(py::module_ &m, const char* class_name)
             [] (MACEKokkos<Precision>& self) {
                 return view2vector(self.H2_adj);
             },
-            [] (MACEKokkos<Precision>& self, py::array_t<double> H2_adj) {
+            [] (MACEKokkos<Precision>& self, ContiguousDoubleArray H2_adj) {
                 const int num_nodes = H2_adj.size()/self.num_channels;
                 set_kokkos_view(self.H2_adj, H2_adj, num_nodes, self.num_channels);
             })
         .def("compute_H2",
             [] (MACEKokkos<Precision>& self,
                     const int num_nodes,
-                    py::array_t<int> node_types) {
+                    ContiguousIntArray node_types) {
                 self.compute_H2(
                     num_nodes,
                     create_kokkos_view("node_types", node_types));
@@ -395,7 +551,7 @@ void bind_mace_kokkos(py::module_ &m, const char* class_name)
         .def("reverse_H2",
             [] (MACEKokkos<Precision>& self,
                     const int num_nodes,
-                    py::array_t<int> node_types,
+                    ContiguousIntArray node_types,
                     bool zero_H1_adj) {
                 self.reverse_H2(
                     num_nodes,
@@ -406,7 +562,7 @@ void bind_mace_kokkos(py::module_ &m, const char* class_name)
         .def("compute_readouts",
             [] (MACEKokkos<Precision>& self,
                     const int num_nodes,
-                    py::array_t<int> node_types) {
+                    ContiguousIntArray node_types) {
                 return self.compute_readouts(
                     num_nodes,
                     create_kokkos_view("node_types", node_types));

--- a/symmetrix/source/cpp/multilayer_perceptron.cpp
+++ b/symmetrix/source/cpp/multilayer_perceptron.cpp
@@ -13,6 +13,7 @@ void bind_multilayer_perceptron(py::module_ &m)
         .def(py::init<std::vector<int>,std::vector<std::vector<double>>,double>())
         .def("evaluate", &MultilayerPerceptron::evaluate)
         .def("evaluate_gradient", &MultilayerPerceptron::evaluate_gradient)
+        .def("evaluate_gradient_directional", &MultilayerPerceptron::evaluate_gradient_directional)
         .def("evaluate_batch", &MultilayerPerceptron::evaluate_batch)
         .def("evaluate_gradient_batch", &MultilayerPerceptron::evaluate_gradient_batch);
 }

--- a/symmetrix/source/cpp/multivariate_polynomial.cpp
+++ b/symmetrix/source/cpp/multivariate_polynomial.cpp
@@ -14,6 +14,7 @@ void bind_multivariate_polynomial(py::module_ &m)
         .def("evaluate", &MultivariatePolynomial::evaluate)
         .def("evaluate_simple", &MultivariatePolynomial::evaluate_simple)
         .def("evaluate_gradient", &MultivariatePolynomial::evaluate_gradient)
+        .def("evaluate_gradient_directional", &MultivariatePolynomial::evaluate_gradient_directional)
         .def("evaluate_gradient_simple", &MultivariatePolynomial::evaluate_gradient_simple)
         .def("evaluate_batch", &MultivariatePolynomial::evaluate_batch)
         ;

--- a/symmetrix/source/cpp/utilities_kokkos.hpp
+++ b/symmetrix/source/cpp/utilities_kokkos.hpp
@@ -11,10 +11,10 @@
 
 namespace py = pybind11;
 
-template<typename T>
+template<typename T, int ExtraFlags>
 Kokkos::View<const T*> create_kokkos_view(
     std::string label,
-    py::array_t<T> array)
+    py::array_t<T, ExtraFlags> array)
 {
     return create_mirror_view_and_copy(
         Kokkos::DefaultExecutionSpace(),
@@ -22,10 +22,10 @@ Kokkos::View<const T*> create_kokkos_view(
         label);
 }
 
-template<typename T>
+template<typename T, int ExtraFlags>
 void set_kokkos_view(
     Kokkos::View<T*>& view,
-    py::array_t<T> array)
+    py::array_t<T, ExtraFlags> array)
 {
     auto d_array = Kokkos::create_mirror_view_and_copy(
         Kokkos::DefaultExecutionSpace(),
@@ -37,10 +37,10 @@ void set_kokkos_view(
     Kokkos::deep_copy(view, d_array);
 }
 
-template<typename T>
+template<typename T, int ExtraFlags>
 void set_kokkos_view(
     Kokkos::View<T**,Kokkos::LayoutRight>& view,
-    py::array_t<T> array,
+    py::array_t<T, ExtraFlags> array,
     const int N0,
     const int N1)
 {
@@ -55,10 +55,10 @@ void set_kokkos_view(
     Kokkos::deep_copy(view, d_array);
 }
 
-template<typename T>
+template<typename T, int ExtraFlags>
 void set_kokkos_view(
     Kokkos::View<T***,Kokkos::LayoutRight>& view,
-    py::array_t<T> array,
+    py::array_t<T, ExtraFlags> array,
     const int N0,
     const int N1,
     const int N2)

--- a/symmetrix/source/symmetrix/__init__.py
+++ b/symmetrix/source/symmetrix/__init__.py
@@ -6,4 +6,8 @@ import importlib
 _sym = importlib.import_module(".symmetrix", __name__)
 _sym.__all__ = [n for n in vars(_sym) if not (n.startswith("__") and n.endswith("__"))]
 from .symmetrix import *
-from .calculator import Symmetrix as Symmetrix
+from .calculator import (
+    FieldAwareCalculator as FieldAwareCalculator,
+    FieldContributionCalculator as FieldContributionCalculator,
+    Symmetrix as Symmetrix,
+)

--- a/symmetrix/source/symmetrix/calculator.py
+++ b/symmetrix/source/symmetrix/calculator.py
@@ -16,10 +16,30 @@ except ImportError:
     logging.warning("Symmetrix using slow ase.neighborlist.neighbor_list")
     from ase.neighborlist import neighbor_list
 
-from ase.calculators.calculator import Calculator, all_changes
+from ase.calculators.calculator import (
+    Calculator,
+    PropertyNotImplementedError,
+    all_changes,
+    compare_atoms,
+    equal,
+)
 from ase.stress import full_3x3_to_voigt_6_stress
 
 from . import symmetrix
+
+
+_FIELD_ADDITIVE_PROPERTIES = ["energy", "free_energy", "energies", "forces", "stress"]
+_FIELD_RESPONSE_PROPERTIES = ["polarization", "becs", "polarizability"]
+_FIELD_NOT_SET = object()
+
+
+def _to_voigt_stress(stress):
+    stress = np.asarray(stress, dtype=float)
+    if stress.shape == (3, 3):
+        return full_3x3_to_voigt_6_stress(stress)
+    if stress.shape == (6,):
+        return stress
+    raise ValueError("ASE stress must have shape (6,) or (3, 3).")
 
 
 class Symmetrix(Calculator):
@@ -36,7 +56,9 @@ class Symmetrix(Calculator):
     Wraps symmetrix library from https://github.com/wcwitt/symmetrix via python interface at https://pypi.org/project/symmetrix/
     """
 
-    implemented_properties = ["energy", "free_energy", "energies", "forces", "stress"]
+    implemented_properties = list(_FIELD_ADDITIVE_PROPERTIES)
+    _macefield_response_properties = list(_FIELD_RESPONSE_PROPERTIES)
+    _macefield_eps0 = 8.8541878128e-12 / 1.602176634e-19 / 1e10
 
     def __init__(self, model_file, dtype="float64", use_kokkos=True, **kwargs):
         Calculator.__init__(self, **kwargs)
@@ -44,6 +66,8 @@ class Symmetrix(Calculator):
             raise ValueError(
                 f"Unsupported dtype '{dtype}'. Supported dtypes are 'float64' and 'float32'."
             )
+        self._macefield_electric_field = None
+        self._electric_field = kwargs.get("electric_field", None)
         if use_kokkos and not hasattr(symmetrix, "MACEKokkos"):
             raise RuntimeError("Symmetrix was built without Kokkos support.")
         self.use_kokkos = use_kokkos
@@ -61,14 +85,20 @@ class Symmetrix(Calculator):
             MACE = symmetrix.MACE
         try:
             self.evaluator = MACE(str(model_file))
-        except RuntimeError:  # expecting json.exception.parse_error.101
+        except RuntimeError as native_error:  # expecting json.exception.parse_error.101
+            if str(model_file).lower().endswith(
+                ".json"
+            ) or "[json.exception.parse_error." not in str(native_error):
+                raise
+            self._raise_if_macefield_checkpoint(model_file)
+
             # import this here so that torch/mace support isn't needed if file is already symmetrix json
             from .extract_mace_data import extract_mace_data
 
             kwargs_extract = {
                 k: v
                 for k, v in kwargs.items()
-                if k in ["species", "head", "num_spline_points"]
+                if k in ["species", "head", "num_spline_points", "radial_format"]
             }
             logging.warning(
                 f"Converting model from pytorch model to symmetrix dict with {kwargs_extract}"
@@ -80,50 +110,510 @@ class Symmetrix(Calculator):
                 self.evaluator = MACE(fout.name)
 
         self.cutoff = self.evaluator.r_cut
+        self.implemented_properties = list(type(self).implemented_properties)
+        if self._has_native_field_coupling():
+            self.implemented_properties.append("node_energy")
+            self.implemented_properties.extend(self._macefield_response_properties)
 
-    def calculate(self, atoms=None, properties=["energy"], system_changes=all_changes):
-        Calculator.calculate(self, atoms, properties, system_changes)
+    def _raise_if_macefield_checkpoint(self, model_file):
+        try:
+            import torch
+        except ImportError:
+            return
 
-        ase_atomic_numbers = self.atoms.get_atomic_numbers().tolist()
+        model = torch.load(
+            model_file,
+            map_location=torch.device("cpu"),
+            weights_only=False,
+        )
+
+        is_macefield = type(model).__name__ == "MACEField" or (
+            hasattr(model, "field_feats") and hasattr(model, "field_linear")
+        )
+        if is_macefield:
+            raise RuntimeError(
+                "MACEField PyTorch checkpoints cannot be used directly with Symmetrix. "
+                "Convert/extract the model to Symmetrix JSON first, then pass the JSON file."
+            )
+
+    def check_state(self, atoms, tol=1e-15):
+        state = super().check_state(atoms, tol=tol)
+        if (
+            self._has_native_field_coupling()
+            and not state
+            and (
+                not hasattr(self, "atoms")
+                or not equal(
+                    self._macefield_electric_field,
+                    self._resolve_electric_field(atoms),
+                    atol=tol,
+                )
+            )
+        ):
+            state.append("info")
+        return state
+
+    def _has_native_field_coupling(self):
+        return hasattr(self, "evaluator") and getattr(
+            self.evaluator, "has_field_coupling", False
+        )
+
+    @property
+    def electric_field(self):
+        return self._electric_field
+
+    @electric_field.setter
+    def electric_field(self, value):
+        self._electric_field = value
+        self.results.clear()
+
+    def _resolve_electric_field(self, atoms=None):
+        if atoms is None:
+            atoms = self.atoms
+
+        if self._electric_field is not None:
+            field = self._electric_field
+        elif "electric_field" in atoms.info:
+            field = atoms.info["electric_field"]
+        elif "REF_electric_field" in atoms.info:
+            field = atoms.info["REF_electric_field"]
+        else:
+            field = np.zeros(3)
+
+        field = np.asarray(field, dtype=float)
+        if field.shape == (3,):
+            return field
+        if field.shape == (1, 3):
+            return field.reshape(3)
+        if field.shape == (len(atoms), 3):
+            raise ValueError(
+                "MACEField ASE electric_field must be a graph-level electric_field "
+                "with shape (3,) or (1, 3); per-atom fields are not supported."
+            )
+        raise ValueError("electric_field must have shape (3,) or (1, 3).")
+
+    def _mace_inputs(self, atoms):
+        ase_atomic_numbers = atoms.get_atomic_numbers().tolist()
         mace_atomic_numbers = self.evaluator.atomic_numbers
-        i_list, j_list, r, xyz = neighbor_list("ijdD", self.atoms, self.cutoff)
-        num_nodes = np.max(i_list) + 1
+        unsupported = sorted(set(ase_atomic_numbers) - set(mace_atomic_numbers))
+        if unsupported:
+            raise ValueError(
+                f"Model does not support atomic numbers {unsupported}. "
+                f"Supported atomic numbers are {mace_atomic_numbers}."
+            )
+        i_list, j_list, r, xyz = neighbor_list("ijdD", atoms, self.cutoff)
+        num_nodes = len(atoms)
         node_types = [
             mace_atomic_numbers.index(ase_atomic_numbers[i]) for i in range(num_nodes)
         ]
         num_neigh = np.bincount(j_list, minlength=num_nodes)
         neigh_types = [mace_atomic_numbers.index(ase_atomic_numbers[j]) for j in j_list]
-        self.evaluator.compute_node_energies_forces(
-            num_nodes, node_types, num_neigh, j_list, neigh_types, xyz.flatten(), r
+        return num_nodes, node_types, num_neigh, j_list, neigh_types, xyz, r, i_list
+
+    def _compute_macefield(self, atoms, electric_field, mace_inputs=None):
+        if mace_inputs is None:
+            mace_inputs = self._mace_inputs(atoms)
+        num_nodes, node_types, num_neigh, j_list, neigh_types, xyz, r, i_list = (
+            mace_inputs
         )
-
-        self.results["energy"] = self.results["free_energy"] = np.sum(
-            self.evaluator.node_energies
+        self.evaluator.compute_node_energies_forces_field(
+            num_nodes,
+            node_types,
+            num_neigh,
+            j_list,
+            neigh_types,
+            xyz.flatten(),
+            r,
+            np.asarray(electric_field, dtype=float).flatten(),
         )
-        self.results["energies"] = np.asarray(self.evaluator.node_energies)
+        return mace_inputs
 
-        pair_forces = np.asarray(self.evaluator.node_forces).reshape((-1, 3))
-        pair_forces = pair_forces[
-            : len(i_list), :
-        ]  # currently, `evaluator.node_forces` is a container
-        # which can grow larger than the actual number of pairs
+    def _calculate_macefield_responses(
+        self, atoms, electric_field, properties, mace_inputs
+    ):
+        volume = atoms.get_volume()
+        raw_polarization = -np.asarray(self.evaluator.electric_field_adj, dtype=float)
+        if raw_polarization.shape != (3,):
+            raise PropertyNotImplementedError(
+                "MACEField response properties require a graph-level electric_field with shape (3,)."
+            )
 
-        # atom forces from pair_forces
-        N_atoms = len(self.atoms)
-        atom_forces = np.zeros((N_atoms, 3))
-        atom_forces[:, 0] = np.bincount(
-            j_list, weights=pair_forces[:, 0], minlength=N_atoms
-        ) - np.bincount(i_list, weights=pair_forces[:, 0], minlength=N_atoms)
-        atom_forces[:, 1] = np.bincount(
-            j_list, weights=pair_forces[:, 1], minlength=N_atoms
-        ) - np.bincount(i_list, weights=pair_forces[:, 1], minlength=N_atoms)
-        atom_forces[:, 2] = np.bincount(
-            j_list, weights=pair_forces[:, 2], minlength=N_atoms
-        ) - np.bincount(i_list, weights=pair_forces[:, 2], minlength=N_atoms)
+        results = {"polarization": np.array(raw_polarization / volume, copy=True)}
 
-        self.results["forces"] = atom_forces
+        field_derivatives_computed = False
+        force_derivatives_computed = False
 
-        # stress from pair_forces
-        self.results["stress"] = full_3x3_to_voigt_6_stress(
-            (-pair_forces.T @ xyz) / self.atoms.get_volume()
+        def compute_field_derivatives(include_forces=False):
+            nonlocal field_derivatives_computed, force_derivatives_computed
+            if include_forces and force_derivatives_computed:
+                return
+            if field_derivatives_computed and not include_forces:
+                return
+            num_nodes, node_types, num_neigh, j_list, neigh_types, xyz, r, _ = (
+                mace_inputs
+            )
+            if include_forces:
+                self.evaluator.compute_electric_field_force_derivative(
+                    num_nodes,
+                    node_types,
+                    num_neigh,
+                    j_list,
+                    neigh_types,
+                    xyz.flatten(),
+                    r,
+                    np.asarray(electric_field, dtype=float).flatten(),
+                )
+                field_derivatives_computed = True
+                force_derivatives_computed = True
+            else:
+                self.evaluator.compute_electric_field_hessian(
+                    num_nodes,
+                    node_types,
+                    num_neigh,
+                    j_list,
+                    neigh_types,
+                    xyz.flatten(),
+                    r,
+                    np.asarray(electric_field, dtype=float).flatten(),
+                )
+                field_derivatives_computed = True
+
+        if "polarizability" in properties:
+            compute_field_derivatives(include_forces="becs" in properties)
+            polarizability = -np.asarray(
+                self.evaluator.electric_field_hessian, dtype=float
+            ).reshape(3, 3)
+            results["polarizability"] = np.array(
+                (polarizability / volume / self._macefield_eps0).reshape(9),
+                copy=True,
+            )
+
+        if "becs" in properties:
+            compute_field_derivatives(include_forces=True)
+            num_nodes, _, _, j_list, _, xyz, _, i_list = mace_inputs
+            pair_derivatives = np.asarray(
+                self.evaluator.electric_field_force_derivative,
+                dtype=float,
+            ).reshape(3, -1, 3)[:, : len(i_list), :]
+            becs = np.zeros((len(atoms), 3, 3))
+            for field_component in range(3):
+                for cartesian in range(3):
+                    becs[:, field_component, cartesian] = np.bincount(
+                        j_list,
+                        weights=pair_derivatives[field_component, :, cartesian],
+                        minlength=num_nodes,
+                    ) - np.bincount(
+                        i_list,
+                        weights=pair_derivatives[field_component, :, cartesian],
+                        minlength=num_nodes,
+                    )
+            results["becs"] = becs.reshape(len(atoms), 9)
+
+        return results
+
+    def _collect_mace_results(self, atoms, mace_inputs):
+        num_nodes, node_types, _, j_list, _, xyz, _, i_list = mace_inputs
+        node_energies = np.array(self.evaluator.node_energies, dtype=float, copy=True)
+        results = {
+            "energy": float(np.sum(node_energies)),
+            "free_energy": float(np.sum(node_energies)),
+            "energies": node_energies,
+        }
+        if self._has_native_field_coupling():
+            atomic_energies = np.asarray(self.evaluator.atomic_energies, dtype=float)
+            results["node_energy"] = (
+                node_energies - atomic_energies[np.asarray(node_types, dtype=int)]
+            )
+
+        pair_forces = np.asarray(self.evaluator.node_forces, dtype=float).reshape(
+            (-1, 3)
         )
+        pair_forces = np.array(pair_forces[: len(i_list), :], copy=True)
+
+        atom_forces = np.zeros((num_nodes, 3))
+        for component in range(3):
+            atom_forces[:, component] = np.bincount(
+                j_list,
+                weights=pair_forces[:, component],
+                minlength=num_nodes,
+            ) - np.bincount(
+                i_list,
+                weights=pair_forces[:, component],
+                minlength=num_nodes,
+            )
+        results["forces"] = atom_forces
+        results["stress"] = full_3x3_to_voigt_6_stress(
+            (-pair_forces.T @ xyz) / atoms.get_volume()
+        )
+        return results
+
+    def _calculate_macefield_results(
+        self, atoms, electric_field, properties, mace_inputs=None
+    ):
+        if mace_inputs is None:
+            mace_inputs = self._mace_inputs(atoms)
+        self._compute_macefield(atoms, electric_field, mace_inputs=mace_inputs)
+        results = self._collect_mace_results(atoms, mace_inputs)
+        if any(prop in properties for prop in self._macefield_response_properties):
+            results.update(
+                self._calculate_macefield_responses(
+                    atoms,
+                    electric_field,
+                    properties,
+                    mace_inputs,
+                )
+            )
+        return results
+
+    def calculate(self, atoms=None, properties=["energy"], system_changes=all_changes):
+        Calculator.calculate(self, atoms, properties, system_changes)
+
+        num_nodes, node_types, num_neigh, j_list, neigh_types, xyz, r, i_list = (
+            self._mace_inputs(self.atoms)
+        )
+        mace_inputs = (
+            num_nodes,
+            node_types,
+            num_neigh,
+            j_list,
+            neigh_types,
+            xyz,
+            r,
+            i_list,
+        )
+        if self._has_native_field_coupling():
+            electric_field = self._resolve_electric_field()
+            self.results = self._calculate_macefield_results(
+                self.atoms,
+                electric_field,
+                properties,
+                mace_inputs=mace_inputs,
+            )
+            self._macefield_electric_field = np.array(electric_field, copy=True)
+        else:
+            self.evaluator.compute_node_energies_forces(
+                num_nodes, node_types, num_neigh, j_list, neigh_types, xyz.flatten(), r
+            )
+            self.results = self._collect_mace_results(self.atoms, mace_inputs)
+
+
+class FieldContributionCalculator(Calculator):
+    """Return the exact finite-field contribution of a MACEField calculator.
+
+    Additive properties are evaluated as ``Q(E) - Q(0)``. Electrical response
+    properties are returned from the requested-field calculation because the
+    zero-field reference is independent of the requested field.
+    """
+
+    implemented_properties = _FIELD_ADDITIVE_PROPERTIES + _FIELD_RESPONSE_PROPERTIES
+
+    def __init__(self, field_calculator, **kwargs):
+        electric_field = kwargs.pop("electric_field", None)
+        Calculator.__init__(self, **kwargs)
+        if not isinstance(field_calculator, Symmetrix):
+            raise TypeError("field_calculator must be a Symmetrix calculator.")
+        if not field_calculator._has_native_field_coupling():
+            raise ValueError("field_calculator must use a field-aware MACEField model.")
+        self.field_calculator = field_calculator
+        if electric_field is not None:
+            self.field_calculator.electric_field = electric_field
+        self.implemented_properties = list(type(self).implemented_properties)
+        self._last_electric_field = None
+        self._zero_field_atoms = None
+        self._zero_field_results = None
+
+    @property
+    def electric_field(self):
+        return self.field_calculator.electric_field
+
+    @electric_field.setter
+    def electric_field(self, value):
+        self.field_calculator.electric_field = value
+        self.results.clear()
+
+    def _resolve_electric_field(self, atoms=None):
+        if atoms is None:
+            atoms = self.atoms
+        return self.field_calculator._resolve_electric_field(atoms)
+
+    def check_state(self, atoms, tol=1e-15):
+        state = super().check_state(atoms, tol=tol)
+        if not state and (
+            self._last_electric_field is None
+            or not equal(
+                self._last_electric_field,
+                self._resolve_electric_field(atoms),
+                atol=tol,
+            )
+        ):
+            state.append("info")
+        return state
+
+    @staticmethod
+    def _zero_results(atoms):
+        return {
+            "energy": 0.0,
+            "free_energy": 0.0,
+            "energies": np.zeros(len(atoms)),
+            "forces": np.zeros((len(atoms), 3)),
+            "stress": np.zeros(6),
+        }
+
+    def _zero_reference_is_current(self, atoms):
+        if self._zero_field_atoms is None or self._zero_field_results is None:
+            return False
+        return not compare_atoms(self._zero_field_atoms, atoms)
+
+    def calculate(self, atoms=None, properties=["energy"], system_changes=all_changes):
+        Calculator.calculate(self, atoms, properties, system_changes)
+        electric_field = self._resolve_electric_field(self.atoms)
+        needs_response = any(prop in properties for prop in _FIELD_RESPONSE_PROPERTIES)
+        needs_additive = any(prop in properties for prop in _FIELD_ADDITIVE_PROPERTIES)
+        is_zero_field = np.array_equal(electric_field, np.zeros(3))
+        mace_inputs = None
+
+        if is_zero_field:
+            results = self._zero_results(self.atoms)
+            if needs_response:
+                mace_inputs = self.field_calculator._mace_inputs(self.atoms)
+                field_results = self.field_calculator._calculate_macefield_results(
+                    self.atoms,
+                    electric_field,
+                    properties,
+                    mace_inputs=mace_inputs,
+                )
+                for prop in _FIELD_RESPONSE_PROPERTIES:
+                    if prop in field_results:
+                        results[prop] = np.array(field_results[prop], copy=True)
+        elif needs_additive:
+            mace_inputs = self.field_calculator._mace_inputs(self.atoms)
+            if not self._zero_reference_is_current(self.atoms):
+                self._zero_field_results = (
+                    self.field_calculator._calculate_macefield_results(
+                        self.atoms,
+                        np.zeros(3),
+                        [],
+                        mace_inputs=mace_inputs,
+                    )
+                )
+                self._zero_field_atoms = self.atoms.copy()
+
+            field_results = self.field_calculator._calculate_macefield_results(
+                self.atoms,
+                electric_field,
+                properties,
+                mace_inputs=mace_inputs,
+            )
+            results = {
+                prop: np.asarray(field_results[prop])
+                - np.asarray(self._zero_field_results[prop])
+                for prop in _FIELD_ADDITIVE_PROPERTIES
+            }
+            results["energy"] = float(results["energy"])
+            results["free_energy"] = float(results["free_energy"])
+            for prop in _FIELD_RESPONSE_PROPERTIES:
+                if prop in field_results:
+                    results[prop] = np.array(field_results[prop], copy=True)
+        else:
+            mace_inputs = self.field_calculator._mace_inputs(self.atoms)
+            field_results = self.field_calculator._calculate_macefield_results(
+                self.atoms,
+                electric_field,
+                properties,
+                mace_inputs=mace_inputs,
+            )
+            results = {
+                prop: np.array(field_results[prop], copy=True)
+                for prop in _FIELD_RESPONSE_PROPERTIES
+                if prop in field_results
+            }
+
+        self.results = results
+        self._last_electric_field = np.array(electric_field, copy=True)
+        self.field_calculator.results.clear()
+
+
+class FieldAwareCalculator(Calculator):
+    """Add an exact MACEField contribution to an arbitrary ASE calculator."""
+
+    def __init__(self, base_calculator, field_calculator, **kwargs):
+        electric_field = kwargs.pop("electric_field", _FIELD_NOT_SET)
+        Calculator.__init__(self, **kwargs)
+        self.base_calculator = base_calculator
+        if isinstance(field_calculator, FieldContributionCalculator):
+            self.field_contribution = field_calculator
+        else:
+            self.field_contribution = FieldContributionCalculator(field_calculator)
+        self.field_calculator = self.field_contribution.field_calculator
+        if electric_field is not _FIELD_NOT_SET:
+            self.field_contribution.electric_field = electric_field
+
+        additive = [
+            prop
+            for prop in _FIELD_ADDITIVE_PROPERTIES
+            if prop in self.base_calculator.implemented_properties
+            and prop in self.field_contribution.implemented_properties
+        ]
+        responses = [
+            prop
+            for prop in _FIELD_RESPONSE_PROPERTIES
+            if prop in self.field_contribution.implemented_properties
+        ]
+        self.implemented_properties = additive + responses
+        self._last_electric_field = None
+        self._base_properties = set()
+
+    @property
+    def electric_field(self):
+        return self.field_contribution.electric_field
+
+    @electric_field.setter
+    def electric_field(self, value):
+        self.field_contribution.electric_field = value
+        self.results.clear()
+
+    def check_state(self, atoms, tol=1e-15):
+        state = super().check_state(atoms, tol=tol)
+        if not state and self._base_properties:
+            base_state = self.base_calculator.check_state(atoms, tol=tol)
+            base_results_missing = any(
+                prop not in self.base_calculator.results
+                for prop in self._base_properties
+            )
+            if base_state or base_results_missing:
+                state.append("calculator")
+        if not state and (
+            self._last_electric_field is None
+            or not equal(
+                self._last_electric_field,
+                self.field_contribution._resolve_electric_field(atoms),
+                atol=tol,
+            )
+        ):
+            state.append("info")
+        return state
+
+    def calculate(self, atoms=None, properties=["energy"], system_changes=all_changes):
+        Calculator.calculate(self, atoms, properties, system_changes)
+        results = {}
+        base_properties = set()
+        base_atoms = self.atoms.copy()
+        base_atoms.calc = None
+        for prop in properties:
+            field_value = self.field_contribution.get_property(prop, self.atoms)
+            if prop in _FIELD_RESPONSE_PROPERTIES:
+                results[prop] = field_value
+            else:
+                base_value = self.base_calculator.get_property(prop, base_atoms)
+                if prop == "stress":
+                    results[prop] = _to_voigt_stress(base_value) + _to_voigt_stress(
+                        field_value
+                    )
+                else:
+                    results[prop] = base_value + field_value
+                base_properties.add(prop)
+        self.results = results
+        self._base_properties = base_properties
+        self._last_electric_field = self.field_contribution._resolve_electric_field(
+            self.atoms
+        ).copy()

--- a/symmetrix/source/symmetrix/cli/extract_mace.py
+++ b/symmetrix/source/symmetrix/cli/extract_mace.py
@@ -30,6 +30,18 @@ def main():
         help="Head to keep, ignored unless model is multihead. "
         "Defaults to first non-PT head, same as mace.tools.script_utils.remove_pt_head",
     )
+    parser.add_argument(
+        "--radial-format",
+        choices=("compact", "pair-splines"),
+        default="compact",
+        help="Radial representation. Compact supports universal artifacts; pair-splines is legacy.",
+    )
+    parser.add_argument(
+        "--num-spline-points",
+        type=int,
+        default=256,
+        help="Number of radial spline grid points.",
+    )
     parser.add_argument("--output", "-o", help="Output filename.")
     args = parser.parse_args()
 
@@ -44,14 +56,25 @@ def main():
     species = (
         args.atomic_numbers if args.chemical_symbols == [] else args.chemical_symbols
     )
-    output = extract_mace_data(args.model, species, args.head)
+    output = extract_mace_data(
+        args.model,
+        species=species,
+        head=args.head,
+        num_spline_points=args.num_spline_points,
+        radial_format=args.radial_format,
+    )
 
     ### ----- WRITE JSON -----
 
     if args.output is None:
-        args.output = (
-            model_name + "-" + "-".join(str(a) for a in sorted(species)) + ".json"
+        suffix = (
+            "universal" if not species else "-".join(str(a) for a in sorted(species))
         )
+        args.output = model_name + "-" + suffix + ".json"
     print("WRITING JSON TO", args.output)
     with open(args.output, "w") as f:
-        json.dump(output, f, indent=4)
+        if args.radial_format == "compact":
+            json.dump(output, f, separators=(",", ":"))
+        else:
+            json.dump(output, f, indent=4)
+        f.write("\n")

--- a/symmetrix/source/symmetrix/extract_mace_data.py
+++ b/symmetrix/source/symmetrix/extract_mace_data.py
@@ -15,7 +15,13 @@ from mace.tools.scripts_utils import remove_pt_head
 from ase.data import chemical_symbols
 
 
-def extract_mace_data(model, species, head=None, num_spline_points=256):
+def extract_mace_data(
+    model,
+    species=None,
+    head=None,
+    num_spline_points=256,
+    radial_format="compact",
+):
     """Extract data from pytorch model file into structure that can be
     written as symmetrix JSON data file
 
@@ -23,12 +29,16 @@ def extract_mace_data(model, species, head=None, num_spline_points=256):
     ----------
     model: str / Path
         path to pytorch model file
-    species: list(int / str)
-        list of atomic numbers or chemical symbols to extract
+    species: list(int / str), default None
+        list of atomic numbers or chemical symbols to extract. If omitted,
+        retain every element supported by the checkpoint.
     head: str, default None
         head to keep, if multihead model, default same as mace.tools.scripts_utils.remove_pt_head
     num_spline_points: int, default 256
         number of spline points to approximate various functions
+    radial_format: str, default "compact"
+        compact stores the shared radial model and materializes splines for
+        active compositions at runtime. pair-splines stores legacy pair tables.
 
     Returns
     -------
@@ -42,6 +52,13 @@ def extract_mace_data(model, species, head=None, num_spline_points=256):
 
     if species is None:
         species = []
+    if radial_format not in ("compact", "pair-splines"):
+        raise ValueError(
+            f"Unsupported radial_format '{radial_format}'. "
+            "Expected 'compact' or 'pair-splines'."
+        )
+    if radial_format == "compact" and num_spline_points < 4:
+        raise ValueError("Compact radial output requires at least 4 spline points.")
 
     # extract atomic numbers
     atomic_numbers = []
@@ -66,11 +83,26 @@ def extract_mace_data(model, species, head=None, num_spline_points=256):
         torch.set_default_dtype(next(model.parameters()).dtype)
         model = remove_pt_head(model, head).to(device=device, dtype=torch.float64)
         model.eval()
+    model_dtype = next(model.parameters()).dtype
 
     ### ----- CHECK FOR COMPATIBILITY -----
 
+    is_macefield = type(model).__name__ == "MACEField" or (
+        hasattr(model, "field_feats") and hasattr(model, "field_linear")
+    )
+
     if len(model.interactions) != 2:
         raise RuntimeError("Currently, symmetrix only supports two-layer MACE models.")
+
+    if is_macefield:
+        if not hasattr(model, "field_feats") or not hasattr(model, "field_linear"):
+            raise RuntimeError(
+                "MACEField models must have field_feats and field_linear modules."
+            )
+        if len(model.field_feats) != 1 or len(model.field_linear) != 1:
+            raise RuntimeError(
+                "Currently, symmetrix only supports MACEField models with one field coupling."
+            )
 
     from mace.modules.blocks import (
         RealAgnosticInteractionBlock,
@@ -115,17 +147,261 @@ def extract_mace_data(model, species, head=None, num_spline_points=256):
         simplified.bias = linear.bias
         return simplified.to(device=device, dtype=torch.float64)
 
+    def serialize_instruction(instruction):
+        serialized = {}
+        for name in (
+            "i_in",
+            "i_in1",
+            "i_in2",
+            "i_out",
+            "connection_mode",
+            "has_weight",
+            "path_weight",
+            "path_shape",
+        ):
+            if hasattr(instruction, name):
+                value = getattr(instruction, name)
+                if isinstance(value, tuple):
+                    value = list(value)
+                serialized[name] = value
+        return serialized
+
+    def serialize_field_coupling(field_feats, field_linear):
+        return {
+            "field_feats_irreps_in1": str(field_feats.irreps_in1),
+            "field_feats_irreps_in2": str(field_feats.irreps_in2),
+            "field_feats_irreps_out": str(field_feats.irreps_out),
+            "field_feats_instructions": [
+                serialize_instruction(instruction)
+                for instruction in field_feats.instructions
+            ],
+            "field_feats_weight": field_feats.weight.numpy(force=True).tolist(),
+            "field_feats_output_mask": field_feats.output_mask.numpy(
+                force=True
+            ).tolist(),
+            "field_linear_irreps_in": str(field_linear.irreps_in),
+            "field_linear_irreps_out": str(field_linear.irreps_out),
+            "field_linear_instructions": [
+                serialize_instruction(instruction)
+                for instruction in field_linear.instructions
+            ],
+            "field_linear_weight": field_linear.weight.numpy(force=True).tolist(),
+            "field_linear_bias": field_linear.bias.numpy(force=True).tolist(),
+            "field_linear_output_mask": field_linear.output_mask.numpy(
+                force=True
+            ).tolist(),
+        }
+
+    def serialize_e3nn_fully_connected_net(network, name):
+        if (
+            type(network).__module__ != "e3nn.nn._fc"
+            or type(network).__name__ != "FullyConnectedNet"
+        ):
+            raise RuntimeError(
+                f"Compact radial extraction does not support {name} network "
+                f"{type(network).__module__}.{type(network).__name__}. "
+                "Use radial_format='pair-splines' with an explicit species list."
+            )
+
+        layers = list(network._modules.values())
+        if len(layers) != len(network.hs) - 1:
+            raise RuntimeError(
+                f"Compact radial extraction found an invalid {name} network layout."
+            )
+
+        weights = []
+        activation_scale = None
+        for layer_index, layer in enumerate(layers):
+            if tuple(layer.weight.shape) != (layer.h_in, layer.h_out):
+                raise RuntimeError(
+                    f"Compact radial extraction found invalid {name} layer dimensions."
+                )
+            if getattr(layer, "bias", None) is not None:
+                raise RuntimeError(
+                    f"Compact radial extraction does not support biases in {name}. "
+                    "Use radial_format='pair-splines' with an explicit species list."
+                )
+            if layer.var_in != 1 or layer.var_out != 1:
+                raise RuntimeError(
+                    f"Compact radial extraction only supports unit e3nn variances in {name}. "
+                    "Use radial_format='pair-splines' with an explicit species list."
+                )
+
+            is_final = layer_index == len(layers) - 1
+            if is_final:
+                if layer.act is not None:
+                    raise RuntimeError(
+                        f"Compact radial extraction does not support an output activation in {name}."
+                    )
+            else:
+                act = layer.act
+                if (
+                    act is None
+                    or getattr(act, "f", None) is not torch.nn.functional.silu
+                ):
+                    raise RuntimeError(
+                        f"Compact radial extraction only supports normalized SiLU in {name}. "
+                        "Use radial_format='pair-splines' with an explicit species list."
+                    )
+                if activation_scale is None:
+                    activation_scale = float(act.cst)
+                elif not np.isclose(
+                    activation_scale, float(act.cst), rtol=0.0, atol=1e-15
+                ):
+                    raise RuntimeError(
+                        f"Compact radial extraction requires one activation scale across {name}."
+                    )
+
+            effective_weight = (
+                layer.weight.detach()
+                / np.sqrt(
+                    float(layer.h_in) * float(layer.var_in) / float(layer.var_out)
+                )
+            ).T
+            weights.append(effective_weight.numpy(force=True).flatten().tolist())
+
+        return {
+            "shape": [int(value) for value in network.hs],
+            "weights": weights,
+            "activation": "silu",
+            "activation_scale": 1.0 if activation_scale is None else activation_scale,
+        }
+
+    def serialize_compact_radial(model, atomic_numbers):
+        from mace.modules.blocks import RadialEmbeddingBlock
+        from mace.modules.radial import AgnesiTransform, BesselBasis, PolynomialCutoff
+
+        radial = model.radial_embedding
+        if not isinstance(radial, RadialEmbeddingBlock):
+            raise RuntimeError(
+                "Compact radial extraction requires mace.modules.blocks.RadialEmbeddingBlock. "
+                "Use radial_format='pair-splines' with an explicit species list."
+            )
+        if not isinstance(radial.bessel_fn, BesselBasis):
+            raise RuntimeError(
+                f"Compact radial extraction does not support basis {type(radial.bessel_fn).__name__}. "
+                "Use radial_format='pair-splines' with an explicit species list."
+            )
+        if not isinstance(radial.cutoff_fn, PolynomialCutoff) or not getattr(
+            radial, "apply_cutoff", True
+        ):
+            raise RuntimeError(
+                "Compact radial extraction requires an applied PolynomialCutoff. "
+                "Use radial_format='pair-splines' with an explicit species list."
+            )
+
+        transform = getattr(radial, "distance_transform", None)
+        if transform is None:
+            distance_transform = {"type": "none"}
+        else:
+            if not isinstance(transform, AgnesiTransform):
+                raise RuntimeError(
+                    f"Compact radial extraction does not support distance transform "
+                    f"{type(transform).__name__}. Use radial_format='pair-splines' "
+                    "with an explicit species list."
+                )
+            distance_transform = {
+                "type": "agnesi",
+                "a": float(transform.a),
+                "q": float(transform.q),
+                "p": float(transform.p),
+                "covalent_radii": [
+                    float(transform.covalent_radii[atomic_number])
+                    for atomic_number in atomic_numbers
+                ],
+            }
+
+        networks = {
+            "R0": serialize_e3nn_fully_connected_net(
+                model.interactions[0].conv_tp_weights, "R0"
+            ),
+            "R1": serialize_e3nn_fully_connected_net(
+                model.interactions[1].conv_tp_weights, "R1"
+            ),
+        }
+        if "Density" in type(model.interactions[0]).__name__:
+            networks["A0"] = serialize_e3nn_fully_connected_net(
+                model.interactions[0].density_fn, "A0"
+            )
+            networks["A0"]["postprocess"] = "tanh-square"
+        if "Density" in type(model.interactions[1]).__name__:
+            networks["A1"] = serialize_e3nn_fully_connected_net(
+                model.interactions[1].density_fn, "A1"
+            )
+            networks["A1"]["postprocess"] = "tanh-square"
+
+        return {
+            "spline_grid_min": 1e-12,
+            "num_spline_points": int(num_spline_points),
+            "basis": {
+                "type": "bessel",
+                "weights": radial.bessel_fn.bessel_weights.numpy(force=True).tolist(),
+                "prefactor": float(radial.bessel_fn.prefactor),
+            },
+            "cutoff": {
+                "type": "polynomial",
+                "r_max": float(radial.cutoff_fn.r_max),
+                "p": int(radial.cutoff_fn.p),
+            },
+            "distance_transform": distance_transform,
+            "networks": networks,
+        }
+
     ### ----- BASIC MODEL INFO -----
 
     num_channels = model.node_embedding.linear.irreps_out.count("0e")
     r_cut = model.r_max.item()
     l_max = model.spherical_harmonics._lmax
     L_max = model.products[0].linear.irreps_out.lmax
+    if is_macefield and L_max != 1:
+        raise RuntimeError(
+            "Currently, symmetrix only supports MACEField models whose first "
+            "layer contains scalar and vector features (L_max=1)."
+        )
     output = {}
     output["num_channels"] = num_channels
     output["r_cut"] = r_cut
     output["l_max"] = l_max
     output["L_max"] = L_max
+    output["model_type"] = "MACEField" if is_macefield else "MACE"
+    output["has_field_coupling"] = is_macefield
+    output["field_couplings"] = []
+
+    if is_macefield:
+        field_feats = model.field_feats[0]
+        field_linear = model.field_linear[0]
+        expected_hidden_dim = ((L_max + 1) ** 2) * num_channels
+        if field_feats.irreps_in1.dim != expected_hidden_dim:
+            raise RuntimeError(
+                "MACEField field_feats.0 input irreps do not match the extracted H1 layout."
+            )
+        if str(field_feats.irreps_in2) != "1x1o":
+            raise RuntimeError(
+                "Currently, symmetrix only supports MACEField electric-field irreps '1x1o'."
+            )
+        if field_feats.irreps_out != field_linear.irreps_in:
+            raise RuntimeError(
+                "MACEField field_feats.0 output irreps must match field_linear.0 input irreps."
+            )
+        if field_linear.irreps_out != field_feats.irreps_in1:
+            raise RuntimeError(
+                "MACEField field_linear.0 output irreps must match field_feats.0 input irreps."
+            )
+        if field_linear.irreps_out.dim != expected_hidden_dim:
+            raise RuntimeError(
+                "MACEField field_linear.0 output irreps do not match the extracted H1 layout."
+            )
+        if not torch.all(field_feats.output_mask == 1):
+            raise RuntimeError(
+                "Currently, symmetrix only supports MACEField field_feats.0 output masks of all ones."
+            )
+        if not torch.all(field_linear.output_mask == 1):
+            raise RuntimeError(
+                "Currently, symmetrix only supports MACEField field_linear.0 output masks of all ones."
+            )
+        output["field_couplings"] = [
+            serialize_field_coupling(field_feats, field_linear)
+        ]
 
     ### ----- ATOMIC NUMBERS AND ENERGIES -----
 
@@ -143,6 +419,11 @@ def extract_mace_data(model, species, head=None, num_spline_points=256):
     output["atomic_numbers"] = atomic_numbers
     output["num_elements"] = len(atomic_numbers)
     output["atomic_energies"] = atomic_energies
+
+    if radial_format == "compact":
+        output["symmetrix_format_version"] = 2
+        output["radial_representation"] = "compact"
+        output["compact_radial"] = serialize_compact_radial(model, atomic_numbers)
 
     ### --- ZBL ---
 
@@ -163,50 +444,58 @@ def extract_mace_data(model, species, head=None, num_spline_points=256):
 
     ### ----- RADIAL SPLINES -----
 
-    logging.info("R0+R1")
-    r, h = np.linspace(1e-12, r_cut, num_spline_points, retstep=True)
-    spline_values_0 = []
-    spline_derivatives_0 = []
-    spline_values_1 = []
-    spline_derivatives_1 = []
-    for a_i in atomic_numbers:
-        for a_j in atomic_numbers:
-            if a_j < a_i:
-                continue
-            model_i = model.atomic_numbers.tolist().index(a_i)
-            model_j = model.atomic_numbers.tolist().index(a_j)
-            bessels = model.radial_embedding(
-                torch.tensor(
-                    r, dtype=torch.get_default_dtype(), device=device
-                ).unsqueeze(-1),
-                torch.eye(len(model.atomic_numbers), device=device),
-                torch.tensor([[model_i], [model_j]], dtype=torch.int64, device=device),
-                model.atomic_numbers.to(device),
-            )
-            if isinstance(bessels, tuple):
-                bessels = bessels[0]  # newer versions return (bessels, cutoffs)
-            # radial basis for interaction 0
-            R = model.interactions[0].conv_tp_weights(bessels).numpy(force=True)
-            spl_0 = [
-                CubicSpline(r, R[:, k], bc_type=spline_bc_type)
-                for k in range(R.shape[1])
-            ]
-            spline_values_0.append([spl(r).tolist() for spl in spl_0])
-            spline_derivatives_0.append([spl.derivative()(r).tolist() for spl in spl_0])
-            # radial basis for interaction 1
-            R = model.interactions[1].conv_tp_weights(bessels).numpy(force=True)
-            spl_1 = [
-                CubicSpline(r, R[:, k], bc_type=spline_bc_type)
-                for k in range(R.shape[1])
-            ]
-            spline_values_1.append([spl(r).tolist() for spl in spl_1])
-            spline_derivatives_1.append([spl.derivative()(r).tolist() for spl in spl_1])
+    if radial_format == "pair-splines":
+        logging.info("R0+R1")
+        r, h = np.linspace(1e-12, r_cut, num_spline_points, retstep=True)
+        spline_values_0 = []
+        spline_derivatives_0 = []
+        spline_values_1 = []
+        spline_derivatives_1 = []
+        for a_i in atomic_numbers:
+            for a_j in atomic_numbers:
+                if a_j < a_i:
+                    continue
+                model_i = model.atomic_numbers.tolist().index(a_i)
+                model_j = model.atomic_numbers.tolist().index(a_j)
+                bessels = model.radial_embedding(
+                    torch.tensor(r, dtype=model_dtype, device=device).unsqueeze(-1),
+                    torch.eye(
+                        len(model.atomic_numbers), dtype=model_dtype, device=device
+                    ),
+                    torch.tensor(
+                        [[model_i], [model_j]], dtype=torch.int64, device=device
+                    ),
+                    model.atomic_numbers.to(device),
+                )
+                if isinstance(bessels, tuple):
+                    bessels = bessels[0]  # newer versions return (bessels, cutoffs)
+                # radial basis for interaction 0
+                R = model.interactions[0].conv_tp_weights(bessels).numpy(force=True)
+                spl_0 = [
+                    CubicSpline(r, R[:, k], bc_type=spline_bc_type)
+                    for k in range(R.shape[1])
+                ]
+                spline_values_0.append([spl(r).tolist() for spl in spl_0])
+                spline_derivatives_0.append(
+                    [spl.derivative()(r).tolist() for spl in spl_0]
+                )
+                # radial basis for interaction 1
+                R = model.interactions[1].conv_tp_weights(bessels).numpy(force=True)
+                spl_1 = [
+                    CubicSpline(r, R[:, k], bc_type=spline_bc_type)
+                    for k in range(R.shape[1])
+                ]
+                spline_values_1.append([spl(r).tolist() for spl in spl_1])
+                spline_derivatives_1.append(
+                    [spl.derivative()(r).tolist() for spl in spl_1]
+                )
 
-    output["radial_spline_h"] = float(h)
-    output["radial_spline_values_0"] = spline_values_0
-    output["radial_spline_derivs_0"] = spline_derivatives_0
-    output["radial_spline_values_1"] = spline_values_1
-    output["radial_spline_derivs_1"] = spline_derivatives_1
+        output["radial_spline_h"] = float(h)
+        output["radial_spline_min"] = float(r[0])
+        output["radial_spline_values_0"] = spline_values_0
+        output["radial_spline_derivs_0"] = spline_derivatives_0
+        output["radial_spline_values_1"] = spline_values_1
+        output["radial_spline_derivs_1"] = spline_derivatives_1
 
     ### ----- H0 -----
 
@@ -236,7 +525,7 @@ def extract_mace_data(model, species, head=None, num_spline_points=256):
     logging.info("A0")
     A0_scaled = True if ("Density" in type(model.interactions[0]).__name__) else False
     output["A0_scaled"] = A0_scaled
-    if A0_scaled:
+    if A0_scaled and radial_format == "pair-splines":
         r, h = np.linspace(1e-12, r_cut, num_spline_points, retstep=True)
         A0_spline_values = []
         A0_spline_derivs = []
@@ -247,10 +536,10 @@ def extract_mace_data(model, species, head=None, num_spline_points=256):
                 model_i = model.atomic_numbers.tolist().index(a_i)
                 model_j = model.atomic_numbers.tolist().index(a_j)
                 bessels = model.radial_embedding(
-                    torch.tensor(
-                        r, dtype=torch.get_default_dtype(), device=device
-                    ).unsqueeze(-1),
-                    torch.eye(len(model.atomic_numbers), device=device),
+                    torch.tensor(r, dtype=model_dtype, device=device).unsqueeze(-1),
+                    torch.eye(
+                        len(model.atomic_numbers), dtype=model_dtype, device=device
+                    ),
                     torch.tensor(
                         [[model_i], [model_j]], dtype=torch.int64, device=device
                     ),
@@ -265,6 +554,7 @@ def extract_mace_data(model, species, head=None, num_spline_points=256):
                 A0_spline_values.append(spl(r).tolist())
                 A0_spline_derivs.append(spl.derivative()(r).tolist())
         output["A0_spline_h"] = float(h)
+        output["A0_spline_min"] = float(r[0])
         output["A0_spline_values"] = A0_spline_values
         output["A0_spline_derivs"] = A0_spline_derivs
     A0_weights = []
@@ -389,6 +679,9 @@ def extract_mace_data(model, species, head=None, num_spline_points=256):
     for l in range(L_max + 1):
         H1_weights[l, :, :] = weights_0[l, :, :] @ weights_1[l, :, :]
     output["H1_weights"] = H1_weights.flatten().tolist()
+    if is_macefield:
+        output["H1_product_weights"] = weights_0.flatten().tolist()
+        output["H1_linear_up_weights"] = weights_1.flatten().tolist()
 
     ### ----- Phi1 -----
 
@@ -474,7 +767,7 @@ def extract_mace_data(model, species, head=None, num_spline_points=256):
     logging.info("A1")
     A1_scaled = True if ("Density" in type(model.interactions[1]).__name__) else False
     output["A1_scaled"] = A1_scaled
-    if A1_scaled:
+    if A1_scaled and radial_format == "pair-splines":
         r, h = np.linspace(1e-12, r_cut, num_spline_points, retstep=True)
         A1_spline_values = []
         A1_spline_derivs = []
@@ -485,10 +778,10 @@ def extract_mace_data(model, species, head=None, num_spline_points=256):
                 model_i = model.atomic_numbers.tolist().index(a_i)
                 model_j = model.atomic_numbers.tolist().index(a_j)
                 bessels = model.radial_embedding(
-                    torch.tensor(
-                        r, dtype=torch.get_default_dtype(), device=device
-                    ).unsqueeze(-1),
-                    torch.eye(len(model.atomic_numbers), device=device),
+                    torch.tensor(r, dtype=model_dtype, device=device).unsqueeze(-1),
+                    torch.eye(
+                        len(model.atomic_numbers), dtype=model_dtype, device=device
+                    ),
                     torch.tensor(
                         [[model_i], [model_j]], dtype=torch.int64, device=device
                     ),
@@ -503,6 +796,7 @@ def extract_mace_data(model, species, head=None, num_spline_points=256):
                 A1_spline_values.append(spl(r).tolist())
                 A1_spline_derivs.append(spl.derivative()(r).tolist())
         output["A1_spline_h"] = float(h)
+        output["A1_spline_min"] = float(r[0])
         output["A1_spline_values"] = A1_spline_values
         output["A1_spline_derivs"] = A1_spline_derivs
     A1_weights = []

--- a/symmetrix/test/conftest.py
+++ b/symmetrix/test/conftest.py
@@ -1,13 +1,10 @@
 import pytest
 
-from pathlib import Path
-from urllib.request import urlretrieve
-
-
-MODEL_URLS = {
-    "MACE-OFF23_small-1-8.json": "https://www.dropbox.com/scl/fi/7rz3vh5mhacofp5w2u8cu/MACE-OFF23_small-1-8.json?rlkey=rubpqlut6uhjf4w9pej54alu7&st=w23fcknx&dl=1",
-    "mace-mp-0b3-medium-1-8.json": "https://www.dropbox.com/scl/fi/3lydfgta1lijymq98pgal/mace-mp-0b3-medium-1-8.json?rlkey=7wofp9gznqt5b3wmk5ybbj76z&st=w7cd09x6&dl=1",
-}
+from model_downloads import (
+    MODEL_URLS,
+    cached_model_path,
+    macefield_model_path as cached_macefield_model_path,
+)
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -22,9 +19,20 @@ def finalize_kokkos_after_tests():
 
 @pytest.fixture(scope="session")
 def model_cache():
-    cache_dir = Path(__file__).parent / "model-cache"
-    cache_dir.mkdir(exist_ok=True)
-    return {
-        filename: Path(urlretrieve(url, cache_dir / Path(filename).name)[0])
-        for filename, url in MODEL_URLS.items()
-    }
+    models = {}
+    for filename, url in MODEL_URLS.items():
+        if not filename.endswith(".json"):
+            continue
+        try:
+            models[filename] = cached_model_path(filename, url)
+        except RuntimeError as exc:
+            pytest.skip(str(exc))
+    return models
+
+
+@pytest.fixture(scope="session")
+def macefield_model_path():
+    try:
+        return cached_macefield_model_path()
+    except (FileNotFoundError, RuntimeError) as exc:
+        pytest.skip(str(exc))

--- a/symmetrix/test/model_downloads.py
+++ b/symmetrix/test/model_downloads.py
@@ -1,0 +1,80 @@
+import hashlib
+import os
+from pathlib import Path
+from urllib.error import URLError
+from urllib.request import urlretrieve
+
+
+MODEL_URLS = {
+    "MACE-OFF23_small-1-8.json": "https://www.dropbox.com/scl/fi/7rz3vh5mhacofp5w2u8cu/MACE-OFF23_small-1-8.json?rlkey=rubpqlut6uhjf4w9pej54alu7&st=w23fcknx&dl=1",
+    "mace-mp-0b3-medium-1-8.json": "https://www.dropbox.com/scl/fi/3lydfgta1lijymq98pgal/mace-mp-0b3-medium-1-8.json?rlkey=7wofp9gznqt5b3wmk5ybbj76z&st=w7cd09x6&dl=1",
+    "MACEField-MH-0-omat-dielectric.model": "https://github.com/mdi-group/mace-field/releases/download/1.0.2/MACEField-MH-0-omat-dielectric.model",
+}
+MACEFIELD_MODEL_SHA256 = (
+    "f92e043aaf2cd8879919db8452503553fe7b608cb749d8d169dd96d4aa094aa2"
+)
+
+
+def test_model_cache_dir():
+    override = os.environ.get("SYMMETRIX_TEST_MODEL_CACHE_DIR")
+    if override:
+        return Path(override).expanduser()
+
+    cache_home = os.environ.get("XDG_CACHE_HOME")
+    if cache_home:
+        return Path(cache_home).expanduser() / "symmetrix" / "test-models"
+
+    return Path.home() / ".cache" / "symmetrix" / "test-models"
+
+
+def file_sha256(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as model_file:
+        for chunk in iter(lambda: model_file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def cached_model_path(filename, url, env_var=None, sha256=None):
+    if env_var:
+        override = os.environ.get(env_var)
+        if override:
+            path = Path(override).expanduser()
+            if not path.exists():
+                raise FileNotFoundError(
+                    f"{env_var} points to a missing model file: {path}"
+                )
+            return path
+
+    cache_dir = test_model_cache_dir()
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    destination = cache_dir / filename
+    if destination.exists():
+        if sha256 is None or file_sha256(destination) == sha256:
+            return destination
+        destination.unlink()
+
+    try:
+        urlretrieve(url, destination)
+    except (OSError, URLError) as exc:
+        if destination.exists():
+            destination.unlink()
+        raise RuntimeError(
+            f"Could not download test model {filename} from {url}"
+        ) from exc
+    if sha256 is not None and file_sha256(destination) != sha256:
+        destination.unlink()
+        raise RuntimeError(
+            f"Downloaded test model {filename} failed SHA-256 verification"
+        )
+    return destination
+
+
+def macefield_model_path():
+    filename = "MACEField-MH-0-omat-dielectric.model"
+    return cached_model_path(
+        filename,
+        MODEL_URLS[filename],
+        env_var="SYMMETRIX_MACEFIELD_MODEL",
+        sha256=MACEFIELD_MODEL_SHA256,
+    )

--- a/symmetrix/test/test_extract_mace_data.py
+++ b/symmetrix/test/test_extract_mace_data.py
@@ -1,0 +1,239 @@
+import json
+
+import numpy as np
+import pytest
+
+try:
+    from symmetrix.extract_mace_data import extract_mace_data
+except ImportError as exc:
+    extract_mace_data = None
+    extract_mace_data_import_error = exc
+else:
+    extract_mace_data_import_error = None
+
+
+@pytest.mark.skipif(
+    extract_mace_data is None,
+    reason=f"extract_mace_data is not available: {extract_mace_data_import_error}",
+)
+def test_macefield_extractor_includes_field_schema(macefield_model_path):
+    data = extract_mace_data(
+        macefield_model_path,
+        species=[7, 13],
+        head="mp-dielectric",
+        num_spline_points=8,
+    )
+
+    assert data["model_type"] == "MACEField"
+    assert data["has_field_coupling"] is True
+    assert len(data["field_couplings"]) == 1
+
+    coupling = data["field_couplings"][0]
+    assert coupling["field_feats_irreps_in1"] == "128x0e+128x1o"
+    assert coupling["field_feats_irreps_in2"] == "1x1o"
+    assert coupling["field_feats_irreps_out"] == "128x0e+128x1o"
+    assert coupling["field_linear_irreps_in"] == "128x0e+128x1o"
+    assert coupling["field_linear_irreps_out"] == "128x0e+128x1o"
+
+    assert len(coupling["field_feats_weight"]) == 32768
+    assert len(coupling["field_feats_output_mask"]) == 512
+    assert len(coupling["field_linear_weight"]) == 32768
+    assert coupling["field_linear_bias"] == []
+    assert len(coupling["field_linear_output_mask"]) == 512
+
+    assert len(data["H1_product_weights"]) == 32768
+    assert len(data["H1_linear_up_weights"]) == 32768
+
+    assert data["symmetrix_format_version"] == 2
+    assert data["radial_representation"] == "compact"
+    assert "radial_spline_values_0" not in data
+    assert "radial_spline_values_1" not in data
+    assert "A0_spline_values" not in data
+    assert "A1_spline_values" not in data
+
+    radial = data["compact_radial"]
+    assert radial["num_spline_points"] == 8
+    assert radial["basis"]["type"] == "bessel"
+    assert radial["cutoff"]["type"] == "polynomial"
+    assert radial["distance_transform"]["type"] == "agnesi"
+    assert len(radial["distance_transform"]["covalent_radii"]) == 2
+    assert radial["networks"]["R0"]["shape"] == [10, 64, 64, 64, 512]
+    assert radial["networks"]["R1"]["shape"] == [10, 64, 64, 64, 1280]
+    assert radial["networks"]["A0"]["postprocess"] == "tanh-square"
+    assert radial["networks"]["A1"]["postprocess"] == "tanh-square"
+
+
+@pytest.mark.skipif(
+    extract_mace_data is None,
+    reason=f"extract_mace_data is not available: {extract_mace_data_import_error}",
+)
+def test_macefield_extractor_rejects_unsupported_lmax(
+    macefield_model_path,
+    monkeypatch,
+):
+    from e3nn.o3 import Irreps
+    from mace.tools.scripts_utils import remove_pt_head
+    import torch
+
+    model = torch.load(macefield_model_path, map_location="cpu", weights_only=False)
+    if hasattr(model, "heads") and len(model.heads) != 1:
+        model = remove_pt_head(model, "mp-dielectric")
+    model = model.to(device="cpu", dtype=torch.float64)
+    num_channels = model.node_embedding.linear.irreps_out.count("0e")
+    model.products[0].linear.irreps_out = Irreps(
+        f"{num_channels}x0e+{num_channels}x1o+{num_channels}x2e"
+    )
+    monkeypatch.setattr(model, "to", lambda *args, **kwargs: model)
+    monkeypatch.setattr(torch, "load", lambda *args, **kwargs: model)
+
+    with pytest.raises(RuntimeError, match=r"scalar and vector features \(L_max=1\)"):
+        extract_mace_data(
+            macefield_model_path,
+            species=[7, 13],
+            head="mp-dielectric",
+            num_spline_points=8,
+        )
+
+
+@pytest.mark.skipif(
+    extract_mace_data is None,
+    reason=f"extract_mace_data is not available: {extract_mace_data_import_error}",
+)
+def test_macefield_extractor_retains_legacy_pair_splines(macefield_model_path):
+    data = extract_mace_data(
+        macefield_model_path,
+        species=[7, 13],
+        head="mp-dielectric",
+        num_spline_points=8,
+        radial_format="pair-splines",
+    )
+
+    assert "symmetrix_format_version" not in data
+    assert "compact_radial" not in data
+    assert data["radial_spline_min"] == pytest.approx(1e-12)
+    assert data["A0_spline_min"] == pytest.approx(1e-12)
+    assert data["A1_spline_min"] == pytest.approx(1e-12)
+    assert len(data["radial_spline_values_0"]) == 3
+    assert len(data["radial_spline_values_1"]) == 3
+    assert len(data["A0_spline_values"]) == 3
+    assert len(data["A1_spline_values"]) == 3
+
+
+@pytest.mark.skipif(
+    extract_mace_data is None,
+    reason=f"extract_mace_data is not available: {extract_mace_data_import_error}",
+)
+def test_legacy_pair_splines_retain_low_node_count_support(macefield_model_path):
+    for num_spline_points in (2, 3):
+        data = extract_mace_data(
+            macefield_model_path,
+            species=[7],
+            head="mp-dielectric",
+            num_spline_points=num_spline_points,
+            radial_format="pair-splines",
+        )
+
+        assert len(data["radial_spline_values_0"][0][0]) == num_spline_points
+        assert len(data["radial_spline_derivs_0"][0][0]) == num_spline_points
+        assert len(data["A0_spline_values"][0]) == num_spline_points
+        assert len(data["A1_spline_values"][0]) == num_spline_points
+
+
+@pytest.mark.skipif(
+    extract_mace_data is None,
+    reason=f"extract_mace_data is not available: {extract_mace_data_import_error}",
+)
+def test_macefield_extractor_defaults_to_all_checkpoint_elements(macefield_model_path):
+    data = extract_mace_data(
+        macefield_model_path,
+        head="mp-dielectric",
+        num_spline_points=8,
+    )
+
+    assert len(data["atomic_numbers"]) == 79
+    assert data["num_elements"] == 79
+    assert data["atomic_numbers"] == sorted(data["atomic_numbers"])
+    assert len(data["compact_radial"]["distance_transform"]["covalent_radii"]) == 79
+    assert "radial_spline_values_0" not in data
+    assert "radial_spline_values_1" not in data
+
+
+@pytest.mark.skipif(
+    extract_mace_data is None,
+    reason=f"extract_mace_data is not available: {extract_mace_data_import_error}",
+)
+def test_compact_radial_values_and_derivatives_match_pair_splines(
+    macefield_model_path,
+    tmp_path,
+):
+    from symmetrix import symmetrix as native_symmetrix
+
+    compact = extract_mace_data(
+        macefield_model_path,
+        species=[7, 13],
+        head="mp-dielectric",
+        num_spline_points=32,
+    )
+    legacy = extract_mace_data(
+        macefield_model_path,
+        species=[7, 13],
+        head="mp-dielectric",
+        num_spline_points=32,
+        radial_format="pair-splines",
+    )
+    compact_path = tmp_path / "compact.json"
+    legacy_path = tmp_path / "legacy.json"
+    compact_path.write_text(json.dumps(compact, separators=(",", ":")))
+    legacy_path.write_text(json.dumps(legacy))
+
+    compact_model = native_symmetrix.MACE(str(compact_path))
+    legacy_model = native_symmetrix.MACE(str(legacy_path))
+    compact_model.prepare_active_types(
+        np.asarray([0, 1, 0, 1], dtype=np.int32)[::2],
+    )
+    assert compact_model.active_atomic_numbers == [7]
+    grid_min = compact["compact_radial"]["spline_grid_min"]
+    h = legacy["radial_spline_h"]
+    rng = np.random.default_rng(17)
+    radii = np.concatenate(
+        (
+            grid_min + h * np.arange(32),
+            rng.uniform(grid_min, compact_model.r_cut - h, size=17),
+        )
+    )
+    node_types = np.asarray([0, 1], dtype=np.int32)
+    num_neigh = np.asarray([len(radii), len(radii)], dtype=np.int32)
+    neigh_types = np.concatenate(
+        (
+            np.full(len(radii), 1, dtype=np.int32),
+            np.full(len(radii), 0, dtype=np.int32),
+        )
+    )
+    pair_radii = np.tile(radii, 2)
+
+    for method_name, values_name, derivatives_name in (
+        ("compute_R0", "R0", "R0_deriv"),
+        ("compute_R1", "R1", "R1_deriv"),
+    ):
+        for model in (compact_model, legacy_model):
+            getattr(model, method_name)(
+                2,
+                node_types,
+                num_neigh,
+                neigh_types,
+                pair_radii,
+            )
+        assert np.allclose(
+            getattr(compact_model, values_name),
+            getattr(legacy_model, values_name),
+            rtol=0.0,
+            atol=1e-11,
+        )
+        assert np.allclose(
+            getattr(compact_model, derivatives_name),
+            getattr(legacy_model, derivatives_name),
+            rtol=0.0,
+            atol=1e-9,
+        )
+        assert np.all(np.isfinite(getattr(compact_model, values_name)))
+        assert np.all(np.isfinite(getattr(compact_model, derivatives_name)))

--- a/symmetrix/test/test_field_calculators.py
+++ b/symmetrix/test/test_field_calculators.py
@@ -1,0 +1,354 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from ase import Atoms
+from ase.calculators.calculator import Calculator, all_changes
+
+from symmetrix import FieldAwareCalculator, FieldContributionCalculator, Symmetrix
+
+
+class DummyFieldSymmetrix(Symmetrix):
+    def __init__(self):
+        Calculator.__init__(self)
+        self.evaluator = SimpleNamespace(has_field_coupling=True)
+        self._electric_field = None
+        self._macefield_electric_field = None
+        self.implemented_properties = [
+            "energy",
+            "free_energy",
+            "energies",
+            "forces",
+            "stress",
+            "node_energy",
+            "polarization",
+            "becs",
+            "polarizability",
+        ]
+        self.calls = []
+
+    def _mace_inputs(self, atoms):
+        return None
+
+    @staticmethod
+    def model_results(atoms, electric_field, properties):
+        field = np.asarray(electric_field, dtype=float)
+        positions = np.asarray(atoms.positions, dtype=float)
+        num_atoms = len(atoms)
+        x_sum = np.sum(positions[:, 0])
+        field_norm_2 = np.dot(field, field)
+        normal_energy = np.sum(positions**2)
+        field_energy = field[0] * x_sum + 0.05 * field_norm_2 * x_sum
+        total_energy = normal_energy + field_energy
+
+        forces = -2.0 * positions
+        forces[:, 0] -= field[0] + 0.05 * field_norm_2
+        stress = np.arange(6, dtype=float) + np.array(
+            [field[0], field[1], field[2], field[0], field[1], field[2]]
+        )
+        results = {
+            "energy": total_energy,
+            "free_energy": total_energy,
+            "energies": np.full(num_atoms, total_energy / num_atoms),
+            "forces": forces,
+            "stress": stress,
+            "node_energy": np.full(num_atoms, total_energy / num_atoms),
+        }
+        if any(
+            prop in properties for prop in ("polarization", "becs", "polarizability")
+        ):
+            results["polarization"] = field + np.array([1.0, 2.0, 3.0])
+        if "becs" in properties:
+            results["becs"] = np.full((num_atoms, 9), 4.0)
+        if "polarizability" in properties:
+            results["polarizability"] = np.arange(9, dtype=float)
+        return results
+
+    def _calculate_macefield_results(
+        self,
+        atoms,
+        electric_field,
+        properties,
+        mace_inputs=None,
+    ):
+        self.calls.append(np.array(electric_field, copy=True))
+        return self.model_results(atoms, electric_field, properties)
+
+
+class DummyBaseCalculator(Calculator):
+    implemented_properties = ["energy", "free_energy", "energies", "forces", "stress"]
+
+    def __init__(
+        self,
+        implemented_properties=None,
+        matrix_stress=False,
+        sparse_results=False,
+        reject_attached_calculator=False,
+    ):
+        Calculator.__init__(self)
+        if implemented_properties is not None:
+            self.implemented_properties = list(implemented_properties)
+        self.calls = 0
+        self.energy_offset = 10.0
+        self.matrix_stress = matrix_stress
+        self.sparse_results = sparse_results
+        self.reject_attached_calculator = reject_attached_calculator
+
+    def calculate(self, atoms=None, properties=["energy"], system_changes=all_changes):
+        if self.reject_attached_calculator and atoms.calc is not None:
+            raise NotImplementedError("attached calculator is not supported")
+        Calculator.calculate(self, atoms, properties, system_changes)
+        self.calls += 1
+        energy = self.energy_offset + np.sum(self.atoms.positions**2)
+        available = {
+            "energy": energy,
+            "free_energy": energy,
+            "energies": np.full(len(self.atoms), energy / len(self.atoms)),
+            "forces": -2.0 * self.atoms.positions,
+            "stress": np.eye(3) * 2.0 if self.matrix_stress else np.full(6, 2.0),
+        }
+        self.results = {
+            prop: value
+            for prop, value in available.items()
+            if prop in self.implemented_properties
+            and (not self.sparse_results or prop in properties)
+        }
+
+
+@pytest.fixture
+def atoms():
+    atoms = Atoms(
+        "H2",
+        positions=[[0.1, 0.0, 0.0], [0.8, 0.2, 0.0]],
+        cell=[4.0, 4.0, 4.0],
+        pbc=True,
+    )
+    atoms.info["electric_field"] = np.array([0.2, -0.1, 0.05])
+    return atoms
+
+
+def test_field_contribution_matches_requested_minus_zero_field(atoms):
+    field_calculator = DummyFieldSymmetrix()
+    contribution = FieldContributionCalculator(field_calculator)
+    requested = atoms.info["electric_field"]
+    expected_field = field_calculator.model_results(atoms, requested, [])
+    expected_zero = field_calculator.model_results(atoms, np.zeros(3), [])
+
+    atoms.calc = contribution
+    atoms.get_potential_energy()
+
+    for prop in ("energy", "free_energy", "energies", "forces", "stress"):
+        expected = np.asarray(expected_field[prop]) - np.asarray(expected_zero[prop])
+        assert np.allclose(contribution.get_property(prop, atoms), expected)
+    assert np.allclose(field_calculator.calls, [np.zeros(3), requested])
+
+
+def test_field_contribution_passes_through_response_properties(atoms):
+    field_calculator = DummyFieldSymmetrix()
+    contribution = FieldContributionCalculator(field_calculator)
+    atoms.calc = contribution
+
+    requested = ["polarization", "becs", "polarizability"]
+    contribution.calculate(atoms, requested, all_changes)
+    actual = contribution.results
+    expected = field_calculator.model_results(
+        atoms,
+        atoms.info["electric_field"],
+        requested,
+    )
+
+    assert np.allclose(actual["polarization"], expected["polarization"])
+    assert np.allclose(actual["becs"], expected["becs"])
+    assert np.allclose(actual["polarizability"], expected["polarizability"])
+    assert len(field_calculator.calls) == 1
+    assert np.allclose(field_calculator.calls[0], atoms.info["electric_field"])
+
+
+def test_field_contribution_reuses_zero_reference_for_field_only_changes(atoms):
+    field_calculator = DummyFieldSymmetrix()
+    contribution = FieldContributionCalculator(field_calculator)
+    atoms.calc = contribution
+
+    atoms.get_potential_energy()
+    assert len(field_calculator.calls) == 2
+
+    atoms.info["electric_field"][0] = 0.3
+    atoms.get_potential_energy()
+    assert len(field_calculator.calls) == 3
+    assert np.allclose(field_calculator.calls[-1], atoms.info["electric_field"])
+
+    atoms.positions[0, 0] += 0.1
+    atoms.get_potential_energy()
+    assert len(field_calculator.calls) == 5
+    assert np.allclose(field_calculator.calls[-2], np.zeros(3))
+
+
+def test_field_contribution_force_is_energy_derivative(atoms):
+    contribution = FieldContributionCalculator(DummyFieldSymmetrix())
+    atoms.calc = contribution
+    force = atoms.get_forces()[0, 0]
+    position = atoms.positions[0, 0]
+    step = 1e-6
+
+    atoms.positions[0, 0] = position + step
+    energy_plus = atoms.get_potential_energy()
+    atoms.positions[0, 0] = position - step
+    energy_minus = atoms.get_potential_energy()
+
+    assert np.isclose(force, -(energy_plus - energy_minus) / (2.0 * step), atol=1e-9)
+
+
+def test_zero_field_additive_properties_skip_field_model(atoms):
+    field_calculator = DummyFieldSymmetrix()
+    contribution = FieldContributionCalculator(field_calculator)
+    atoms.info["electric_field"] = np.zeros(3)
+    atoms.calc = contribution
+
+    assert atoms.get_potential_energy() == 0.0
+    assert np.array_equal(atoms.get_forces(), np.zeros((len(atoms), 3)))
+    assert np.array_equal(atoms.get_stress(), np.zeros(6))
+    assert field_calculator.calls == []
+
+    assert contribution.get_property("polarization", atoms).shape == (3,)
+    assert len(field_calculator.calls) == 1
+
+
+def test_field_aware_calculator_combines_base_and_field_contribution(atoms):
+    base = DummyBaseCalculator()
+    field_calculator = DummyFieldSymmetrix()
+    calculator = FieldAwareCalculator(base, field_calculator)
+    contribution = calculator.field_contribution
+    atoms.calc = calculator
+
+    requested = ["energy", "free_energy", "energies", "forces", "stress"]
+    properties = atoms.get_properties(requested)
+    for prop in requested:
+        actual = properties[prop]
+        expected = base.get_property(prop, atoms) + contribution.get_property(
+            prop, atoms
+        )
+        assert np.allclose(actual, expected)
+
+
+def test_field_aware_calculator_reduces_exactly_to_base_at_zero_field(atoms):
+    base = DummyBaseCalculator()
+    field_calculator = DummyFieldSymmetrix()
+    calculator = FieldAwareCalculator(base, field_calculator)
+    atoms.info["electric_field"] = np.zeros(3)
+    atoms.calc = calculator
+
+    assert atoms.get_potential_energy() == base.get_property("energy", atoms)
+    assert np.array_equal(atoms.get_forces(), base.get_property("forces", atoms))
+    assert field_calculator.calls == []
+
+
+def test_field_aware_property_negotiation_and_response_only_request(atoms):
+    base = DummyBaseCalculator(implemented_properties=["energy", "forces"])
+    field_calculator = DummyFieldSymmetrix()
+    calculator = FieldAwareCalculator(base, field_calculator)
+
+    assert calculator.implemented_properties == [
+        "energy",
+        "forces",
+        "polarization",
+        "becs",
+        "polarizability",
+    ]
+
+    atoms.calc = calculator
+    polarization = calculator.get_property("polarization", atoms)
+    assert polarization.shape == (3,)
+    assert base.calls == 0
+    assert len(field_calculator.calls) == 1
+
+
+def test_field_aware_accepts_matrix_stress_from_base(atoms):
+    base = DummyBaseCalculator(matrix_stress=True)
+    calculator = FieldAwareCalculator(base, DummyFieldSymmetrix())
+    atoms.calc = calculator
+
+    actual = atoms.get_stress()
+    expected = np.array([2.0, 2.0, 2.0, 0.0, 0.0, 0.0])
+    expected += calculator.field_contribution.get_property("stress", atoms)
+    assert np.allclose(actual, expected)
+
+
+def test_field_aware_detaches_outer_calculator_from_base_atoms(atoms):
+    base = DummyBaseCalculator(reject_attached_calculator=True)
+    calculator = FieldAwareCalculator(base, DummyFieldSymmetrix())
+    atoms.calc = calculator
+
+    assert np.isfinite(atoms.get_potential_energy())
+    assert base.atoms.calc is None
+
+
+def test_field_aware_invalidates_after_base_reset(atoms):
+    base = DummyBaseCalculator()
+    calculator = FieldAwareCalculator(base, DummyFieldSymmetrix())
+    atoms.calc = calculator
+
+    initial_energy = atoms.get_potential_energy()
+    base.energy_offset += 3.0
+    base.reset()
+    updated_energy = atoms.get_potential_energy()
+
+    assert np.isclose(updated_energy - initial_energy, 3.0)
+
+
+def test_field_aware_tracks_current_sparse_base_results(atoms):
+    base = DummyBaseCalculator(sparse_results=True)
+    calculator = FieldAwareCalculator(base, DummyFieldSymmetrix())
+    atoms.calc = calculator
+
+    atoms.get_potential_energy()
+    atoms.get_forces()
+    calls_after_forces = base.calls
+    atoms.get_forces()
+
+    assert calls_after_forces == 2
+    assert base.calls == calls_after_forces
+
+
+def test_field_aware_constructor_and_property_field_overrides(atoms):
+    field_calculator = DummyFieldSymmetrix()
+    calculator = FieldAwareCalculator(
+        DummyBaseCalculator(),
+        field_calculator,
+        electric_field=np.array([0.4, 0.0, 0.0]),
+    )
+    atoms.calc = calculator
+
+    initial_energy = atoms.get_potential_energy()
+    assert np.allclose(field_calculator.calls[-1], [0.4, 0.0, 0.0])
+
+    calculator.electric_field = np.array([0.5, 0.0, 0.0])
+    updated_energy = atoms.get_potential_energy()
+    assert np.allclose(field_calculator.calls[-1], [0.5, 0.0, 0.0])
+    assert updated_energy != initial_energy
+    assert len(field_calculator.calls) == 3
+
+
+def test_calculator_field_override_takes_precedence(atoms):
+    field_calculator = DummyFieldSymmetrix()
+    contribution = FieldContributionCalculator(field_calculator)
+    contribution.electric_field = np.array([0.4, 0.0, 0.0])
+    atoms.calc = contribution
+
+    atoms.get_potential_energy()
+    assert np.allclose(field_calculator.calls[-1], [0.4, 0.0, 0.0])
+
+    contribution.electric_field = np.array([0.5, 0.0, 0.0])
+    atoms.get_potential_energy()
+    assert np.allclose(field_calculator.calls[-1], [0.5, 0.0, 0.0])
+    assert len(field_calculator.calls) == 3
+
+
+def test_field_contribution_requires_field_aware_symmetrix():
+    with pytest.raises(TypeError, match="must be a Symmetrix"):
+        FieldContributionCalculator(DummyBaseCalculator())
+
+    plain = DummyFieldSymmetrix()
+    plain.evaluator.has_field_coupling = False
+    with pytest.raises(ValueError, match="field-aware"):
+        FieldContributionCalculator(plain)

--- a/symmetrix/test/test_mace.py
+++ b/symmetrix/test/test_mace.py
@@ -1,23 +1,23 @@
 import ase
 from ase.neighborlist import neighbor_list
 import numpy as np
-import os
 import pytest
-from urllib.request import urlretrieve
 
 import symmetrix
+from model_downloads import MODEL_URLS, cached_model_path
 
-if not os.path.exists("MACE-OFF23_small-1-8.json"):
-    urlretrieve(
-        "https://www.dropbox.com/scl/fi/7rz3vh5mhacofp5w2u8cu/MACE-OFF23_small-1-8.json?rlkey=rubpqlut6uhjf4w9pej54alu7&st=w23fcknx&dl=1",
-        "MACE-OFF23_small-1-8.json",
-    )
 
-if not os.path.exists("mace-mp-0b3-medium-1-8.json"):
-    urlretrieve(
-        "https://www.dropbox.com/scl/fi/3lydfgta1lijymq98pgal/mace-mp-0b3-medium-1-8.json?rlkey=7wofp9gznqt5b3wmk5ybbj76z&st=w7cd09x6&dl=1",
-        "mace-mp-0b3-medium-1-8.json",
-    )
+def _cached_json_model(filename):
+    try:
+        return cached_model_path(filename, MODEL_URLS[filename])
+    except RuntimeError as exc:
+        pytest.skip(str(exc), allow_module_level=True)
+
+
+JSON_MODELS = {
+    filename: _cached_json_model(filename)
+    for filename in ("MACE-OFF23_small-1-8.json", "mace-mp-0b3-medium-1-8.json")
+}
 
 model = "mace-off-small"
 # model = "mace-off-medium"
@@ -39,7 +39,7 @@ else:
 
 # load model
 if model == "mace-off-small":
-    evaluator = MACE("MACE-OFF23_small-1-8.json")
+    evaluator = MACE(str(JSON_MODELS["MACE-OFF23_small-1-8.json"]))
 elif model == "mace-off-medium":
     evaluator = MACE("MACE-OFF23_medium-1-8.json")
 elif model == "mace-off-large":
@@ -53,7 +53,7 @@ elif model == "mace-mp-large":
 elif model == "mace-mpa-medium":
     evaluator = MACE("mace-mpa-0-medium-1-8.json")
 elif model == "mace-mp-0b3-medium":
-    evaluator = MACE("mace-mp-0b3-medium-1-8.json")
+    evaluator = MACE(str(JSON_MODELS["mace-mp-0b3-medium-1-8.json"]))
 elif model == "mace-omat-0-medium":
     evaluator = MACE("mace-omat-0-medium-1-8.json")
 
@@ -86,6 +86,28 @@ def numerical_gradient(f, x):
         grad[i] = (fp - fm) / (2 * h)
     f(x)  # reverts side effects of applying f(x+h)
     return grad
+
+
+@pytest.mark.parametrize("backend_name", ["MACE", "MACEKokkos", "MACEKokkosFloat"])
+def test_field_entry_point_rejects_standard_mace(backend_name):
+    if not hasattr(symmetrix, backend_name):
+        pytest.skip(f"{backend_name} is not available.")
+    if backend_name != "MACE" and not symmetrix._kokkos_is_initialized():
+        symmetrix._init_kokkos()
+
+    backend = getattr(symmetrix, backend_name)
+    standard = backend(str(JSON_MODELS["MACE-OFF23_small-1-8.json"]))
+    with pytest.raises(ValueError, match="requires field coupling"):
+        standard.compute_node_energies_forces_field(
+            num_nodes,
+            np.asarray(node_types, dtype=np.int32),
+            np.asarray(num_neigh, dtype=np.int32),
+            np.asarray(j_list, dtype=np.int32),
+            np.asarray(neigh_types, dtype=np.int32),
+            xyz.reshape(-1),
+            r,
+            np.zeros(3, dtype=np.float64),
+        )
 
 
 # def test_Y():
@@ -754,7 +776,7 @@ def test_compute_node_energies_forces():
 
 
 def test_zbl():
-    evaluator = MACE("mace-mp-0b3-medium-1-8.json")
+    evaluator = MACE(str(JSON_MODELS["mace-mp-0b3-medium-1-8.json"]))
     atoms = ase.Atoms(
         "OHH", positions=[[0.0, -0.5, 0.0], [0.5, 0.0, 0.0], [0.0, 0.5, 0.0]]
     )

--- a/symmetrix/test/test_macefield_field_transform.py
+++ b/symmetrix/test/test_macefield_field_transform.py
@@ -1,0 +1,228 @@
+from math import sqrt
+
+import pytest
+
+try:
+    import torch
+
+    torch.serialization.add_safe_globals([slice])
+    from mace.tools.scripts_utils import remove_pt_head
+except ImportError as exc:
+    pytest.skip(
+        f"mace-field tensor test dependencies are not available: {exc}",
+        allow_module_level=True,
+    )
+
+
+@pytest.fixture(scope="module")
+def macefield_modules(macefield_model_path):
+    model = torch.load(
+        macefield_model_path, map_location=torch.device("cpu"), weights_only=False
+    ).to(torch.float64)
+    if hasattr(model, "heads") and len(model.heads) != 1:
+        torch.set_default_dtype(next(model.parameters()).dtype)
+        model = remove_pt_head(model, "mp-dielectric")
+    model.eval()
+
+    return model.field_feats[0], model.field_linear[0]
+
+
+def _frozen_inputs():
+    generator = torch.Generator(device="cpu").manual_seed(20260710)
+    h1_pre = torch.randn(7, 512, dtype=torch.float64, generator=generator)
+    electric_field = torch.randn(7, 3, dtype=torch.float64, generator=generator)
+    return h1_pre, electric_field
+
+
+def _weight_views(module):
+    offset = 0
+    views = []
+    for instruction in module.instructions:
+        numel = 1
+        for size in instruction.path_shape:
+            numel *= size
+        views.append(
+            module.weight.detach()
+            .narrow(0, offset, numel)
+            .reshape(instruction.path_shape)
+        )
+        offset += numel
+    assert offset == module.weight.numel()
+    return views
+
+
+def _compact_field_coupling(field_feats, field_linear):
+    return {
+        "field_feats": {
+            "irreps_in1": str(field_feats.irreps_in1),
+            "irreps_in2": str(field_feats.irreps_in2),
+            "irreps_out": str(field_feats.irreps_out),
+            "output_mask": field_feats.output_mask.detach().clone(),
+            "instructions": [
+                {
+                    "i_in1": instruction.i_in1,
+                    "i_in2": instruction.i_in2,
+                    "i_out": instruction.i_out,
+                    "connection_mode": instruction.connection_mode,
+                    "path_shape": instruction.path_shape,
+                    "path_weight": instruction.path_weight,
+                    "weight": weight.clone(),
+                }
+                for instruction, weight in zip(
+                    field_feats.instructions, _weight_views(field_feats)
+                )
+            ],
+        },
+        "field_linear": {
+            "irreps_in": str(field_linear.irreps_in),
+            "irreps_out": str(field_linear.irreps_out),
+            "output_mask": field_linear.output_mask.detach().clone(),
+            "bias": field_linear.bias.detach().clone(),
+            "instructions": [
+                {
+                    "i_in": instruction.i_in,
+                    "i_out": instruction.i_out,
+                    "path_shape": instruction.path_shape,
+                    "path_weight": instruction.path_weight,
+                    "weight": weight.clone(),
+                }
+                for instruction, weight in zip(
+                    field_linear.instructions, _weight_views(field_linear)
+                )
+            ],
+        },
+    }
+
+
+def _standalone_field_feats(coupling, h1_pre, electric_field):
+    field_feats = coupling["field_feats"]
+    assert field_feats["irreps_in1"] == "128x0e+128x1o"
+    assert field_feats["irreps_in2"] == "1x1o"
+    assert field_feats["irreps_out"] == "128x0e+128x1o"
+
+    scalar_in = h1_pre[..., :128]
+    vector_in = h1_pre[..., 128:].reshape(*h1_pre.shape[:-1], 128, 3)
+    field = electric_field.reshape(*electric_field.shape[:-1], 1, 3)
+
+    scalar_out = torch.zeros_like(scalar_in)
+    vector_out = torch.zeros_like(vector_in)
+
+    for instruction in field_feats["instructions"]:
+        weight = instruction["weight"].to(dtype=h1_pre.dtype, device=h1_pre.device)
+        assert instruction["connection_mode"] == "uvw"
+        assert instruction["path_shape"] == (128, 1, 128)
+
+        if (instruction["i_in1"], instruction["i_in2"], instruction["i_out"]) == (
+            0,
+            0,
+            1,
+        ):
+            vector_out += (
+                instruction["path_weight"]
+                * torch.einsum("uvw,...u,...vj->...wj", weight, scalar_in, field)
+                / sqrt(3.0)
+            )
+        elif (instruction["i_in1"], instruction["i_in2"], instruction["i_out"]) == (
+            1,
+            0,
+            0,
+        ):
+            scalar_out += (
+                instruction["path_weight"]
+                * torch.einsum("uvw,...ui,...vi->...w", weight, vector_in, field)
+                / sqrt(3.0)
+            )
+        else:
+            raise AssertionError(f"Unsupported field_feats instruction: {instruction}")
+
+    output = torch.cat(
+        [scalar_out, vector_out.reshape(*h1_pre.shape[:-1], 384)], dim=-1
+    )
+    return output * field_feats["output_mask"].to(
+        dtype=output.dtype, device=output.device
+    )
+
+
+def _standalone_field_linear(coupling, delta_feats):
+    field_linear = coupling["field_linear"]
+    assert field_linear["irreps_in"] == "128x0e+128x1o"
+    assert field_linear["irreps_out"] == "128x0e+128x1o"
+    assert field_linear["bias"].numel() == 0
+
+    scalar_in = delta_feats[..., :128]
+    vector_in = delta_feats[..., 128:].reshape(*delta_feats.shape[:-1], 128, 3)
+
+    scalar_out = torch.zeros_like(scalar_in)
+    vector_out = torch.zeros_like(vector_in)
+
+    for instruction in field_linear["instructions"]:
+        weight = instruction["weight"].to(
+            dtype=delta_feats.dtype, device=delta_feats.device
+        )
+        assert instruction["path_shape"] == (128, 128)
+
+        if (instruction["i_in"], instruction["i_out"]) == (0, 0):
+            scalar_out += instruction["path_weight"] * torch.einsum(
+                "uw,...u->...w", weight, scalar_in
+            )
+        elif (instruction["i_in"], instruction["i_out"]) == (1, 1):
+            vector_out += instruction["path_weight"] * torch.einsum(
+                "uw,...ui->...wi", weight, vector_in
+            )
+        else:
+            raise AssertionError(f"Unsupported field_linear instruction: {instruction}")
+
+    output = torch.cat(
+        [scalar_out, vector_out.reshape(*delta_feats.shape[:-1], 384)], dim=-1
+    )
+    return output * field_linear["output_mask"].to(
+        dtype=output.dtype, device=output.device
+    )
+
+
+def _standalone_field_transform(coupling, h1_pre, electric_field):
+    delta_feats = _standalone_field_feats(coupling, h1_pre, electric_field)
+    return h1_pre - _standalone_field_linear(coupling, delta_feats)
+
+
+def test_checkpoint_field_coupling_uses_supported_hidden_layout(macefield_modules):
+    field_feats, field_linear = macefield_modules
+
+    assert str(field_feats.irreps_in1) == "128x0e+128x1o"
+    assert str(field_feats.irreps_in2) == "1x1o"
+    assert str(field_feats.irreps_out) == "128x0e+128x1o"
+    assert str(field_linear.irreps_in) == "128x0e+128x1o"
+    assert str(field_linear.irreps_out) == "128x0e+128x1o"
+
+    assert [instruction.path_shape for instruction in field_feats.instructions] == [
+        (128, 1, 128),
+        (128, 1, 128),
+    ]
+    assert [instruction.path_shape for instruction in field_linear.instructions] == [
+        (128, 128),
+        (128, 128),
+    ]
+    assert torch.all(field_feats.output_mask == 1)
+    assert torch.all(field_linear.output_mask == 1)
+
+
+def test_standalone_field_feats_matches_pytorch_macefield(macefield_modules):
+    field_feats, _ = macefield_modules
+    coupling = _compact_field_coupling(*macefield_modules)
+    h1_pre, electric_field = _frozen_inputs()
+
+    expected = field_feats(h1_pre, electric_field)
+    actual = _standalone_field_feats(coupling, h1_pre, electric_field)
+
+    assert torch.allclose(actual, expected, atol=1e-12, rtol=1e-12)
+
+
+def test_standalone_field_transform_matches_pytorch_macefield(macefield_modules):
+    field_feats, field_linear = macefield_modules
+    coupling = _compact_field_coupling(field_feats, field_linear)
+    h1_pre, electric_field = _frozen_inputs()
+
+    expected = h1_pre - field_linear(field_feats(h1_pre, electric_field))
+    actual = _standalone_field_transform(coupling, h1_pre, electric_field)
+
+    assert torch.allclose(actual, expected, atol=1e-12, rtol=1e-12)

--- a/symmetrix/test/test_macefield_native.py
+++ b/symmetrix/test/test_macefield_native.py
@@ -1,0 +1,621 @@
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+try:
+    import torch
+
+    from ase.build import bulk
+    from symmetrix import symmetrix as native_symmetrix
+    from symmetrix.extract_mace_data import extract_mace_data
+    from mace.calculators import MACECalculator
+    from test_macefield_field_transform import (
+        _compact_field_coupling,
+        _frozen_inputs,
+        _standalone_field_transform,
+    )
+except ImportError as exc:
+    pytest.skip(
+        f"MACEField native test dependencies are not available: {exc}",
+        allow_module_level=True,
+    )
+
+
+try:
+    from matscipy.neighbours import neighbour_list as neighbor_list
+except ImportError:
+    from ase.neighborlist import neighbor_list
+
+
+@pytest.fixture(scope="module")
+def macefield_json_path(tmp_path_factory, macefield_model_path):
+    output_path = tmp_path_factory.mktemp("macefield-json") / "macefield.json"
+    data = extract_mace_data(
+        macefield_model_path,
+        species=[7, 13],
+        head="mp-dielectric",
+        num_spline_points=8,
+    )
+    output_path.write_text(json.dumps(data))
+    return output_path
+
+
+@pytest.fixture(scope="module")
+def macefield_full_json_path(tmp_path_factory, macefield_model_path):
+    output_path = tmp_path_factory.mktemp("macefield-full-json") / "macefield.json"
+    data = extract_mace_data(
+        macefield_model_path,
+        species=[7, 13],
+        head="mp-dielectric",
+    )
+    output_path.write_text(json.dumps(data))
+    return output_path
+
+
+def _compact_to_native_h1(compact):
+    compact = np.asarray(compact)
+    native = np.zeros((compact.shape[0], 4, 128), dtype=np.float64)
+    native[:, 0, :] = compact[:, :128]
+    native[:, 1:, :] = (
+        -compact[:, 128:].reshape(compact.shape[0], 128, 3).transpose(0, 2, 1)
+    )
+    return native.reshape(-1)
+
+
+def _native_to_compact_h1(native, num_nodes):
+    native = np.asarray(native, dtype=np.float64).reshape(num_nodes, 4, 128)
+    compact = np.zeros((num_nodes, 512), dtype=np.float64)
+    compact[:, :128] = native[:, 0, :]
+    compact[:, 128:] = -native[:, 1:, :].transpose(0, 2, 1).reshape(num_nodes, 384)
+    return compact
+
+
+def test_native_compute_field_h1_matches_standalone_transform(macefield_json_path):
+    evaluator = native_symmetrix.MACE(str(macefield_json_path))
+
+    assert evaluator.has_field_coupling is True
+
+    h1_pre, electric_field = _frozen_inputs()
+    expected = _standalone_field_transform(
+        _compact_field_coupling_from_json(macefield_json_path),
+        h1_pre,
+        electric_field,
+    ).numpy(force=True)
+
+    evaluator.H1 = _compact_to_native_h1(h1_pre.numpy(force=True)).tolist()
+    evaluator.compute_field_H1(
+        h1_pre.shape[0], electric_field.numpy(force=True).reshape(-1)
+    )
+
+    actual = _native_to_compact_h1(evaluator.H1, h1_pre.shape[0])
+    assert np.allclose(actual, expected, atol=1e-12, rtol=1e-12)
+
+
+def test_native_reverse_field_h1_matches_torch_autograd(macefield_json_path):
+    evaluator = native_symmetrix.MACE(str(macefield_json_path))
+    coupling = _compact_field_coupling_from_json(macefield_json_path)
+
+    h1_pre, electric_field = _frozen_inputs()
+    h1_pre = h1_pre.detach().clone().requires_grad_(True)
+    electric_field = electric_field.detach().clone().requires_grad_(True)
+    generator = torch.Generator(device="cpu").manual_seed(20260711)
+    h1_post_adj = torch.randn(h1_pre.shape, dtype=torch.float64, generator=generator)
+
+    h1_post = _standalone_field_transform(coupling, h1_pre, electric_field)
+    torch.sum(h1_post * h1_post_adj).backward()
+
+    evaluator.H1 = _compact_to_native_h1(h1_pre.detach().numpy(force=True)).tolist()
+    evaluator.compute_field_H1(
+        h1_pre.shape[0], electric_field.detach().numpy(force=True).reshape(-1)
+    )
+    evaluator.H1_adj = _compact_to_native_h1(h1_post_adj.numpy(force=True)).tolist()
+    evaluator.reverse_field_H1(
+        h1_pre.shape[0], electric_field.detach().numpy(force=True).reshape(-1)
+    )
+
+    actual_h1_adj = _native_to_compact_h1(evaluator.H1_adj, h1_pre.shape[0])
+    actual_field_adj = np.asarray(
+        evaluator.electric_field_adj, dtype=np.float64
+    ).reshape(h1_pre.shape[0], 3)
+
+    assert np.allclose(
+        actual_h1_adj, h1_pre.grad.numpy(force=True), atol=1e-12, rtol=1e-12
+    )
+    assert np.allclose(
+        actual_field_adj, electric_field.grad.numpy(force=True), atol=1e-12, rtol=1e-12
+    )
+
+
+def test_kokkos_compute_field_h1_matches_native_transform(macefield_json_path):
+    if not hasattr(native_symmetrix, "MACEKokkos"):
+        pytest.skip("Symmetrix was built without Kokkos bindings.")
+    if not native_symmetrix._kokkos_is_initialized():
+        native_symmetrix._init_kokkos()
+
+    evaluator = native_symmetrix.MACEKokkos(str(macefield_json_path))
+    assert evaluator.has_field_coupling is True
+
+    h1_pre, electric_field = _frozen_inputs()
+    expected = _standalone_field_transform(
+        _compact_field_coupling_from_json(macefield_json_path),
+        h1_pre,
+        electric_field,
+    ).numpy(force=True)
+
+    evaluator.H1 = _compact_to_native_h1(h1_pre.numpy(force=True))
+    evaluator.compute_field_H1(
+        h1_pre.shape[0], electric_field.numpy(force=True).reshape(-1)
+    )
+
+    actual = _native_to_compact_h1(evaluator.H1, h1_pre.shape[0])
+    assert np.allclose(actual, expected, atol=1e-12, rtol=1e-12)
+
+
+def test_kokkos_reverse_field_h1_matches_native_reverse(macefield_json_path):
+    if not hasattr(native_symmetrix, "MACEKokkos"):
+        pytest.skip("Symmetrix was built without Kokkos bindings.")
+    if not native_symmetrix._kokkos_is_initialized():
+        native_symmetrix._init_kokkos()
+
+    h1_pre, electric_field = _frozen_inputs()
+    generator = torch.Generator(device="cpu").manual_seed(20260711)
+    h1_post_adj = torch.randn(h1_pre.shape, dtype=torch.float64, generator=generator)
+
+    native = native_symmetrix.MACE(str(macefield_json_path))
+    native.H1 = _compact_to_native_h1(h1_pre.numpy(force=True)).tolist()
+    native.compute_field_H1(
+        h1_pre.shape[0], electric_field.numpy(force=True).reshape(-1)
+    )
+    native.H1_adj = _compact_to_native_h1(h1_post_adj.numpy(force=True)).tolist()
+    native.reverse_field_H1(
+        h1_pre.shape[0], electric_field.numpy(force=True).reshape(-1)
+    )
+
+    kokkos = native_symmetrix.MACEKokkos(str(macefield_json_path))
+    kokkos.H1 = _compact_to_native_h1(h1_pre.numpy(force=True))
+    kokkos.compute_field_H1(
+        h1_pre.shape[0], electric_field.numpy(force=True).reshape(-1)
+    )
+    kokkos.H1_adj = _compact_to_native_h1(h1_post_adj.numpy(force=True))
+    kokkos.reverse_field_H1(
+        h1_pre.shape[0], electric_field.numpy(force=True).reshape(-1)
+    )
+
+    assert np.allclose(kokkos.H1_adj, native.H1_adj, atol=1e-12, rtol=1e-12)
+    assert np.allclose(
+        kokkos.electric_field_adj, native.electric_field_adj, atol=1e-12, rtol=1e-12
+    )
+
+
+def test_native_field_energy_forces_match_ase_macefield(
+    macefield_full_json_path, macefield_model_path
+):
+    atoms = bulk("AlN", "wurtzite", a=3.112, c=4.982)
+    electric_field = np.array([0.01, 0.0, 0.0], dtype=np.float64)
+    atoms.info["electric_field"] = electric_field
+
+    calc_torch = MACECalculator(
+        model_paths=[str(macefield_model_path)],
+        model_type="MACEField",
+        head="mp-dielectric",
+        device="cpu",
+        default_dtype="float64",
+    )
+    atoms.calc = calc_torch
+    expected_energy = atoms.get_potential_energy()
+    expected_forces = atoms.get_forces()
+
+    evaluator = native_symmetrix.MACE(str(macefield_full_json_path))
+    atomic_numbers = atoms.get_atomic_numbers().tolist()
+    mace_atomic_numbers = evaluator.atomic_numbers
+    i_list, j_list, r, xyz = neighbor_list("ijdD", atoms, evaluator.r_cut)
+    num_nodes = len(atoms)
+    node_types = [
+        mace_atomic_numbers.index(atomic_numbers[i]) for i in range(num_nodes)
+    ]
+    num_neigh = np.bincount(j_list, minlength=num_nodes)
+    neigh_types = [mace_atomic_numbers.index(atomic_numbers[j]) for j in j_list]
+    per_atom_field = np.tile(electric_field, (num_nodes, 1))
+
+    evaluator.compute_node_energies_forces_field(
+        num_nodes,
+        np.asarray(node_types, dtype=np.int32),
+        np.asarray(num_neigh, dtype=np.int32),
+        np.asarray(j_list, dtype=np.int32),
+        np.asarray(neigh_types, dtype=np.int32),
+        xyz.reshape(-1),
+        r,
+        per_atom_field.reshape(-1),
+    )
+
+    native_energy = np.sum(evaluator.node_energies)
+    pair_forces = np.asarray(evaluator.node_forces).reshape((-1, 3))[: len(i_list), :]
+    native_forces = np.zeros((num_nodes, 3))
+    for component in range(3):
+        native_forces[:, component] = np.bincount(
+            j_list, weights=pair_forces[:, component], minlength=num_nodes
+        ) - np.bincount(i_list, weights=pair_forces[:, component], minlength=num_nodes)
+
+    assert np.allclose(native_energy, expected_energy, atol=1e-3)
+    assert np.allclose(native_forces, expected_forces, atol=2e-3)
+
+
+def _skip_without_kokkos():
+    if not hasattr(native_symmetrix, "MACEKokkos"):
+        pytest.skip("Symmetrix was built without Kokkos bindings.")
+    if not native_symmetrix._kokkos_is_initialized():
+        native_symmetrix._init_kokkos()
+
+
+def _field_backend_inputs(evaluator):
+    atoms = bulk("AlN", "wurtzite", a=3.112, c=4.982)
+    atomic_numbers = atoms.get_atomic_numbers().tolist()
+    mace_atomic_numbers = evaluator.atomic_numbers
+    i_list, j_list, r, xyz = neighbor_list("ijdD", atoms, evaluator.r_cut)
+    num_nodes = len(atoms)
+    node_types = np.asarray(
+        [mace_atomic_numbers.index(atomic_numbers[i]) for i in range(num_nodes)],
+        dtype=np.int32,
+    )
+    num_neigh = np.asarray(np.bincount(j_list, minlength=num_nodes), dtype=np.int32)
+    neigh_types = np.asarray(
+        [mace_atomic_numbers.index(atomic_numbers[j]) for j in j_list], dtype=np.int32
+    )
+    neigh_indices = np.asarray(j_list, dtype=np.int32)
+    return num_nodes, node_types, num_neigh, neigh_indices, neigh_types, xyz, r, i_list
+
+
+def test_kokkos_field_energy_forces_match_native(macefield_full_json_path):
+    _skip_without_kokkos()
+
+    electric_field = np.array([0.01, 0.0, 0.0], dtype=np.float64)
+
+    native = native_symmetrix.MACE(str(macefield_full_json_path))
+    kokkos = native_symmetrix.MACEKokkos(str(macefield_full_json_path))
+    num_nodes, node_types, num_neigh, neigh_indices, neigh_types, xyz, r, _ = (
+        _field_backend_inputs(native)
+    )
+
+    native.compute_node_energies_forces_field(
+        num_nodes,
+        node_types,
+        num_neigh,
+        neigh_indices,
+        neigh_types,
+        xyz.reshape(-1),
+        r,
+        electric_field,
+    )
+    kokkos.compute_node_energies_forces_field(
+        num_nodes,
+        node_types,
+        num_neigh,
+        neigh_indices,
+        neigh_types,
+        xyz.reshape(-1),
+        r,
+        electric_field,
+    )
+
+    assert np.sum(kokkos.node_energies) == pytest.approx(
+        np.sum(native.node_energies), abs=1e-8
+    )
+    assert np.allclose(kokkos.node_forces, native.node_forces, atol=1e-8, rtol=1e-8)
+
+
+@pytest.mark.parametrize(
+    "kokkos_class,atol,rtol",
+    [
+        ("MACEKokkos", 2e-6, 2e-6),
+        ("MACEKokkosFloat", 2e-4, 2e-4),
+    ],
+)
+def test_kokkos_electric_field_hessian_matches_native(
+    macefield_full_json_path,
+    kokkos_class,
+    atol,
+    rtol,
+):
+    _skip_without_kokkos()
+
+    electric_field = np.array([0.01, -0.02, 0.03], dtype=np.float64)
+
+    native = native_symmetrix.MACE(str(macefield_full_json_path))
+    kokkos = getattr(native_symmetrix, kokkos_class)(str(macefield_full_json_path))
+    num_nodes, node_types, num_neigh, neigh_indices, neigh_types, xyz, r, _ = (
+        _field_backend_inputs(native)
+    )
+
+    native.compute_electric_field_hessian(
+        num_nodes,
+        node_types,
+        num_neigh,
+        neigh_indices,
+        neigh_types,
+        xyz.reshape(-1),
+        r,
+        electric_field,
+    )
+    kokkos.compute_electric_field_hessian(
+        num_nodes,
+        node_types,
+        num_neigh,
+        neigh_indices,
+        neigh_types,
+        xyz.reshape(-1),
+        r,
+        electric_field,
+    )
+
+    assert np.allclose(
+        kokkos.electric_field_hessian,
+        native.electric_field_hessian,
+        atol=atol,
+        rtol=rtol,
+    )
+
+
+@pytest.mark.parametrize(
+    "kokkos_class,atol,rtol",
+    [
+        ("MACEKokkos", 2e-6, 2e-6),
+        ("MACEKokkosFloat", 5e-4, 5e-4),
+    ],
+)
+def test_kokkos_electric_field_force_derivative_matches_native(
+    macefield_full_json_path,
+    kokkos_class,
+    atol,
+    rtol,
+):
+    _skip_without_kokkos()
+
+    electric_field = np.array([0.01, -0.02, 0.03], dtype=np.float64)
+
+    native = native_symmetrix.MACE(str(macefield_full_json_path))
+    kokkos = getattr(native_symmetrix, kokkos_class)(str(macefield_full_json_path))
+    num_nodes, node_types, num_neigh, neigh_indices, neigh_types, xyz, r, i_list = (
+        _field_backend_inputs(native)
+    )
+
+    native.compute_electric_field_force_derivative(
+        num_nodes,
+        node_types,
+        num_neigh,
+        neigh_indices,
+        neigh_types,
+        xyz.reshape(-1),
+        r,
+        electric_field,
+    )
+    kokkos.compute_electric_field_force_derivative(
+        num_nodes,
+        node_types,
+        num_neigh,
+        neigh_indices,
+        neigh_types,
+        xyz.reshape(-1),
+        r,
+        electric_field,
+    )
+
+    native_deriv = np.asarray(
+        native.electric_field_force_derivative, dtype=np.float64
+    ).reshape(3, -1, 3)
+    kokkos_deriv = np.asarray(
+        kokkos.electric_field_force_derivative, dtype=np.float64
+    ).reshape(3, -1, 3)
+    assert np.allclose(
+        kokkos_deriv[:, : len(i_list)],
+        native_deriv[:, : len(i_list)],
+        atol=atol,
+        rtol=rtol,
+    )
+
+
+def test_native_exposes_atomic_energies_for_node_energy(macefield_full_json_path):
+    evaluator = native_symmetrix.MACE(str(macefield_full_json_path))
+
+    atomic_energies = np.asarray(evaluator.atomic_energies, dtype=np.float64)
+
+    assert atomic_energies.shape == (len(evaluator.atomic_numbers),)
+    assert np.all(np.isfinite(atomic_energies))
+
+
+def test_native_electric_field_hessian_matches_field_adjoint_finite_difference(
+    macefield_full_json_path,
+):
+    atoms = bulk("AlN", "wurtzite", a=3.112, c=4.982)
+    electric_field = np.array([0.01, -0.02, 0.03], dtype=np.float64)
+
+    evaluator = native_symmetrix.MACE(str(macefield_full_json_path))
+    atomic_numbers = atoms.get_atomic_numbers().tolist()
+    mace_atomic_numbers = evaluator.atomic_numbers
+    i_list, j_list, r, xyz = neighbor_list("ijdD", atoms, evaluator.r_cut)
+    num_nodes = len(atoms)
+    node_types = np.asarray(
+        [mace_atomic_numbers.index(atomic_numbers[i]) for i in range(num_nodes)],
+        dtype=np.int32,
+    )
+    num_neigh = np.asarray(np.bincount(j_list, minlength=num_nodes), dtype=np.int32)
+    neigh_types = np.asarray(
+        [mace_atomic_numbers.index(atomic_numbers[j]) for j in j_list], dtype=np.int32
+    )
+    neigh_indices = np.asarray(j_list, dtype=np.int32)
+
+    evaluator.compute_electric_field_hessian(
+        num_nodes,
+        node_types,
+        num_neigh,
+        neigh_indices,
+        neigh_types,
+        xyz.reshape(-1),
+        r,
+        electric_field,
+    )
+    actual = np.asarray(evaluator.electric_field_hessian, dtype=np.float64).reshape(
+        3, 3
+    )
+
+    step = 1e-4
+    expected = np.zeros((3, 3))
+    for component in range(3):
+        field_plus = electric_field.copy()
+        field_minus = electric_field.copy()
+        field_plus[component] += step
+        field_minus[component] -= step
+        evaluator.compute_node_energies_forces_field(
+            num_nodes,
+            node_types,
+            num_neigh,
+            neigh_indices,
+            neigh_types,
+            xyz.reshape(-1),
+            r,
+            field_plus,
+        )
+        adj_plus = np.asarray(evaluator.electric_field_adj, dtype=np.float64)
+        evaluator.compute_node_energies_forces_field(
+            num_nodes,
+            node_types,
+            num_neigh,
+            neigh_indices,
+            neigh_types,
+            xyz.reshape(-1),
+            r,
+            field_minus,
+        )
+        adj_minus = np.asarray(evaluator.electric_field_adj, dtype=np.float64)
+        expected[:, component] = (adj_plus - adj_minus) / (2.0 * step)
+
+    assert np.allclose(actual, expected, atol=2e-6, rtol=2e-5)
+
+
+def test_native_electric_field_force_derivative_matches_force_finite_difference(
+    macefield_full_json_path,
+):
+    atoms = bulk("AlN", "wurtzite", a=3.112, c=4.982)
+    electric_field = np.array([0.01, -0.02, 0.03], dtype=np.float64)
+
+    evaluator = native_symmetrix.MACE(str(macefield_full_json_path))
+    atomic_numbers = atoms.get_atomic_numbers().tolist()
+    mace_atomic_numbers = evaluator.atomic_numbers
+    i_list, j_list, r, xyz = neighbor_list("ijdD", atoms, evaluator.r_cut)
+    num_nodes = len(atoms)
+    node_types = np.asarray(
+        [mace_atomic_numbers.index(atomic_numbers[i]) for i in range(num_nodes)],
+        dtype=np.int32,
+    )
+    num_neigh = np.asarray(np.bincount(j_list, minlength=num_nodes), dtype=np.int32)
+    neigh_types = np.asarray(
+        [mace_atomic_numbers.index(atomic_numbers[j]) for j in j_list], dtype=np.int32
+    )
+    neigh_indices = np.asarray(j_list, dtype=np.int32)
+
+    evaluator.compute_electric_field_force_derivative(
+        num_nodes,
+        node_types,
+        num_neigh,
+        neigh_indices,
+        neigh_types,
+        xyz.reshape(-1),
+        r,
+        electric_field,
+    )
+    actual = np.asarray(
+        evaluator.electric_field_force_derivative, dtype=np.float64
+    ).reshape(3, -1, 3)
+
+    step = 1e-4
+    expected = np.zeros_like(actual)
+    for component in range(3):
+        field_plus = electric_field.copy()
+        field_minus = electric_field.copy()
+        field_plus[component] += step
+        field_minus[component] -= step
+        evaluator.compute_node_energies_forces_field(
+            num_nodes,
+            node_types,
+            num_neigh,
+            neigh_indices,
+            neigh_types,
+            xyz.reshape(-1),
+            r,
+            field_plus,
+        )
+        forces_plus = np.asarray(evaluator.node_forces, dtype=np.float64).reshape(
+            (-1, 3)
+        )[: len(i_list)]
+        evaluator.compute_node_energies_forces_field(
+            num_nodes,
+            node_types,
+            num_neigh,
+            neigh_indices,
+            neigh_types,
+            xyz.reshape(-1),
+            r,
+            field_minus,
+        )
+        forces_minus = np.asarray(evaluator.node_forces, dtype=np.float64).reshape(
+            (-1, 3)
+        )[: len(i_list)]
+        expected[component] = (forces_plus - forces_minus) / (2.0 * step)
+
+    assert np.allclose(
+        actual[:, : len(i_list)], expected[:, : len(i_list)], atol=2e-6, rtol=2e-5
+    )
+
+
+def _compact_field_coupling_from_json(path):
+    data = json.loads(Path(path).read_text())
+    coupling = data["field_couplings"][0]
+
+    class Module:
+        pass
+
+    class Instruction:
+        pass
+
+    field_feats = Module()
+    field_feats.irreps_in1 = coupling["field_feats_irreps_in1"]
+    field_feats.irreps_in2 = coupling["field_feats_irreps_in2"]
+    field_feats.irreps_out = coupling["field_feats_irreps_out"]
+    field_feats.output_mask = torch.tensor(
+        coupling["field_feats_output_mask"], dtype=torch.float64
+    )
+    field_feats.weight = torch.tensor(
+        coupling["field_feats_weight"], dtype=torch.float64
+    )
+    field_feats.instructions = []
+    for item in coupling["field_feats_instructions"]:
+        instruction = Instruction()
+        instruction.i_in1 = item["i_in1"]
+        instruction.i_in2 = item["i_in2"]
+        instruction.i_out = item["i_out"]
+        instruction.connection_mode = item["connection_mode"]
+        instruction.path_shape = tuple(item["path_shape"])
+        instruction.path_weight = item["path_weight"]
+        field_feats.instructions.append(instruction)
+
+    field_linear = Module()
+    field_linear.irreps_in = coupling["field_linear_irreps_in"]
+    field_linear.irreps_out = coupling["field_linear_irreps_out"]
+    field_linear.output_mask = torch.tensor(
+        coupling["field_linear_output_mask"], dtype=torch.float64
+    )
+    field_linear.bias = torch.tensor(coupling["field_linear_bias"], dtype=torch.float64)
+    field_linear.weight = torch.tensor(
+        coupling["field_linear_weight"], dtype=torch.float64
+    )
+    field_linear.instructions = []
+    for item in coupling["field_linear_instructions"]:
+        instruction = Instruction()
+        instruction.i_in = item["i_in"]
+        instruction.i_out = item["i_out"]
+        instruction.path_shape = tuple(item["path_shape"])
+        instruction.path_weight = item["path_weight"]
+        field_linear.instructions.append(instruction)
+
+    return _compact_field_coupling(field_feats, field_linear)

--- a/symmetrix/test/test_model_downloads.py
+++ b/symmetrix/test/test_model_downloads.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+import hashlib
+
+
+def test_cached_model_path_uses_external_cache_and_reuses_download(
+    monkeypatch, tmp_path
+):
+    from model_downloads import cached_model_path
+
+    cache_dir = tmp_path / "cache"
+    repo_cache = Path(__file__).parent / "model-cache"
+    calls = []
+
+    def fake_urlretrieve(url, destination):
+        calls.append((url, Path(destination)))
+        Path(destination).write_text("model")
+        return str(destination), None
+
+    monkeypatch.setenv("SYMMETRIX_TEST_MODEL_CACHE_DIR", str(cache_dir))
+    monkeypatch.setattr("model_downloads.urlretrieve", fake_urlretrieve)
+
+    first = cached_model_path("example.model", "https://example.invalid/example.model")
+    second = cached_model_path("example.model", "https://example.invalid/example.model")
+
+    assert first == cache_dir / "example.model"
+    assert second == first
+    assert first.read_text() == "model"
+    assert calls == [
+        ("https://example.invalid/example.model", cache_dir / "example.model")
+    ]
+    assert repo_cache not in first.parents
+
+
+def test_cached_model_path_accepts_existing_env_override(monkeypatch, tmp_path):
+    from model_downloads import cached_model_path
+
+    override = tmp_path / "local.model"
+    override.write_text("local")
+    monkeypatch.setenv("SYMMETRIX_MACEFIELD_MODEL", str(override))
+
+    path = cached_model_path(
+        "MACEField-MH-0-omat-dielectric.model",
+        "https://example.invalid/MACEField-MH-0-omat-dielectric.model",
+        env_var="SYMMETRIX_MACEFIELD_MODEL",
+    )
+
+    assert path == override
+
+
+def test_cached_model_path_replaces_corrupt_cached_download(monkeypatch, tmp_path):
+    from model_downloads import cached_model_path
+
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    destination = cache_dir / "example.model"
+    destination.write_bytes(b"corrupt")
+    expected = b"verified model"
+    expected_sha256 = hashlib.sha256(expected).hexdigest()
+    calls = []
+
+    def fake_urlretrieve(url, path):
+        calls.append((url, Path(path)))
+        Path(path).write_bytes(expected)
+        return str(path), None
+
+    monkeypatch.setenv("SYMMETRIX_TEST_MODEL_CACHE_DIR", str(cache_dir))
+    monkeypatch.setattr("model_downloads.urlretrieve", fake_urlretrieve)
+
+    path = cached_model_path(
+        "example.model",
+        "https://example.invalid/example.model",
+        sha256=expected_sha256,
+    )
+
+    assert path.read_bytes() == expected
+    assert calls == [("https://example.invalid/example.model", destination)]

--- a/symmetrix/test/test_multilayer_perceptron.py
+++ b/symmetrix/test/test_multilayer_perceptron.py
@@ -170,3 +170,28 @@ def test_evaluate_gradient_batch():
     f1, g1 = mlp.evaluate_gradient_batch(x.flatten(), 100)
     assert f.flatten() == pytest.approx(f1)
     assert g.flatten() == pytest.approx(g1)
+
+
+def test_evaluate_gradient_directional():
+    shape = [4, 7, 5, 2]
+    rng = np.random.default_rng(20260711)
+    weights = [
+        rng.normal(size=(7, 4)).flatten(),
+        rng.normal(size=(5, 7)).flatten(),
+        rng.normal(size=(2, 5)).flatten(),
+    ]
+    mlp = MultilayerPerceptron(shape, weights, 0.9)
+    x = rng.normal(size=4)
+    x_dot = rng.normal(size=4)
+
+    f, g, g_dot = mlp.evaluate_gradient_directional(x, x_dot)
+    expected_f, expected_g = mlp.evaluate_gradient(x)
+
+    step = 1e-6
+    _, g_plus = mlp.evaluate_gradient(x + step * x_dot)
+    _, g_minus = mlp.evaluate_gradient(x - step * x_dot)
+    expected_g_dot = (np.asarray(g_plus) - np.asarray(g_minus)) / (2.0 * step)
+
+    assert f == pytest.approx(expected_f)
+    assert np.allclose(g, expected_g)
+    assert np.allclose(g_dot, expected_g_dot, rtol=1e-5, atol=1e-7)

--- a/symmetrix/test/test_multivariate_polynomial.py
+++ b/symmetrix/test/test_multivariate_polynomial.py
@@ -39,3 +39,24 @@ def test_evaluate_batch():
     F, G = poly.evaluate_batch(X, 3)
     assert np.allclose(F, [F0, F1, F2])
     assert np.allclose(G, np.concatenate([G0, G1, G2]))
+
+
+def test_evaluate_gradient_directional():
+    num_variables = 6
+    coefficients = [0.7, -1.3, 0.2, 1.1]
+    monomials = [[0, 1, 1], [2, 3], [0, 4, 5], [1, 2, 3, 5]]
+    poly = MultivariatePolynomial(num_variables, coefficients, monomials)
+    x = np.array([0.2, -0.4, 0.7, 1.1, -0.3, 0.5])
+    x_dot = np.array([-0.1, 0.3, 0.2, -0.6, 0.4, -0.2])
+
+    f, g, g_dot = poly.evaluate_gradient_directional(x, x_dot)
+    expected_f, expected_g = poly.evaluate_gradient_simple(x)
+
+    step = 1e-6
+    _, g_plus = poly.evaluate_gradient_simple(x + step * x_dot)
+    _, g_minus = poly.evaluate_gradient_simple(x - step * x_dot)
+    expected_g_dot = (np.asarray(g_plus) - np.asarray(g_minus)) / (2.0 * step)
+
+    assert f == pytest.approx(expected_f)
+    assert np.allclose(g, expected_g)
+    assert np.allclose(g_dot, expected_g_dot, rtol=1e-8, atol=1e-9)

--- a/symmetrix/test/test_symmetrix_calc.py
+++ b/symmetrix/test/test_symmetrix_calc.py
@@ -1,18 +1,20 @@
 # This file was written and publicly released by Dr. Noam Bernstein as part of his
 # work for the U. S. Government, and is not subject to copyright.
 
-import pytest
-
+import gc
 import os
+import json
 import time
 
 import numpy as np
+import pytest
 
 from ase.atoms import Atoms
+from ase.build import bulk
 from ase.stress import full_3x3_to_voigt_6_stress
 
 try:
-    from symmetrix import Symmetrix
+    from symmetrix import FieldAwareCalculator, FieldContributionCalculator, Symmetrix
 except ModuleNotFoundError as exc:
     if "No module named 'symmetrix.symmetrix'" in str(exc):
         raise RuntimeError(
@@ -30,24 +32,27 @@ try:
 except ImportError:
     mace = None
 
+from model_downloads import test_model_cache_dir
+
 
 @pytest.fixture(scope="module")
-def mace_foundation_model(tmp_path_factory):
+def mace_foundation_model():
     if mace is None:
         return None
-    else:
-        # download into a temp dir by modifying XDG_CACHE_HOME which
-        # mace.calculators.foundations_models uses
-        cache_dir = tmp_path_factory.mktemp("mace_cache")
-        xdg_cache_home = os.environ.get("XDG_CACHE_HOME")
-        os.environ["XDG_CACHE_HOME"] = str(cache_dir)
+    cache_dir = test_model_cache_dir() / "mace-foundation"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    xdg_cache_home = os.environ.get("XDG_CACHE_HOME")
+    os.environ["XDG_CACHE_HOME"] = str(cache_dir)
+    try:
         downloaded_model = download_mace_mp_checkpoint("small-omat-0")
+    except Exception as exc:
+        pytest.skip(f"MACE foundation model is not available: {exc}")
+    finally:
         if xdg_cache_home is None:
             del os.environ["XDG_CACHE_HOME"]
         else:
             os.environ["XDG_CACHE_HOME"] = xdg_cache_home
-
-        return str(downloaded_model)
+    return str(downloaded_model)
 
 
 @pytest.mark.parametrize("use_kokkos", [True, False])
@@ -138,6 +143,1187 @@ def test_symmetrix_vs_pytorch(mace_foundation_model, use_kokkos):
     )
     assert np.allclose(atoms_s.get_forces(), atoms_p.get_forces(), atol=0.002)
     assert np.allclose(atoms_s.get_stress(), atoms_p.get_stress(), atol=0.003)
+
+
+@pytest.mark.skipif(mace is None, reason="mace-field is not available")
+def test_macefield_model_requires_explicit_json_conversion(macefield_model_path):
+    with pytest.raises(
+        RuntimeError, match="MACEField.*Convert/extract.*Symmetrix JSON"
+    ):
+        Symmetrix(
+            macefield_model_path,
+            species=[7, 13],
+            head="mp-dielectric",
+            use_kokkos=False,
+            dtype="float64",
+        )
+
+
+@pytest.mark.skipif(mace is None, reason="mace-field is not available")
+def test_macefield_float32_checkpoint_extracts_to_float64_json(
+    macefield_model_path, tmp_path
+):
+    import torch
+    from symmetrix.extract_mace_data import extract_mace_data
+
+    model = torch.load(
+        macefield_model_path,
+        map_location=torch.device("cpu"),
+        weights_only=False,
+    )
+    parameter_dtype = next(model.parameters()).dtype
+    if parameter_dtype != torch.float32:
+        pytest.skip(f"Expected float32 MACEField checkpoint, got {parameter_dtype}.")
+
+    json_path = tmp_path / "macefield-from-float32.json"
+    json_path.write_text(
+        json.dumps(
+            extract_mace_data(
+                macefield_model_path,
+                species=[7, 13],
+                head="mp-dielectric",
+            )
+        )
+    )
+
+    atoms = bulk("AlN", "wurtzite", a=3.112, c=4.982)
+    atoms.info["electric_field"] = np.array([0.01, -0.02, 0.03])
+    atoms.calc = Symmetrix(json_path, use_kokkos=False, dtype="float64")
+
+    assert np.isfinite(atoms.get_potential_energy())
+    assert atoms.get_forces().shape == (len(atoms), 3)
+    assert atoms.calc.get_property("polarization", atoms).shape == (3,)
+
+
+@pytest.mark.skipif(mace is None, reason="mace-field is not available")
+def test_macefield_native_json_ase_energy_forces_match_pytorch(
+    macefield_model_path, tmp_path
+):
+    from symmetrix.extract_mace_data import extract_mace_data
+
+    json_path = tmp_path / "macefield.json"
+    json_path.write_text(
+        json.dumps(
+            extract_mace_data(
+                macefield_model_path,
+                species=[7, 13],
+                head="mp-dielectric",
+            )
+        )
+    )
+
+    atoms = bulk("AlN", "wurtzite", a=3.112, c=4.982)
+    atoms.info["electric_field"] = np.array([0.01, 0.0, 0.0])
+
+    atoms_sym = atoms.copy()
+    atoms_torch = atoms.copy()
+    atoms_sym.calc = Symmetrix(json_path, use_kokkos=False, dtype="float64")
+    atoms_torch.calc = MACECalculator(
+        model_paths=[str(macefield_model_path)],
+        model_type="MACEField",
+        head="mp-dielectric",
+        device="cpu",
+        default_dtype="float64",
+    )
+
+    assert np.allclose(
+        atoms_sym.get_potential_energy(), atoms_torch.get_potential_energy(), atol=1e-3
+    )
+    assert np.allclose(atoms_sym.get_forces(), atoms_torch.get_forces(), atol=2e-3)
+
+
+@pytest.mark.skipif(mace is None, reason="mace-field is not available")
+@pytest.mark.parametrize("use_kokkos", [False, True])
+def test_macefield_field_contribution_matches_explicit_difference(
+    macefield_model_path,
+    tmp_path,
+    use_kokkos,
+):
+    from symmetrix import symmetrix as native_symmetrix
+    from symmetrix.extract_mace_data import extract_mace_data
+
+    if use_kokkos and not hasattr(native_symmetrix, "MACEKokkos"):
+        pytest.skip("Symmetrix was built without Kokkos bindings.")
+
+    json_path = tmp_path / "macefield.json"
+    json_path.write_text(
+        json.dumps(
+            extract_mace_data(
+                macefield_model_path,
+                species=[7, 13],
+                head="mp-dielectric",
+            )
+        )
+    )
+
+    atoms = bulk("AlN", "wurtzite", a=3.112, c=4.982)
+    electric_field = np.array([0.01, -0.02, 0.03])
+
+    direct_atoms = atoms.copy()
+    direct_calculator = Symmetrix(json_path, use_kokkos=use_kokkos, dtype="float64")
+    direct_atoms.calc = direct_calculator
+    direct_calculator.electric_field = electric_field
+    field_results = {
+        prop: direct_calculator.get_property(prop, direct_atoms)
+        for prop in ("energy", "forces", "stress")
+    }
+    direct_calculator.electric_field = np.zeros(3)
+    zero_results = {
+        prop: direct_calculator.get_property(prop, direct_atoms)
+        for prop in ("energy", "forces", "stress")
+    }
+
+    contribution_atoms = atoms.copy()
+    contribution = FieldContributionCalculator(
+        Symmetrix(json_path, use_kokkos=use_kokkos, dtype="float64"),
+        electric_field=electric_field,
+    )
+    contribution_atoms.calc = contribution
+    contribution_results = contribution_atoms.get_properties(
+        ["energy", "forces", "stress"]
+    )
+
+    for prop in ("energy", "forces", "stress"):
+        expected = np.asarray(field_results[prop]) - np.asarray(zero_results[prop])
+        assert np.allclose(contribution_results[prop], expected, atol=1e-12, rtol=1e-12)
+
+    step = 1e-4
+    positions = contribution_atoms.positions.copy()
+    contribution_atoms.positions[0, 0] += step
+    energy_plus = contribution_atoms.get_potential_energy()
+    contribution_atoms.positions[0, 0] -= 2.0 * step
+    energy_minus = contribution_atoms.get_potential_energy()
+    contribution_atoms.positions = positions
+    force_fd = -(energy_plus - energy_minus) / (2.0 * step)
+    assert np.isclose(contribution_results["forces"][0, 0], force_fd, atol=1e-7)
+
+    cell = contribution_atoms.cell.copy()
+    volume = contribution_atoms.get_volume()
+    deformation = np.eye(3)
+    deformation[0, 0] += step
+    contribution_atoms.set_cell(cell @ deformation, scale_atoms=True)
+    energy_plus = contribution_atoms.get_potential_energy()
+    deformation[0, 0] -= 2.0 * step
+    contribution_atoms.set_cell(cell @ deformation, scale_atoms=True)
+    energy_minus = contribution_atoms.get_potential_energy()
+    contribution_atoms.set_cell(cell, scale_atoms=True)
+    stress_fd = (energy_plus - energy_minus) / (2.0 * step * volume)
+    assert np.isclose(contribution_results["stress"][0], stress_fd, atol=1e-7)
+
+    base = Symmetrix(json_path, use_kokkos=use_kokkos, dtype="float64")
+    combined = FieldAwareCalculator(base, contribution)
+    combined_atoms = atoms.copy()
+    combined_atoms.calc = combined
+    combined_results = combined_atoms.get_properties(["energy", "forces", "stress"])
+    for prop in ("energy", "forces", "stress"):
+        expected = base.get_property(prop, combined_atoms) + contribution.get_property(
+            prop,
+            combined_atoms,
+        )
+        assert np.allclose(combined_results[prop], expected, atol=1e-12, rtol=1e-12)
+
+
+@pytest.mark.skipif(mace is None, reason="mace-field is not available")
+def test_macefield_native_json_ase_response_properties_match_pytorch(
+    macefield_model_path, tmp_path
+):
+    from symmetrix.extract_mace_data import extract_mace_data
+
+    json_path = tmp_path / "macefield.json"
+    json_path.write_text(
+        json.dumps(
+            extract_mace_data(
+                macefield_model_path,
+                species=[7, 13],
+                head="mp-dielectric",
+            )
+        )
+    )
+
+    atoms = bulk("AlN", "wurtzite", a=3.112, c=4.982)
+    atoms.info["electric_field"] = np.array([0.01, -0.02, 0.03])
+
+    atoms_sym = atoms.copy()
+    atoms_torch = atoms.copy()
+    atoms_sym.calc = Symmetrix(json_path, use_kokkos=False, dtype="float64")
+    atoms_torch.calc = MACECalculator(
+        model_paths=[str(macefield_model_path)],
+        model_type="MACEField",
+        head="mp-dielectric",
+        device="cpu",
+        default_dtype="float64",
+    )
+
+    atoms_torch.get_potential_energy()
+    expected_polarization = atoms_torch.calc.results["polarization"]
+    expected_becs = atoms_torch.calc.results["becs"]
+    expected_polarizability = atoms_torch.calc.results["polarizability"]
+
+    assert "polarization" in atoms_sym.calc.implemented_properties
+    assert "becs" in atoms_sym.calc.implemented_properties
+    assert "polarizability" in atoms_sym.calc.implemented_properties
+
+    actual_polarization = atoms_sym.calc.get_property("polarization", atoms_sym)
+    actual_becs = atoms_sym.calc.get_property("becs", atoms_sym)
+    actual_polarizability = atoms_sym.calc.get_property("polarizability", atoms_sym)
+
+    assert actual_polarization.shape == (3,)
+    assert actual_becs.shape == (len(atoms), 9)
+    assert actual_polarizability.shape == (9,)
+    assert np.allclose(actual_polarization, expected_polarization, atol=1e-5)
+    assert np.allclose(actual_becs, expected_becs, atol=5e-2)
+    assert np.allclose(actual_polarizability, expected_polarizability, atol=5e-3)
+
+
+@pytest.mark.skipif(mace is None, reason="mace-field is not available")
+@pytest.mark.parametrize(
+    "dtype,tolerances",
+    [
+        (
+            "float64",
+            {
+                "energy": 1e-8,
+                "forces": 1e-8,
+                "polarization": 1e-8,
+                "becs": 2e-6,
+                "polarizability": 2e-6,
+            },
+        ),
+        (
+            "float32",
+            {
+                "energy": 5e-4,
+                "forces": 5e-4,
+                "polarization": 5e-5,
+                "becs": 1e-3,
+                "polarizability": 1e-3,
+            },
+        ),
+    ],
+)
+def test_macefield_json_kokkos_response_properties_match_native(
+    macefield_model_path,
+    tmp_path,
+    dtype,
+    tolerances,
+):
+    from symmetrix import symmetrix as native_symmetrix
+    from symmetrix.extract_mace_data import extract_mace_data
+
+    if not hasattr(native_symmetrix, "MACEKokkos"):
+        pytest.skip("Symmetrix was built without Kokkos bindings.")
+
+    json_path = tmp_path / "macefield.json"
+    json_path.write_text(
+        json.dumps(
+            extract_mace_data(
+                macefield_model_path,
+                species=[7, 13],
+                head="mp-dielectric",
+            )
+        )
+    )
+
+    atoms = bulk("AlN", "wurtzite", a=3.112, c=4.982)
+    atoms.info["electric_field"] = np.array([0.01, -0.02, 0.03])
+
+    atoms_native = atoms.copy()
+    atoms_kokkos = atoms.copy()
+    atoms_native.calc = Symmetrix(json_path, use_kokkos=False, dtype="float64")
+    atoms_kokkos.calc = Symmetrix(json_path, use_kokkos=True, dtype=dtype)
+
+    assert atoms_kokkos.calc.use_kokkos is True
+    assert "polarization" in atoms_kokkos.calc.implemented_properties
+    assert "becs" in atoms_kokkos.calc.implemented_properties
+    assert "polarizability" in atoms_kokkos.calc.implemented_properties
+
+    for prop, tolerance in tolerances.items():
+        expected = atoms_native.calc.get_property(prop, atoms_native)
+        actual = atoms_kokkos.calc.get_property(prop, atoms_kokkos)
+        assert np.allclose(actual, expected, atol=tolerance, rtol=tolerance)
+
+    atoms_native.calc = None
+    atoms_kokkos.calc = None
+    gc.collect()
+
+
+@pytest.mark.skipif(mace is None, reason="mace-field is not available")
+def test_compact_macefield_calculator_replaces_active_composition_cache(
+    macefield_model_path,
+    tmp_path,
+):
+    from symmetrix import symmetrix as native_symmetrix
+    from symmetrix.extract_mace_data import extract_mace_data
+
+    if not hasattr(native_symmetrix, "MACEKokkos"):
+        pytest.skip("Symmetrix was built without Kokkos bindings.")
+
+    json_path = tmp_path / "macefield-multicomposition.json"
+    json_path.write_text(
+        json.dumps(
+            extract_mace_data(
+                macefield_model_path,
+                species=[7, 8, 12, 13],
+                head="mp-dielectric",
+            ),
+            separators=(",", ":"),
+        )
+    )
+
+    if not native_symmetrix._kokkos_is_initialized():
+        native_symmetrix._init_kokkos()
+    partial_node_types = np.asarray([0, 99], dtype=np.int32)[::2]
+    partial_num_neigh = np.asarray([1, 99], dtype=np.int32)[::2]
+    partial_neigh_types = np.asarray([3, 99], dtype=np.int32)[::2]
+    partial_r = np.asarray([1.5, 99.0], dtype=float)[::2]
+    partial_R1 = []
+    for evaluator_type in (native_symmetrix.MACE, native_symmetrix.MACEKokkos):
+        evaluator = evaluator_type(str(json_path))
+        evaluator.compute_R1(
+            1,
+            partial_node_types,
+            partial_num_neigh,
+            partial_neigh_types,
+            partial_r,
+        )
+        assert evaluator.active_atomic_numbers == [7, 13]
+        partial_R1.append(np.asarray(evaluator.R1))
+    assert np.allclose(partial_R1[1], partial_R1[0], rtol=0.0, atol=1e-11)
+
+    structures = (
+        (bulk("AlN", "wurtzite", a=3.112, c=4.982), [7, 13]),
+        (bulk("MgO", "rocksalt", a=4.21), [8, 12]),
+        (bulk("AlN", "wurtzite", a=3.112, c=4.982), [7, 13]),
+    )
+    backend_energies = {}
+    for use_kokkos in (False, True):
+        calc = Symmetrix(json_path, use_kokkos=use_kokkos, dtype="float64")
+        energies = []
+        for atoms, expected_active in structures:
+            atoms = atoms.copy()
+            atoms.calc = calc
+            energies.append(atoms.get_potential_energy())
+            assert calc.evaluator.active_atomic_numbers == expected_active
+        assert energies[0] == pytest.approx(energies[2], abs=1e-11)
+        backend_energies[use_kokkos] = energies
+
+    assert np.allclose(
+        backend_energies[True],
+        backend_energies[False],
+        rtol=0.0,
+        atol=1e-8,
+    )
+
+    electric_field = np.array([0.001, -0.002, 0.003])
+    response_calc = Symmetrix(json_path, use_kokkos=True, dtype="float64")
+    old_atoms = bulk("AlN", "rocksalt", a=4.05)
+    new_atoms = bulk("MgO", "rocksalt", a=4.21)
+    old_inputs = response_calc._mace_inputs(old_atoms)
+    response_calc.evaluator.compute_node_energies_forces_field(
+        *old_inputs[:7],
+        electric_field,
+    )
+    new_inputs = response_calc._mace_inputs(new_atoms)
+    response_calc.evaluator.compute_electric_field_hessian(
+        *new_inputs[:7],
+        electric_field,
+    )
+    switched_hessian = np.asarray(
+        response_calc.evaluator.electric_field_hessian,
+    ).copy()
+
+    fresh_calc = Symmetrix(json_path, use_kokkos=True, dtype="float64")
+    fresh_inputs = fresh_calc._mace_inputs(new_atoms)
+    fresh_calc.evaluator.compute_electric_field_hessian(
+        *fresh_inputs[:7],
+        electric_field,
+    )
+    assert np.allclose(
+        switched_hessian,
+        fresh_calc.evaluator.electric_field_hessian,
+        rtol=1e-8,
+        atol=2e-6,
+    )
+
+    same_composition_calc = Symmetrix(json_path, use_kokkos=True, dtype="float64")
+    baseline_atoms = bulk("AlN", "rocksalt", a=4.05)
+    changed_atoms = baseline_atoms.copy()
+    changed_atoms.positions[0, 0] += 0.05
+    baseline_inputs = same_composition_calc._mace_inputs(baseline_atoms)
+    same_composition_calc.evaluator.compute_node_energies_forces_field(
+        *baseline_inputs[:7],
+        electric_field,
+    )
+    changed_inputs = same_composition_calc._mace_inputs(changed_atoms)
+    same_composition_calc.evaluator.compute_electric_field_hessian(
+        *changed_inputs[:7],
+        electric_field,
+    )
+    changed_hessian = np.asarray(
+        same_composition_calc.evaluator.electric_field_hessian,
+    ).copy()
+
+    changed_fresh_calc = Symmetrix(json_path, use_kokkos=True, dtype="float64")
+    changed_fresh_inputs = changed_fresh_calc._mace_inputs(changed_atoms)
+    changed_fresh_calc.evaluator.compute_electric_field_hessian(
+        *changed_fresh_inputs[:7],
+        electric_field,
+    )
+    assert np.allclose(
+        changed_hessian,
+        changed_fresh_calc.evaluator.electric_field_hessian,
+        rtol=1e-8,
+        atol=2e-6,
+    )
+
+    fresh_calc.evaluator.prepare_active_types(
+        np.asarray([0, 1, 0, 1], dtype=np.int32)[::2],
+    )
+    assert fresh_calc.evaluator.active_atomic_numbers == [7]
+
+
+@pytest.mark.skipif(mace is None, reason="mace-field is not available")
+def test_macefield_native_json_node_energy_matches_pytorch(
+    macefield_model_path, tmp_path
+):
+    from symmetrix.extract_mace_data import extract_mace_data
+
+    json_path = tmp_path / "macefield.json"
+    json_path.write_text(
+        json.dumps(
+            extract_mace_data(
+                macefield_model_path,
+                species=[7, 13],
+                head="mp-dielectric",
+            )
+        )
+    )
+
+    atoms = bulk("AlN", "wurtzite", a=3.112, c=4.982)
+    atoms.info["electric_field"] = np.array([0.01, -0.02, 0.03])
+
+    atoms_sym = atoms.copy()
+    atoms_torch = atoms.copy()
+    atoms_sym.calc = Symmetrix(json_path, use_kokkos=False, dtype="float64")
+    atoms_torch.calc = MACECalculator(
+        model_paths=[str(macefield_model_path)],
+        model_type="MACEField",
+        head="mp-dielectric",
+        device="cpu",
+        default_dtype="float64",
+    )
+
+    atoms_sym.get_potential_energy()
+    atoms_torch.get_potential_energy()
+
+    assert "node_energy" in atoms_sym.calc.implemented_properties
+    assert atoms_sym.calc.results["node_energy"].shape == (len(atoms),)
+    assert np.allclose(
+        atoms_sym.calc.results["energies"],
+        atoms_torch.calc.results["energies"],
+        atol=1e-5,
+    )
+    assert np.allclose(
+        atoms_sym.calc.results["node_energy"],
+        atoms_torch.calc.results["node_energy"],
+        atol=1e-5,
+    )
+
+
+@pytest.mark.skipif(mace is None, reason="mace-field is not available")
+def test_macefield_native_json_requires_graph_field(macefield_model_path, tmp_path):
+    from symmetrix.extract_mace_data import extract_mace_data
+
+    json_path = tmp_path / "macefield.json"
+    json_path.write_text(
+        json.dumps(
+            extract_mace_data(
+                macefield_model_path,
+                species=[7, 13],
+                head="mp-dielectric",
+            )
+        )
+    )
+
+    atoms = bulk("AlN", "wurtzite", a=3.112, c=4.982)
+    atoms.info["electric_field"] = np.zeros((len(atoms), 3))
+    atoms.calc = Symmetrix(json_path, use_kokkos=False, dtype="float64")
+
+    with pytest.raises(ValueError, match="graph-level electric_field"):
+        atoms.get_potential_energy()
+
+
+def test_macefield_native_json_accepts_singleton_graph_field(monkeypatch, tmp_path):
+    class DummyFieldEvaluator:
+        has_field_coupling = True
+        r_cut = 3.0
+        atomic_numbers = [7, 13]
+        atomic_energies = np.array([0.0, 0.0])
+
+        def __init__(self):
+            self.electric_fields = []
+            self.node_energies = []
+            self.node_forces = []
+            self.electric_field_adj = []
+
+        def compute_node_energies_forces_field(
+            self,
+            num_nodes,
+            node_types,
+            num_neigh,
+            neigh_indices,
+            neigh_types,
+            xyz,
+            r,
+            electric_field,
+        ):
+            self.electric_fields.append(np.asarray(electric_field, dtype=float).copy())
+            self.node_energies = np.zeros(num_nodes)
+            self.node_forces = np.zeros_like(np.asarray(xyz, dtype=float))
+            self.electric_field_adj = np.array([1.0, 2.0, 3.0])
+
+    evaluator = DummyFieldEvaluator()
+    monkeypatch.setattr(
+        "symmetrix.calculator.symmetrix.MACE", lambda filename: evaluator
+    )
+
+    json_path = tmp_path / "macefield.json"
+    json_path.write_text(json.dumps({"has_field_coupling": True}))
+
+    atoms = Atoms(
+        "AlN",
+        positions=[[0.0, 0.0, 0.0], [1.8, 0.0, 0.0]],
+        cell=[5.0, 5.0, 5.0],
+        pbc=True,
+    )
+    atoms.info["electric_field"] = np.array([[0.01, -0.02, 0.03]])
+    atoms.calc = Symmetrix(json_path, use_kokkos=False, dtype="float64")
+
+    assert np.isfinite(atoms.get_potential_energy())
+    assert np.allclose(evaluator.electric_fields[-1], np.array([0.01, -0.02, 0.03]))
+
+
+@pytest.mark.skipif(mace is None, reason="mace-field is not available")
+def test_macefield_native_json_keeps_response_properties_selective(
+    macefield_model_path, tmp_path
+):
+    from symmetrix.extract_mace_data import extract_mace_data
+
+    json_path = tmp_path / "macefield.json"
+    json_path.write_text(
+        json.dumps(
+            extract_mace_data(
+                macefield_model_path,
+                species=[7, 13],
+                head="mp-dielectric",
+            )
+        )
+    )
+
+    atoms = bulk("AlN", "wurtzite", a=3.112, c=4.982)
+    atoms.info["electric_field"] = np.array([0.01, -0.02, 0.03])
+    atoms.calc = Symmetrix(json_path, use_kokkos=False, dtype="float64")
+
+    assert np.isfinite(atoms.get_potential_energy())
+    assert "polarization" not in atoms.calc.results
+    assert "becs" not in atoms.calc.results
+    assert "polarizability" not in atoms.calc.results
+
+    assert atoms.calc.get_property("polarization", atoms).shape == (3,)
+
+
+def test_macefield_native_json_polarization_uses_single_native_field_call(
+    monkeypatch, tmp_path
+):
+    class DummyFieldEvaluator:
+        has_field_coupling = True
+        r_cut = 3.0
+        atomic_numbers = [7, 13]
+        atomic_energies = np.array([0.0, 0.0])
+
+        def __init__(self):
+            self.calls = 0
+            self.node_energies = []
+            self.node_forces = []
+            self.electric_field_adj = []
+
+        def compute_node_energies_forces_field(
+            self,
+            num_nodes,
+            node_types,
+            num_neigh,
+            neigh_indices,
+            neigh_types,
+            xyz,
+            r,
+            electric_field,
+        ):
+            self.calls += 1
+            self.node_energies = np.zeros(num_nodes)
+            self.node_forces = np.zeros_like(np.asarray(xyz, dtype=float))
+            self.electric_field_adj = np.array([1.0, 2.0, 3.0])
+
+    evaluator = DummyFieldEvaluator()
+    monkeypatch.setattr(
+        "symmetrix.calculator.symmetrix.MACE", lambda filename: evaluator
+    )
+
+    json_path = tmp_path / "macefield.json"
+    json_path.write_text(json.dumps({"has_field_coupling": True}))
+
+    atoms = Atoms(
+        "AlN",
+        positions=[[0.0, 0.0, 0.0], [1.8, 0.0, 0.0]],
+        cell=[5.0, 5.0, 5.0],
+        pbc=True,
+    )
+    atoms.info["electric_field"] = np.array([0.01, 0.0, 0.0])
+    atoms.calc = Symmetrix(json_path, use_kokkos=False, dtype="float64")
+
+    assert np.allclose(
+        atoms.calc.get_property("polarization", atoms),
+        -np.array([1.0, 2.0, 3.0]) / atoms.get_volume(),
+    )
+    assert evaluator.calls == 1
+
+
+def test_macefield_native_json_polarizability_uses_native_field_hessian(
+    monkeypatch, tmp_path
+):
+    class DummyFieldEvaluator:
+        has_field_coupling = True
+        r_cut = 3.0
+        atomic_numbers = [7, 13]
+        atomic_energies = np.array([0.0, 0.0])
+
+        def __init__(self):
+            self.calls = 0
+            self.hessian_calls = 0
+            self.node_energies = []
+            self.node_forces = []
+            self.electric_field_adj = []
+            self.electric_field_hessian = []
+
+        def compute_node_energies_forces_field(
+            self,
+            num_nodes,
+            node_types,
+            num_neigh,
+            neigh_indices,
+            neigh_types,
+            xyz,
+            r,
+            electric_field,
+        ):
+            self.calls += 1
+            self.node_energies = np.zeros(num_nodes)
+            self.node_forces = np.zeros_like(np.asarray(xyz, dtype=float))
+            self.electric_field_adj = np.array([1.0, 2.0, 3.0])
+
+        def compute_electric_field_hessian(
+            self,
+            num_nodes,
+            node_types,
+            num_neigh,
+            neigh_indices,
+            neigh_types,
+            xyz,
+            r,
+            electric_field,
+        ):
+            self.hessian_calls += 1
+            self.electric_field_hessian = np.arange(9, dtype=float).reshape(3, 3)
+
+    evaluator = DummyFieldEvaluator()
+    monkeypatch.setattr(
+        "symmetrix.calculator.symmetrix.MACE", lambda filename: evaluator
+    )
+
+    json_path = tmp_path / "macefield.json"
+    json_path.write_text(json.dumps({"has_field_coupling": True}))
+
+    atoms = Atoms(
+        "AlN",
+        positions=[[0.0, 0.0, 0.0], [1.8, 0.0, 0.0]],
+        cell=[5.0, 5.0, 5.0],
+        pbc=True,
+    )
+    atoms.info["electric_field"] = np.array([0.01, 0.0, 0.0])
+    atoms.calc = Symmetrix(json_path, use_kokkos=False, dtype="float64")
+
+    expected = (
+        -np.arange(9, dtype=float).reshape(3, 3)
+        / atoms.get_volume()
+        / atoms.calc._macefield_eps0
+    ).reshape(9)
+    assert np.allclose(atoms.calc.get_property("polarizability", atoms), expected)
+    assert evaluator.calls == 1
+    assert evaluator.hessian_calls == 1
+
+
+def test_macefield_native_json_becs_use_native_force_field_derivative(
+    monkeypatch, tmp_path
+):
+    class DummyFieldEvaluator:
+        has_field_coupling = True
+        r_cut = 3.0
+        atomic_numbers = [7, 13]
+        atomic_energies = np.array([0.0, 0.0])
+
+        def __init__(self):
+            self.calls = 0
+            self.derivative_calls = 0
+            self.node_energies = []
+            self.node_forces = []
+            self.electric_field_adj = []
+            self.electric_field_force_derivative = []
+
+        def compute_node_energies_forces_field(
+            self,
+            num_nodes,
+            node_types,
+            num_neigh,
+            neigh_indices,
+            neigh_types,
+            xyz,
+            r,
+            electric_field,
+        ):
+            self.calls += 1
+            self.node_energies = np.zeros(num_nodes)
+            self.node_forces = np.zeros_like(np.asarray(xyz, dtype=float))
+            self.electric_field_adj = np.array([1.0, 2.0, 3.0])
+
+        def compute_electric_field_force_derivative(
+            self,
+            num_nodes,
+            node_types,
+            num_neigh,
+            neigh_indices,
+            neigh_types,
+            xyz,
+            r,
+            electric_field,
+        ):
+            self.derivative_calls += 1
+            self.electric_field_force_derivative = np.arange(
+                3 * len(xyz), dtype=float
+            ).reshape(3, -1, 3)
+
+    evaluator = DummyFieldEvaluator()
+    monkeypatch.setattr(
+        "symmetrix.calculator.symmetrix.MACE", lambda filename: evaluator
+    )
+
+    json_path = tmp_path / "macefield.json"
+    json_path.write_text(json.dumps({"has_field_coupling": True}))
+
+    atoms = Atoms(
+        "AlN",
+        positions=[[0.0, 0.0, 0.0], [1.8, 0.0, 0.0]],
+        cell=[5.0, 5.0, 5.0],
+        pbc=True,
+    )
+    atoms.info["electric_field"] = np.array([0.01, 0.0, 0.0])
+    atoms.calc = Symmetrix(json_path, use_kokkos=False, dtype="float64")
+
+    num_nodes, _, _, j_list, _, xyz, _, i_list = atoms.calc._mace_inputs(atoms)
+    pair_derivative = np.arange(3 * xyz.size, dtype=float).reshape(3, -1, 3)[
+        :, : len(i_list)
+    ]
+    expected = np.zeros((num_nodes, 3, 3))
+    for field_component in range(3):
+        for cartesian in range(3):
+            expected[:, field_component, cartesian] = np.bincount(
+                j_list,
+                weights=pair_derivative[field_component, :, cartesian],
+                minlength=num_nodes,
+            ) - np.bincount(
+                i_list,
+                weights=pair_derivative[field_component, :, cartesian],
+                minlength=num_nodes,
+            )
+
+    assert np.allclose(
+        atoms.calc.get_property("becs", atoms), expected.reshape(num_nodes, 9)
+    )
+    assert evaluator.calls == 1
+    assert evaluator.derivative_calls == 1
+
+
+def test_macefield_native_json_cache_tracks_only_electric_field(monkeypatch, tmp_path):
+    class DummyFieldEvaluator:
+        has_field_coupling = True
+        r_cut = 3.0
+        atomic_numbers = [7, 13]
+        atomic_energies = np.array([0.0, 0.0])
+
+        def __init__(self):
+            self.calls = 0
+            self.node_energies = []
+            self.node_forces = []
+            self.electric_field_adj = []
+
+        def compute_node_energies_forces_field(
+            self,
+            num_nodes,
+            node_types,
+            num_neigh,
+            neigh_indices,
+            neigh_types,
+            xyz,
+            r,
+            electric_field,
+        ):
+            self.calls += 1
+            field = np.asarray(electric_field, dtype=float)
+            self.node_energies = np.full(num_nodes, field[0])
+            self.node_forces = np.zeros_like(np.asarray(xyz, dtype=float))
+            self.electric_field_adj = np.array([1.0, 2.0, 3.0])
+
+    class NonNumericMetadata:
+        pass
+
+    evaluator = DummyFieldEvaluator()
+    monkeypatch.setattr(
+        "symmetrix.calculator.symmetrix.MACE", lambda filename: evaluator
+    )
+
+    json_path = tmp_path / "macefield.json"
+    json_path.write_text(json.dumps({"has_field_coupling": True}))
+
+    atoms = Atoms(
+        "AlN",
+        positions=[[0.0, 0.0, 0.0], [1.8, 0.0, 0.0]],
+        cell=[5.0, 5.0, 5.0],
+        pbc=True,
+    )
+    atoms.info["spacegroup"] = NonNumericMetadata()
+    atoms.info["electric_field"] = np.array([0.01, 0.0, 0.0])
+    atoms.calc = Symmetrix(json_path, use_kokkos=False, dtype="float64")
+
+    assert np.isfinite(atoms.get_potential_energy())
+    assert np.isfinite(atoms.get_forces()).all()
+    assert evaluator.calls == 1
+
+    atoms.info["spacegroup"] = NonNumericMetadata()
+    assert np.isfinite(atoms.get_forces()).all()
+    assert evaluator.calls == 1
+
+    atoms.info["electric_field"][0] = 0.02
+    assert np.isfinite(atoms.get_potential_energy())
+    assert evaluator.calls == 2
+
+
+def test_macefield_native_json_calculator_electric_field_override(
+    monkeypatch, tmp_path
+):
+    class DummyFieldEvaluator:
+        has_field_coupling = True
+        r_cut = 3.0
+        atomic_numbers = [7, 13]
+        atomic_energies = np.array([0.0, 0.0])
+
+        def __init__(self):
+            self.electric_fields = []
+            self.node_energies = []
+            self.node_forces = []
+            self.electric_field_adj = []
+
+        def compute_node_energies_forces_field(
+            self,
+            num_nodes,
+            node_types,
+            num_neigh,
+            neigh_indices,
+            neigh_types,
+            xyz,
+            r,
+            electric_field,
+        ):
+            field = np.asarray(electric_field, dtype=float)
+            self.electric_fields.append(field.copy())
+            self.node_energies = np.full(num_nodes, field[2])
+            self.node_forces = np.zeros_like(np.asarray(xyz, dtype=float))
+            self.electric_field_adj = np.array([1.0, 2.0, 3.0])
+
+    evaluator = DummyFieldEvaluator()
+    monkeypatch.setattr(
+        "symmetrix.calculator.symmetrix.MACE", lambda filename: evaluator
+    )
+
+    json_path = tmp_path / "macefield.json"
+    json_path.write_text(json.dumps({"has_field_coupling": True}))
+
+    atoms = Atoms(
+        "AlN",
+        positions=[[0.0, 0.0, 0.0], [1.8, 0.0, 0.0]],
+        cell=[5.0, 5.0, 5.0],
+        pbc=True,
+    )
+    atoms.info["electric_field"] = np.array([0.01, 0.0, 0.0])
+    atoms.calc = Symmetrix(json_path, use_kokkos=False, dtype="float64")
+
+    atoms.calc.electric_field = [0.0, 0.0, 0.02]
+    energy_override = atoms.get_potential_energy()
+
+    atoms.calc.electric_field = [0.0, 0.0, 0.03]
+    energy_updated = atoms.get_potential_energy()
+
+    assert np.isclose(energy_override, 0.04)
+    assert np.isclose(energy_updated, 0.06)
+    assert np.allclose(evaluator.electric_fields, [[0.0, 0.0, 0.02], [0.0, 0.0, 0.03]])
+
+
+@pytest.mark.skipif(mace is None, reason="mace-field is not available")
+def test_macefield_native_json_uses_kokkos_field_path_when_kokkos_requested(
+    macefield_model_path, tmp_path
+):
+    from symmetrix import symmetrix as native_symmetrix
+    from symmetrix.extract_mace_data import extract_mace_data
+
+    if not hasattr(native_symmetrix, "MACEKokkos"):
+        pytest.skip("Symmetrix was built without Kokkos bindings.")
+
+    json_path = tmp_path / "macefield.json"
+    json_path.write_text(
+        json.dumps(
+            extract_mace_data(
+                macefield_model_path,
+                species=[7, 13],
+                head="mp-dielectric",
+            )
+        )
+    )
+
+    atoms = bulk("AlN", "wurtzite", a=3.112, c=4.982)
+    atoms.info["electric_field"] = np.array([0.01, 0.0, 0.0])
+    atoms.calc = Symmetrix(json_path, use_kokkos=True, dtype="float64")
+
+    assert atoms.calc.use_kokkos is True
+    assert "polarization" in atoms.calc.implemented_properties
+    assert np.isfinite(atoms.get_potential_energy())
+    assert atoms.calc.get_property("polarization", atoms).shape == (3,)
+
+
+def test_macefield_json_with_kokkos_requested_constructs_kokkos_evaluator(
+    monkeypatch, tmp_path
+):
+    class DummyKokkosEvaluator:
+        has_field_coupling = True
+        r_cut = 3.0
+        atomic_numbers = [7, 13]
+        atomic_energies = np.array([0.0, 0.0])
+
+        def __init__(self, filename):
+            self.filename = filename
+            self.node_energies = []
+            self.node_forces = []
+            self.electric_field_adj = []
+
+    constructed = []
+
+    def fake_init_kokkos():
+        constructed.append("init")
+
+    def fake_mace_kokkos(filename):
+        constructed.append("kokkos")
+        return DummyKokkosEvaluator(filename)
+
+    def fake_mace(filename):
+        constructed.append("serial")
+        raise AssertionError(
+            "field-aware use_kokkos=True should not instantiate serial MACE"
+        )
+
+    monkeypatch.setattr(
+        "symmetrix.calculator.symmetrix._kokkos_is_initialized", lambda: False
+    )
+    monkeypatch.setattr("symmetrix.calculator.symmetrix._init_kokkos", fake_init_kokkos)
+    monkeypatch.setattr("symmetrix.calculator.symmetrix.MACEKokkos", fake_mace_kokkos)
+    monkeypatch.setattr("symmetrix.calculator.symmetrix.MACE", fake_mace)
+
+    json_path = tmp_path / "macefield.json"
+    json_path.write_text(json.dumps({"has_field_coupling": True}))
+
+    calc = Symmetrix(json_path, use_kokkos=True, dtype="float64")
+
+    assert calc.use_kokkos is True
+    assert constructed == ["init", "kokkos"]
+    assert isinstance(calc.evaluator, DummyKokkosEvaluator)
+    assert "polarization" in calc.implemented_properties
+
+
+@pytest.mark.skipif(mace is None, reason="mace-field is not available")
+def test_macefield_native_json_electric_field_changes_cached_results(
+    macefield_model_path, tmp_path
+):
+    from symmetrix.extract_mace_data import extract_mace_data
+
+    json_path = tmp_path / "macefield.json"
+    json_path.write_text(
+        json.dumps(
+            extract_mace_data(
+                macefield_model_path,
+                species=[7, 13],
+                head="mp-dielectric",
+            )
+        )
+    )
+
+    atoms = bulk("AlN", "wurtzite", a=3.112, c=4.982)
+    atoms.calc = Symmetrix(json_path, use_kokkos=False, dtype="float64")
+
+    atoms.info["electric_field"] = np.array([0.0, 0.0, 0.0])
+    energy_zero = atoms.get_potential_energy()
+    forces_zero = atoms.get_forces()
+
+    atoms.info["electric_field"][0] = 0.01
+    energy_field = atoms.get_potential_energy()
+    forces_field = atoms.get_forces()
+
+    assert not np.isclose(energy_zero, energy_field, rtol=0.0, atol=1e-8)
+    assert not np.allclose(forces_zero, forces_field)
+
+
+def test_plain_mace_model_uses_native_symmetrix_path(monkeypatch, tmp_path):
+    class PlainTorchModel:
+        pass
+
+    class DummyEvaluator:
+        r_cut = 3.0
+
+    def fake_torch_load(*args, **kwargs):
+        return PlainTorchModel()
+
+    monkeypatch.setattr("torch.load", fake_torch_load)
+    monkeypatch.setattr(
+        "symmetrix.calculator.symmetrix.MACE", lambda filename: DummyEvaluator()
+    )
+
+    calc = Symmetrix(tmp_path / "plain.model", use_kokkos=False)
+
+    assert calc.evaluator.r_cut == 3.0
+    assert calc.implemented_properties == [
+        "energy",
+        "free_energy",
+        "energies",
+        "forces",
+        "stress",
+    ]
+
+
+@pytest.mark.parametrize("filename", ["macefield.JSON", "macefield"])
+def test_json_loading_is_suffix_independent_without_python_deserialization(
+    monkeypatch,
+    tmp_path,
+    filename,
+):
+    class DummyFieldEvaluator:
+        has_field_coupling = True
+        r_cut = 3.0
+
+    model_path = tmp_path / filename
+    model_path.write_text(json.dumps({"has_field_coupling": True}))
+    evaluator = DummyFieldEvaluator()
+    monkeypatch.setattr(
+        "symmetrix.calculator.symmetrix.MACE",
+        lambda path: evaluator,
+    )
+    monkeypatch.setattr(
+        "symmetrix.calculator.json.load",
+        lambda *args, **kwargs: pytest.fail(
+            "calculator must not deserialize JSON in Python"
+        ),
+    )
+
+    calc = Symmetrix(model_path, use_kokkos=False)
+
+    assert calc.evaluator is evaluator
+    assert "polarization" in calc.implemented_properties
+
+
+def test_macefield_kokkos_float32_constructs_float_evaluator_after_single_native_load(
+    monkeypatch,
+    tmp_path,
+):
+    class DummyFieldEvaluator:
+        has_field_coupling = True
+        r_cut = 3.0
+
+    model_path = tmp_path / "macefield"
+    model_path.write_text(json.dumps({"has_field_coupling": True}))
+    constructed = []
+
+    def make_evaluator(path):
+        constructed.append(path)
+        return DummyFieldEvaluator()
+
+    monkeypatch.setattr(
+        "symmetrix.calculator.symmetrix._kokkos_is_initialized",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "symmetrix.calculator.symmetrix.MACEKokkosFloat",
+        make_evaluator,
+    )
+    monkeypatch.setattr(
+        "symmetrix.calculator.json.load",
+        lambda *args, **kwargs: pytest.fail(
+            "calculator must not deserialize JSON in Python"
+        ),
+    )
+
+    calc = Symmetrix(model_path, use_kokkos=True, dtype="float32")
+
+    assert constructed == [str(model_path)]
+    assert calc.evaluator.has_field_coupling is True
+    assert "polarizability" in calc.implemented_properties
+
+
+def test_missing_kokkos_is_reported_without_loading_extensionless_model(
+    monkeypatch,
+    tmp_path,
+):
+    def fail_torch_load(*args, **kwargs):
+        pytest.fail("model loading must not precede the missing-Kokkos error")
+
+    monkeypatch.delattr("symmetrix.calculator.symmetrix.MACEKokkos")
+    monkeypatch.setattr("torch.load", fail_torch_load)
+
+    with pytest.raises(RuntimeError, match="built without Kokkos support"):
+        Symmetrix(tmp_path / "extensionless-json", use_kokkos=True)
+
+
+def test_unloadable_torch_model_preserves_load_error(monkeypatch, tmp_path):
+    def fake_native_loader(filename):
+        raise RuntimeError("[json.exception.parse_error.101] not native json")
+
+    def fake_torch_load(*args, **kwargs):
+        raise ValueError("checkpoint cannot be unpickled")
+
+    monkeypatch.setattr("symmetrix.calculator.symmetrix.MACE", fake_native_loader)
+    monkeypatch.setattr("torch.load", fake_torch_load)
+
+    with pytest.raises(ValueError, match="checkpoint cannot be unpickled"):
+        Symmetrix(tmp_path / "broken.model", use_kokkos=False)
+
+
+def test_extensionless_native_json_schema_error_is_not_treated_as_checkpoint(
+    monkeypatch,
+    tmp_path,
+):
+    def fake_native_loader(filename):
+        raise RuntimeError("[json.exception.type_error.302] invalid model schema")
+
+    def fail_torch_load(*args, **kwargs):
+        pytest.fail("native JSON schema errors must not fall through to torch.load")
+
+    monkeypatch.setattr("symmetrix.calculator.symmetrix.MACE", fake_native_loader)
+    monkeypatch.setattr("torch.load", fail_torch_load)
+
+    with pytest.raises(RuntimeError, match="type_error.302"):
+        Symmetrix(tmp_path / "invalid-extensionless-json", use_kokkos=False)
 
 
 def do_grad_test(atoms, calc, check, ax=None, label=None, plot_factor=1.0):


### PR DESCRIPTION
## Summary

- add native MACEField electric-field coupling to the serial and Kokkos evaluators
- expose field-aware energies, forces, polarization, Born effective charges, and polarizability through the ASE calculator
- add Kokkos LAMMPS electric-field support, including MPI communication modes
- add Symmetrix JSON format v2 with compact radial data, avoiding explicit atom-pair spline tables
- add analytical field response implementations and reusable Kokkos field workspaces

## Compact JSON v2

The legacy pair-spline format evaluates the learned radial networks during
extraction and writes a separate spline table for every selected element pair.
The species therefore have to be chosen in advance, the output grows
quadratically with the number of elements, and using another element supported
by the original checkpoint requires extracting the model again.

Format v2 instead stores the shared radial model: the basis, cutoff and distance
transform parameters, the element metadata, and the radial network weights.
The native evaluator materializes and caches spline tables only for the atomic
types active in the current calculation. When extraction is run without a
species filter, one compact JSON model can consequently evaluate any element or
composition supported by the original checkpoint without pre-defining explicit
atom pairs or re-extracting the model. It does not extend the checkpoint to
elements that the checkpoint itself does not support.

## Scope

This PR contains field-aware support and the compact v2 JSON format only. It does not include MH-1 or Sobek support.

The current native field coupling supports first-layer scalar and vector features (`L_max=1`) with arbitrary channel counts. Extraction rejects unsupported higher-order MACEField layouts before writing JSON. The Kokkos field-aware path supports `float64` and `float32`; float64 remains recommended for the most accurate polarizability and Born effective charge tensors.

## References

- MACEField implementation: https://github.com/mdi-group/mace-field
- MACEField 1.0.2 release: https://github.com/mdi-group/mace-field/releases/tag/1.0.2
- Pretrained dielectric model: https://github.com/mdi-group/mace-field/releases/download/1.0.2/MACEField-MH-0-omat-dielectric.model

## Validation

- complete Python/native suite: 132 passed, 1 skipped
- ASE field-aware energy, force, polarization, BEC, and polarizability comparisons cover both `float64` and `float32`
- extractor suite: 6 passed
- native field suite: 13 passed
- standard MACE regression suite: 16 passed
- LAMMPS single-rank field integration: 4 passed
- two-rank MPI field integration: 4 passed across `mpi_message_passing` and `no_mpi_message_passing`
- maximum MPI force error below `2.6e-11`
- all pre-commit hooks passed
