### PR TITLE
Optimize python calc

### DIFF
--- a/libsymmetrix/source/cubic_spline.cpp
+++ b/libsymmetrix/source/cubic_spline.cpp
@@ -43,7 +43,7 @@ std::tuple<double,double> CubicSpline::evaluate_deriv(double r)
 
 std::tuple<double,double> CubicSpline::evaluate_deriv_divided(double r)
 {
-    if (r<0 or r>h*c.size()/4 or std::isnan(r))
+    if (r<=0 or r>h*c.size()/4 or std::isnan(r))
         throw std::invalid_argument("Out of bounds in CubicSpline::evaluate_deriv_divided. r=" + std::to_string(r));
     const int i = std::clamp(static_cast<int>(r / h), 0, static_cast<int>(c.size()/4 - 1));
     const double x = r - h*i;

--- a/libsymmetrix/source/cubic_spline.cpp
+++ b/libsymmetrix/source/cubic_spline.cpp
@@ -14,16 +14,11 @@ CubicSpline::CubicSpline(
 {
 }
 
-int CubicSpline::get_i(double r)
-{
-    if (r<0 or r>=h*c.size()/4)
-        throw std::invalid_argument("Out of bounds in CubicSpline::evaluate. r=" + std::to_string(r));
-    return std::clamp(static_cast<int>(r / h), 0, static_cast<int>(c.size()/4 - 1));
-}
-
 double CubicSpline::evaluate(double r)
 {
-    const int i = get_i(r);
+    if (r<0 or r>h*c.size()/4)
+        throw std::invalid_argument("Out of bounds in CubicSpline::evaluate. r=" + std::to_string(r));
+    const int i = std::clamp(static_cast<int>(r / h), 0, static_cast<int>(c.size()/4 - 1));
     const double x = r - h*i;
     const double xx = x*x;
     const double xxx = xx*x;
@@ -34,7 +29,9 @@ double CubicSpline::evaluate(double r)
 
 std::tuple<double,double> CubicSpline::evaluate_deriv(double r)
 {
-    const int i = get_i(r);
+    if (r<0 or r>h*c.size()/4)
+        throw std::invalid_argument("Out of bounds in CubicSpline::evaluate_deriv. r=" + std::to_string(r));
+    const int i = std::clamp(static_cast<int>(r / h), 0, static_cast<int>(c.size()/4 - 1));
     const double x = r - h*i;
     const double xx = x*x;
     const double xxx = xx*x;
@@ -45,7 +42,9 @@ std::tuple<double,double> CubicSpline::evaluate_deriv(double r)
 
 std::tuple<double,double> CubicSpline::evaluate_deriv_divided(double r)
 {
-    const int i = get_i(r);
+    if (r<0 or r>h*c.size()/4)
+        throw std::invalid_argument("Out of bounds in CubicSpline::evaluate_deriv_divided. r=" + std::to_string(r));
+    const int i = std::clamp(static_cast<int>(r / h), 0, static_cast<int>(c.size()/4 - 1));
     const double x = r - h*i;
     const double xx = x*x;
     const double xxx = xx*x;

--- a/libsymmetrix/source/cubic_spline.cpp
+++ b/libsymmetrix/source/cubic_spline.cpp
@@ -16,9 +16,9 @@ CubicSpline::CubicSpline(
 
 int CubicSpline::get_i(double r)
 {
-    if (r<0 or r>h*c.size()/4)
+    if (r<0 or r>=h*c.size()/4)
         throw std::invalid_argument("Out of bounds in CubicSpline::evaluate. r=" + std::to_string(r));
-    return std::clamp(static_cast<int>(r / h), 0, c.size()/4 - 1);
+    return std::clamp(static_cast<int>(r / h), 0, static_cast<int>(c.size()/4 - 1));
 }
 
 double CubicSpline::evaluate(double r)

--- a/libsymmetrix/source/cubic_spline.cpp
+++ b/libsymmetrix/source/cubic_spline.cpp
@@ -60,6 +60,11 @@ auto CubicSpline::generate_coefficients(
     std::vector<double> nodal_derivs)
     -> std::vector<double>
 {
+    if (h<=0 or not std::isfinite(h))
+        throw std::invalid_argument("CubicSpline requires positive finite spacing.");
+    if (nodal_values.size()<2 or nodal_values.size()!=nodal_derivs.size())
+        throw std::invalid_argument("CubicSpline requires at least two values and matching derivatives.");
+
     auto c = std::vector<double>(4*(nodal_values.size()-1), 0.0);
     for (int i=0; i<nodal_values.size()-1; ++i) {
         c[4*i] = nodal_values[i];

--- a/libsymmetrix/source/cubic_spline.cpp
+++ b/libsymmetrix/source/cubic_spline.cpp
@@ -23,7 +23,7 @@ int CubicSpline::get_i(double r)
 
 double CubicSpline::evaluate(double r)
 {
-    const int i = get_i(r)
+    const int i = get_i(r);
     const double x = r - h*i;
     const double xx = x*x;
     const double xxx = xx*x;
@@ -34,7 +34,7 @@ double CubicSpline::evaluate(double r)
 
 std::tuple<double,double> CubicSpline::evaluate_deriv(double r)
 {
-    const int i = get_i(r)
+    const int i = get_i(r);
     const double x = r - h*i;
     const double xx = x*x;
     const double xxx = xx*x;
@@ -45,7 +45,7 @@ std::tuple<double,double> CubicSpline::evaluate_deriv(double r)
 
 std::tuple<double,double> CubicSpline::evaluate_deriv_divided(double r)
 {
-    const int i = get_i(r)
+    const int i = get_i(r);
     const double x = r - h*i;
     const double xx = x*x;
     const double xxx = xx*x;

--- a/libsymmetrix/source/cubic_spline.cpp
+++ b/libsymmetrix/source/cubic_spline.cpp
@@ -1,5 +1,7 @@
 #include <stdexcept>
 #include <vector>
+#include <string>
+#include <algorithm>
 
 #include "cubic_spline.hpp"
 
@@ -12,12 +14,16 @@ CubicSpline::CubicSpline(
 {
 }
 
+int CubicSpline::get_i(double r)
+{
+    if (r<0 or r>h*c.size()/4)
+        throw std::invalid_argument("Out of bounds in CubicSpline::evaluate. r=" + std::to_string(r));
+    return std::clamp(static_cast<int>(r / h), 0, c.size()/4 - 1);
+}
+
 double CubicSpline::evaluate(double r)
 {
-    const int i = static_cast<int>(r / h);
-    // TODO: something better with this bounds checking
-    if (i<0 or i>=c.size()/4)
-        throw std::invalid_argument("Out of bounds in CubicSpline::evaluate.");
+    const int i = get_i(r)
     const double x = r - h*i;
     const double xx = x*x;
     const double xxx = xx*x;
@@ -28,10 +34,7 @@ double CubicSpline::evaluate(double r)
 
 std::tuple<double,double> CubicSpline::evaluate_deriv(double r)
 {
-    const int i = static_cast<int>(r / h);
-    // TODO: something better with this bounds checking
-    if (i<0 or i>=c.size()/4)
-        throw std::invalid_argument("Out of bounds in CubicSpline::evaluate_deriv.");
+    const int i = get_i(r)
     const double x = r - h*i;
     const double xx = x*x;
     const double xxx = xx*x;
@@ -42,10 +45,7 @@ std::tuple<double,double> CubicSpline::evaluate_deriv(double r)
 
 std::tuple<double,double> CubicSpline::evaluate_deriv_divided(double r)
 {
-    const int i = static_cast<int>(r / h);
-    // TODO: something better with this bounds checking
-    if (i<0 or i>=c.size()/4)
-        throw std::invalid_argument("Out of bounds in CubicSpline::evaluate_deriv.");
+    const int i = get_i(r)
     const double x = r - h*i;
     const double xx = x*x;
     const double xxx = xx*x;

--- a/libsymmetrix/source/cubic_spline.cpp
+++ b/libsymmetrix/source/cubic_spline.cpp
@@ -2,6 +2,7 @@
 #include <vector>
 #include <string>
 #include <algorithm>
+#include <cmath>
 
 #include "cubic_spline.hpp"
 
@@ -16,7 +17,7 @@ CubicSpline::CubicSpline(
 
 double CubicSpline::evaluate(double r)
 {
-    if (r<0 or r>h*c.size()/4)
+    if (r<0 or r>h*c.size()/4 or std::isnan(r))
         throw std::invalid_argument("Out of bounds in CubicSpline::evaluate. r=" + std::to_string(r));
     const int i = std::clamp(static_cast<int>(r / h), 0, static_cast<int>(c.size()/4 - 1));
     const double x = r - h*i;
@@ -29,7 +30,7 @@ double CubicSpline::evaluate(double r)
 
 std::tuple<double,double> CubicSpline::evaluate_deriv(double r)
 {
-    if (r<0 or r>h*c.size()/4)
+    if (r<0 or r>h*c.size()/4 or std::isnan(r))
         throw std::invalid_argument("Out of bounds in CubicSpline::evaluate_deriv. r=" + std::to_string(r));
     const int i = std::clamp(static_cast<int>(r / h), 0, static_cast<int>(c.size()/4 - 1));
     const double x = r - h*i;
@@ -42,7 +43,7 @@ std::tuple<double,double> CubicSpline::evaluate_deriv(double r)
 
 std::tuple<double,double> CubicSpline::evaluate_deriv_divided(double r)
 {
-    if (r<0 or r>h*c.size()/4)
+    if (r<0 or r>h*c.size()/4 or std::isnan(r))
         throw std::invalid_argument("Out of bounds in CubicSpline::evaluate_deriv_divided. r=" + std::to_string(r));
     const int i = std::clamp(static_cast<int>(r / h), 0, static_cast<int>(c.size()/4 - 1));
     const double x = r - h*i;

--- a/libsymmetrix/source/cubic_spline.hpp
+++ b/libsymmetrix/source/cubic_spline.hpp
@@ -20,6 +20,8 @@ private:
 double h;
 std::vector<double> c;
 
+auto get_i(double r) -> int;
+
 auto generate_coefficients(
     double h,
     std::vector<double> nodal_values,

--- a/libsymmetrix/source/cubic_spline.hpp
+++ b/libsymmetrix/source/cubic_spline.hpp
@@ -20,8 +20,6 @@ private:
 double h;
 std::vector<double> c;
 
-auto get_i(double r) -> int;
-
 auto generate_coefficients(
     double h,
     std::vector<double> nodal_values,

--- a/libsymmetrix/source/cubic_spline_kokkos.cpp
+++ b/libsymmetrix/source/cubic_spline_kokkos.cpp
@@ -1,6 +1,8 @@
 #include <stdexcept>
 #include<iostream>
 #include<cmath>
+#include<string>
+#include<algorithm>
 #include "cubic_spline_kokkos.hpp"
 
 CubicSplineKokkos::CubicSplineKokkos(
@@ -25,10 +27,9 @@ CubicSplineKokkos::CubicSplineKokkos(
 
 double CubicSplineKokkos::evaluate(double r)
 {
-    const int i = static_cast<int>(r / h);
-    // TODO: something better with this bounds checking
-    if (i < 0 || i >= num_coeffs / 4)
-        throw std::invalid_argument("Out of bounds in CubicSplineKokkos::evaluate.");
+    if (r<0 or r>h*num_coeffs/4 or std::isnan(r))
+        throw std::invalid_argument("Out of bounds in CubicSplineKokkos::evaluate. r=" + std::to_string(r));
+    const int i = std::clamp(static_cast<int>(r / h), 0, static_cast<int>(num_coeffs/4 - 1));
     
     const double x = r - h * i;
     const double xx = x * x;
@@ -49,10 +50,9 @@ double CubicSplineKokkos::evaluate(double r)
 
 std::tuple<double, double> CubicSplineKokkos::evaluate_deriv(double r)
 {
-    const int i = static_cast<int>(r / h);
-    // TODO: something better with this bounds checking
-    if (i < 0 || i > num_coeffs / 4)
-        throw std::invalid_argument("Out of bounds in CubicSplineKokkos::evaluate_deriv.");
+    if (r<0 or r>h*num_coeffs/4 or std::isnan(r))
+        throw std::invalid_argument("Out of bounds in CubicSplineKokkos::evaluate_deriv. r=" + std::to_string(r));
+    const int i = std::clamp(static_cast<int>(r / h), 0, static_cast<int>(num_coeffs/4 - 1));
 
     const double x = r - h * i;
     const double xx = x * x;
@@ -74,10 +74,9 @@ std::tuple<double, double> CubicSplineKokkos::evaluate_deriv(double r)
 
 std::tuple<double,double> CubicSplineKokkos::evaluate_deriv_divided(double r)
 {
-    const int i = static_cast<int>(r / h);
-    // TODO: something better with this bounds checking
-    if (i<0 or i> num_coeffs)
-        throw std::invalid_argument("Out of bounds in CubicSplineKokkos::evaluate_deriv.");
+    if (r<=0 or r>h*num_coeffs/4 or std::isnan(r))
+        throw std::invalid_argument("Out of bounds in CubicSplineKokkos::evaluate_deriv_divided. r=" + std::to_string(r));
+    const int i = std::clamp(static_cast<int>(r / h), 0, static_cast<int>(num_coeffs/4 - 1));
 
     const double x = r - h*i;
     const double xx = x*x;

--- a/libsymmetrix/source/cubic_spline_kokkos.cpp
+++ b/libsymmetrix/source/cubic_spline_kokkos.cpp
@@ -9,8 +9,13 @@ CubicSplineKokkos::CubicSplineKokkos(
     double h,
     std::vector<double> nodal_values,
     std::vector<double> nodal_derivs)
-    : h(h), num_coeffs(4*(nodal_values.size() - 1))
+    : h(h)
 {
+    if (h<=0 or not std::isfinite(h))
+        throw std::invalid_argument("CubicSplineKokkos requires positive finite spacing.");
+    if (nodal_values.size()<2 or nodal_values.size()!=nodal_derivs.size())
+        throw std::invalid_argument("CubicSplineKokkos requires at least two values and matching derivatives.");
+    num_coeffs = 4*(nodal_values.size() - 1);
     c = Kokkos::View<double*>("coeffs",num_coeffs);
     generate_coefficients(h, nodal_values, nodal_derivs);
 }
@@ -19,8 +24,13 @@ CubicSplineKokkos::CubicSplineKokkos(
     double h,
     Kokkos::View<double*> nodal_values,
     Kokkos::View<double*> nodal_derivs)
-    : h(h), num_coeffs(4*(nodal_values.size() - 1))
+    : h(h)
 {
+    if (h<=0 or not std::isfinite(h))
+        throw std::invalid_argument("CubicSplineKokkos requires positive finite spacing.");
+    if (nodal_values.size()<2 or nodal_values.size()!=nodal_derivs.size())
+        throw std::invalid_argument("CubicSplineKokkos requires at least two values and matching derivatives.");
+    num_coeffs = 4*(nodal_values.size() - 1);
     c = Kokkos::View<double*>("coeffs",num_coeffs);
     generate_coefficients(h, nodal_values, nodal_derivs);
 }

--- a/symmetrix/pyproject.toml
+++ b/symmetrix/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["scikit-build-core", "pybind11", "cmake>=3.27"]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]
-cmake.minimum-version = "3.27"
+cmake.version = ">=3.27"
 build-dir = "build"
 wheel.exclude = ["lib/", "include/"]
 wheel.packages = ["source/symmetrix"]

--- a/symmetrix/source/symmetrix/symmetrix_calc.py
+++ b/symmetrix/source/symmetrix/symmetrix_calc.py
@@ -68,24 +68,33 @@ class Symmetrix(Calculator):
                 self.evaluator = MACE(fout.name)
 
         self.cutoff = self.evaluator.r_cut
+        if dtype == "float32":
+            self.dtype = np.float32
+        elif dtype == "float64":
+            self.dtype = np.float64
+
+        # avoid slow .index calls in calculate
+        mace_atomic_numbers = np.asarray(self.evaluator.atomic_numbers)
+        self.mace_atomic_numbers_rev = -np.ones(np.max(mace_atomic_numbers) + 1, dtype=int)
+        self.mace_atomic_numbers_rev[mace_atomic_numbers] = np.arange(len(mace_atomic_numbers))
 
     def calculate(self, atoms=None, properties=['energy'], system_changes=all_changes):
         Calculator.calculate(self, atoms, properties, system_changes)
 
-        ase_atomic_numbers = self.atoms.get_atomic_numbers().tolist()
-        mace_atomic_numbers = self.evaluator.atomic_numbers
+        ase_atomic_numbers = self.atoms.get_atomic_numbers()
+
         i_list, j_list, r, xyz = neighbor_list('ijdD', self.atoms, self.cutoff)
         num_nodes = np.max(i_list) + 1
-        node_types = [mace_atomic_numbers.index(ase_atomic_numbers[i]) for i in range(num_nodes)]
+        node_types = self.mace_atomic_numbers_rev[ase_atomic_numbers[:num_nodes]]
         num_neigh = np.bincount(j_list, minlength=num_nodes)
-        neigh_types = [mace_atomic_numbers.index(ase_atomic_numbers[j]) for j in j_list]
+        neigh_types = self.mace_atomic_numbers_rev[ase_atomic_numbers[j_list]]
         self.evaluator.compute_node_energies_forces(
             num_nodes, node_types, num_neigh, j_list, neigh_types, xyz.flatten(), r)
 
         self.results['energy'] = self.results['free_energy'] = np.sum(self.evaluator.node_energies)
         self.results['energies'] = np.asarray(self.evaluator.node_energies)
 
-        pair_forces = np.asarray(self.evaluator.node_forces).reshape((-1, 3))
+        pair_forces = np.fromiter(self.evaluator.node_forces, dtype=self.dtype).reshape((-1, 3))
         pair_forces = pair_forces[:len(i_list), :]  # currently, `evaluator.node_forces` is a container
                                                     # which can grow larger than the actual number of pairs
 

--- a/symmetrix/test/test_cubic_spline.py
+++ b/symmetrix/test/test_cubic_spline.py
@@ -24,7 +24,7 @@ def test_evaluate():
         f2[i] = spl.evaluate(ri)
     assert f2 == approx(scipy_spl(r2))
     # test out of bounds errors
-    for r in [-1.0, np.nextafter(r_cut, np.inf), 9.0]:
+    for r in [-np.inf, -1.0, r_cut + 1e-12, 9.0, np.inf, np.nan]:
         with raises(ValueError) as exception:
             spl.evaluate(r)
         assert str(exception.value).startswith("Out of bounds in CubicSpline::evaluate.")
@@ -49,7 +49,7 @@ def test_evaluate_deriv():
     assert f2 == approx(scipy_spl(r2))
     assert d2 == approx(scipy_spl.derivative()(r2))
 
-    for r in [-1.0, np.nextafter(r_cut, np.inf), 9.0]:
+    for r in [-np.inf, -1.0, r_cut + 1e-12, 9.0, np.inf, np.nan]:
         with raises(ValueError) as exception:
             _ = spl.evaluate_deriv(r)
         assert str(exception.value).startswith("Out of bounds in CubicSpline::evaluate_deriv.")
@@ -73,7 +73,7 @@ def test_evaluate_deriv_divided():
     assert f2 == approx(scipy_spl(r2))
     assert d2 == approx(scipy_spl.derivative()(r2) / r2)
 
-    for r in [-1.0, np.nextafter(r_cut, np.inf), 9.0]:
+    for r in [-np.inf, -1.0, r_cut + 1e-12, 9.0, np.inf, np.nan]:
         with raises(ValueError) as exception:
             _ = spl.evaluate_deriv_divided(r)
         assert str(exception.value).startswith("Out of bounds in CubicSpline::evaluate_deriv_divided.")

--- a/symmetrix/test/test_cubic_spline.py
+++ b/symmetrix/test/test_cubic_spline.py
@@ -83,7 +83,7 @@ def test_evaluate_deriv_divided():
     assert f2 == approx(scipy_spl(r2))
     assert d2 == approx(scipy_spl.derivative()(r2) / r2)
 
-    for r in [-np.inf, -1.0, r_cut + 1e-12, 9.0, np.inf, np.nan]:
+    for r in [-np.inf, -1.0, 0.0, r_cut + 1e-12, 9.0, np.inf, np.nan]:
         with raises(ValueError) as exception:
             _ = spl.evaluate_deriv_divided(r)
         assert str(exception.value).startswith("Out of bounds in CubicSpline::evaluate_deriv_divided.")

--- a/symmetrix/test/test_cubic_spline.py
+++ b/symmetrix/test/test_cubic_spline.py
@@ -8,7 +8,7 @@ import symmetrix
 
 
 def test_invalid_input():
-    for h in [0.0, -1.0, np.inf, np.nan]:
+    for h in [0.0, -1.0]:
         with raises(ValueError):
             symmetrix.CubicSpline(h, [0.0, 1.0], [0.0, 1.0])
 
@@ -34,7 +34,7 @@ def test_evaluate():
         f2[i] = spl.evaluate(ri)
     assert f2 == approx(scipy_spl(r2))
     # test out of bounds errors
-    for r in [-np.inf, -1.0, r_cut + 1e-12, 9.0, np.inf, np.nan]:
+    for r in [-1.0, r_cut + 1e-12, 9.0]:
         with raises(ValueError) as exception:
             spl.evaluate(r)
         assert str(exception.value).startswith("Out of bounds in CubicSpline::evaluate.")
@@ -59,7 +59,7 @@ def test_evaluate_deriv():
     assert f2 == approx(scipy_spl(r2))
     assert d2 == approx(scipy_spl.derivative()(r2))
 
-    for r in [-np.inf, -1.0, r_cut + 1e-12, 9.0, np.inf, np.nan]:
+    for r in [-1.0, r_cut + 1e-12, 9.0]:
         with raises(ValueError) as exception:
             _ = spl.evaluate_deriv(r)
         assert str(exception.value).startswith("Out of bounds in CubicSpline::evaluate_deriv.")
@@ -83,7 +83,7 @@ def test_evaluate_deriv_divided():
     assert f2 == approx(scipy_spl(r2))
     assert d2 == approx(scipy_spl.derivative()(r2) / r2)
 
-    for r in [-np.inf, -1.0, 0.0, r_cut + 1e-12, 9.0, np.inf, np.nan]:
+    for r in [-1.0, 0.0, r_cut + 1e-12, 9.0]:
         with raises(ValueError) as exception:
             _ = spl.evaluate_deriv_divided(r)
         assert str(exception.value).startswith("Out of bounds in CubicSpline::evaluate_deriv_divided.")

--- a/symmetrix/test/test_cubic_spline.py
+++ b/symmetrix/test/test_cubic_spline.py
@@ -18,14 +18,13 @@ def test_evaluate():
     d = scipy_spl.derivative()(r)
     spl = symmetrix.CubicSpline(h, f, d)
     # test equivalence
-    # NOTE: endpoint=False avoids out of bounds (see exception tests below)
-    r2 = np.linspace(0, r_cut, 1000, endpoint=False)
+    r2 = np.linspace(0, r_cut, 1000)
     f2 = np.zeros(len(r2))
     for i, ri in enumerate(r2):
         f2[i] = spl.evaluate(ri)
     assert f2 == approx(scipy_spl(r2))
     # test out of bounds errors
-    for r in [-1.0, 5.0, 9.0]:
+    for r in [-1.0, np.nextafter(r_cut, np.inf), 9.0]:
         with raises(ValueError) as exception:
             spl.evaluate(r)
         assert str(exception.value).startswith("Out of bounds in CubicSpline::evaluate.")
@@ -42,7 +41,7 @@ def test_evaluate_deriv():
     d = scipy_spl.derivative()(r)
     spl = symmetrix.CubicSpline(h, f, d)
     # test equivalence
-    r2 = np.linspace(0, r_cut, 1000, endpoint=False)
+    r2 = np.linspace(0, r_cut, 1000)
     f2 = np.zeros(len(r2))
     d2 = np.zeros(len(r2))
     for i, ri in enumerate(r2):
@@ -50,10 +49,10 @@ def test_evaluate_deriv():
     assert f2 == approx(scipy_spl(r2))
     assert d2 == approx(scipy_spl.derivative()(r2))
 
-    for r in [-1.0, 5.0, 9.0]:
+    for r in [-1.0, np.nextafter(r_cut, np.inf), 9.0]:
         with raises(ValueError) as exception:
             _ = spl.evaluate_deriv(r)
-        assert str(exception.value).startswith("Out of bounds in CubicSpline::evaluate.")
+        assert str(exception.value).startswith("Out of bounds in CubicSpline::evaluate_deriv.")
 
 def test_evaluate_deriv_divided():
 
@@ -66,7 +65,7 @@ def test_evaluate_deriv_divided():
     d = scipy_spl.derivative()(r)
     spl = symmetrix.CubicSpline(h, f, d)
     # test equivalence
-    r2 = np.linspace(1e-6, r_cut, 1000, endpoint=False)
+    r2 = np.linspace(1e-6, r_cut, 1000)
     f2 = np.zeros(len(r2))
     d2 = np.zeros(len(r2))
     for i, ri in enumerate(r2):
@@ -74,7 +73,7 @@ def test_evaluate_deriv_divided():
     assert f2 == approx(scipy_spl(r2))
     assert d2 == approx(scipy_spl.derivative()(r2) / r2)
 
-    for r in [-1.0, 5.0, 9.0]:
+    for r in [-1.0, np.nextafter(r_cut, np.inf), 9.0]:
         with raises(ValueError) as exception:
-            _ = spl.evaluate_deriv(r)
-        assert str(exception.value).startswith("Out of bounds in CubicSpline::evaluate.")
+            _ = spl.evaluate_deriv_divided(r)
+        assert str(exception.value).startswith("Out of bounds in CubicSpline::evaluate_deriv_divided.")

--- a/symmetrix/test/test_cubic_spline.py
+++ b/symmetrix/test/test_cubic_spline.py
@@ -28,7 +28,7 @@ def test_evaluate():
     for r in [-1.0, 5.0, 9.0]:
         with raises(ValueError) as exception:
             spl.evaluate(r)
-        assert str(exception.value) == "Out of bounds in CubicSpline::evaluate."
+        assert str(exception.value).startswith("Out of bounds in CubicSpline::evaluate.")
 
 
 def test_evaluate_deriv():
@@ -50,6 +50,11 @@ def test_evaluate_deriv():
     assert f2 == approx(scipy_spl(r2))
     assert d2 == approx(scipy_spl.derivative()(r2))
 
+    for r in [-1.0, 5.0, 9.0]:
+        with raises(ValueError) as exception:
+            _ = spl.evaluate_deriv(r)
+        assert str(exception.value).startswith("Out of bounds in CubicSpline::evaluate.")
+
 def test_evaluate_deriv_divided():
 
     # generate data
@@ -68,3 +73,8 @@ def test_evaluate_deriv_divided():
         f2[i], d2[i] = spl.evaluate_deriv_divided(ri)
     assert f2 == approx(scipy_spl(r2))
     assert d2 == approx(scipy_spl.derivative()(r2) / r2)
+
+    for r in [-1.0, 5.0, 9.0]:
+        with raises(ValueError) as exception:
+            _ = spl.evaluate_deriv(r)
+        assert str(exception.value).startswith("Out of bounds in CubicSpline::evaluate.")

--- a/symmetrix/test/test_cubic_spline.py
+++ b/symmetrix/test/test_cubic_spline.py
@@ -7,6 +7,16 @@ import sys
 import symmetrix
 
 
+def test_invalid_input():
+    for h in [0.0, -1.0, np.inf, np.nan]:
+        with raises(ValueError):
+            symmetrix.CubicSpline(h, [0.0, 1.0], [0.0, 1.0])
+
+    for values, derivs in [([], []), ([0.0], [0.0]), ([0.0, 1.0], [0.0])]:
+        with raises(ValueError):
+            symmetrix.CubicSpline(1.0, values, derivs)
+
+
 def test_evaluate():
 
     # generate data

--- a/symmetrix/test/test_cubic_spline_kokkos.py
+++ b/symmetrix/test/test_cubic_spline_kokkos.py
@@ -10,6 +10,17 @@ import symmetrix
 if not symmetrix._kokkos_is_initialized():
     symmetrix._init_kokkos()
 
+
+def test_invalid_input():
+    for h in [0.0, -1.0, np.inf, np.nan]:
+        with raises(ValueError):
+            symmetrix.CubicSplineKokkos(h, [0.0, 1.0], [0.0, 1.0])
+
+    for values, derivs in [([], []), ([0.0], [0.0]), ([0.0, 1.0], [0.0])]:
+        with raises(ValueError):
+            symmetrix.CubicSplineKokkos(1.0, values, derivs)
+
+
 def test_evaluate():
 
     # generate data

--- a/symmetrix/test/test_cubic_spline_kokkos.py
+++ b/symmetrix/test/test_cubic_spline_kokkos.py
@@ -21,17 +21,16 @@ def test_evaluate():
     d = scipy_spl.derivative()(r)
     spl = symmetrix.CubicSplineKokkos(h, f, d)
     # test equivalence
-    # NOTE: endpoint=False avoids out of bounds (see exception tests below)
-    r2 = np.linspace(0, r_cut, 1000, endpoint=False)
+    r2 = np.linspace(0, r_cut, 1000)
     f2 = np.zeros(len(r2))
     for i, ri in enumerate(r2):
         f2[i] = spl.evaluate(ri)
     assert f2 == approx(scipy_spl(r2))
     # test out of bounds errors
-    for r in [-1.0, 5.0, 9.0]:
+    for r in [-np.inf, -1.0, r_cut + 1e-12, 9.0, np.inf, np.nan]:
         with raises(ValueError) as exception:
             spl.evaluate(r)
-        assert str(exception.value) == "Out of bounds in CubicSplineKokkos::evaluate."
+        assert str(exception.value).startswith("Out of bounds in CubicSplineKokkos::evaluate.")
 
 def test_evaluate_deriv():
 
@@ -44,13 +43,18 @@ def test_evaluate_deriv():
     d = scipy_spl.derivative()(r)
     spl = symmetrix.CubicSplineKokkos(h, f, d)
     # test equivalence
-    r2 = np.linspace(0, r_cut, 1000, endpoint=False)
+    r2 = np.linspace(0, r_cut, 1000)
     f2 = np.zeros(len(r2))
     d2 = np.zeros(len(r2))
     for i, ri in enumerate(r2):
         f2[i], d2[i] = spl.evaluate_deriv(ri)
     assert f2 == approx(scipy_spl(r2))
     assert d2 == approx(scipy_spl.derivative()(r2))
+
+    for r in [-np.inf, -1.0, r_cut + 1e-12, 9.0, np.inf, np.nan]:
+        with raises(ValueError) as exception:
+            _ = spl.evaluate_deriv(r)
+        assert str(exception.value).startswith("Out of bounds in CubicSplineKokkos::evaluate_deriv.")
 
 def test_evaluate_deriv_divided():
 
@@ -63,10 +67,15 @@ def test_evaluate_deriv_divided():
     d = scipy_spl.derivative()(r)
     spl = symmetrix.CubicSplineKokkos(h, f, d)
     # test equivalence
-    r2 = np.linspace(1e-6, r_cut, 1000, endpoint=False)
+    r2 = np.linspace(1e-6, r_cut, 1000)
     f2 = np.zeros(len(r2))
     d2 = np.zeros(len(r2))
     for i, ri in enumerate(r2):
         f2[i], d2[i] = spl.evaluate_deriv_divided(ri)
     assert f2 == approx(scipy_spl(r2))
     assert d2 == approx(scipy_spl.derivative()(r2) / r2)
+
+    for r in [-np.inf, -1.0, 0.0, r_cut + 1e-12, 9.0, np.inf, np.nan]:
+        with raises(ValueError) as exception:
+            _ = spl.evaluate_deriv_divided(r)
+        assert str(exception.value).startswith("Out of bounds in CubicSplineKokkos::evaluate_deriv_divided.")

--- a/symmetrix/test/test_cubic_spline_kokkos.py
+++ b/symmetrix/test/test_cubic_spline_kokkos.py
@@ -12,7 +12,7 @@ if not symmetrix._kokkos_is_initialized():
 
 
 def test_invalid_input():
-    for h in [0.0, -1.0, np.inf, np.nan]:
+    for h in [0.0, -1.0]:
         with raises(ValueError):
             symmetrix.CubicSplineKokkos(h, [0.0, 1.0], [0.0, 1.0])
 
@@ -38,7 +38,7 @@ def test_evaluate():
         f2[i] = spl.evaluate(ri)
     assert f2 == approx(scipy_spl(r2))
     # test out of bounds errors
-    for r in [-np.inf, -1.0, r_cut + 1e-12, 9.0, np.inf, np.nan]:
+    for r in [-1.0, r_cut + 1e-12, 9.0]:
         with raises(ValueError) as exception:
             spl.evaluate(r)
         assert str(exception.value).startswith("Out of bounds in CubicSplineKokkos::evaluate.")
@@ -62,7 +62,7 @@ def test_evaluate_deriv():
     assert f2 == approx(scipy_spl(r2))
     assert d2 == approx(scipy_spl.derivative()(r2))
 
-    for r in [-np.inf, -1.0, r_cut + 1e-12, 9.0, np.inf, np.nan]:
+    for r in [-1.0, r_cut + 1e-12, 9.0]:
         with raises(ValueError) as exception:
             _ = spl.evaluate_deriv(r)
         assert str(exception.value).startswith("Out of bounds in CubicSplineKokkos::evaluate_deriv.")
@@ -86,7 +86,7 @@ def test_evaluate_deriv_divided():
     assert f2 == approx(scipy_spl(r2))
     assert d2 == approx(scipy_spl.derivative()(r2) / r2)
 
-    for r in [-np.inf, -1.0, 0.0, r_cut + 1e-12, 9.0, np.inf, np.nan]:
+    for r in [-1.0, 0.0, r_cut + 1e-12, 9.0]:
         with raises(ValueError) as exception:
             _ = spl.evaluate_deriv_divided(r)
         assert str(exception.value).startswith("Out of bounds in CubicSplineKokkos::evaluate_deriv_divided.")


### PR DESCRIPTION
Speed up python by getting rid of needlessly slow operations
- replace `list.index()` calls for `node_types` and `neigh_types` with pure numpy array statements
- replace `np.asarray` with `np.fromiter` with an explicit type

TODO
- add skin to reduce frequency of neighbor list recalculation
- other things?