### PR TITLE
[WIP] Speed up python calculator 

### DIFF
--- a/symmetrix/source/symmetrix/symmetrix_calc.py
+++ b/symmetrix/source/symmetrix/symmetrix_calc.py
@@ -68,24 +68,33 @@ class Symmetrix(Calculator):
                 self.evaluator = MACE(fout.name)
 
         self.cutoff = self.evaluator.r_cut
+        if dtype == "float32":
+            self.dtype = np.float32
+        elif dtype == "float64":
+            self.dtype = np.float64
+
+        # avoid slow .index calls in calculate
+        mace_atomic_numbers = np.asarray(self.evaluator.atomic_numbers)
+        self.mace_atomic_numbers_rev = -np.ones(np.max(mace_atomic_numbers) + 1, dtype=int)
+        self.mace_atomic_numbers_rev[mace_atomic_numbers] = np.arange(len(mace_atomic_numbers))
 
     def calculate(self, atoms=None, properties=['energy'], system_changes=all_changes):
         Calculator.calculate(self, atoms, properties, system_changes)
 
-        ase_atomic_numbers = self.atoms.get_atomic_numbers().tolist()
-        mace_atomic_numbers = self.evaluator.atomic_numbers
+        ase_atomic_numbers = self.atoms.get_atomic_numbers()
+
         i_list, j_list, r, xyz = neighbor_list('ijdD', self.atoms, self.cutoff)
         num_nodes = np.max(i_list) + 1
-        node_types = [mace_atomic_numbers.index(ase_atomic_numbers[i]) for i in range(num_nodes)]
+        node_types = self.mace_atomic_numbers_rev[ase_atomic_numbers[:num_nodes]]
         num_neigh = np.bincount(j_list, minlength=num_nodes)
-        neigh_types = [mace_atomic_numbers.index(ase_atomic_numbers[j]) for j in j_list]
+        neigh_types = self.mace_atomic_numbers_rev[ase_atomic_numbers[j_list]]
         self.evaluator.compute_node_energies_forces(
             num_nodes, node_types, num_neigh, j_list, neigh_types, xyz.flatten(), r)
 
         self.results['energy'] = self.results['free_energy'] = np.sum(self.evaluator.node_energies)
         self.results['energies'] = np.asarray(self.evaluator.node_energies)
 
-        pair_forces = np.asarray(self.evaluator.node_forces).reshape((-1, 3))
+        pair_forces = np.fromiter(self.evaluator.node_forces, dtype=self.dtype).reshape((-1, 3))
         pair_forces = pair_forces[:len(i_list), :]  # currently, `evaluator.node_forces` is a container
                                                     # which can grow larger than the actual number of pairs
 

--- a/symmetrix/source/symmetrix/symmetrix_calc.py
+++ b/symmetrix/source/symmetrix/symmetrix_calc.py
@@ -94,7 +94,9 @@ class Symmetrix(Calculator):
         self.results['energy'] = self.results['free_energy'] = np.sum(self.evaluator.node_energies)
         self.results['energies'] = np.asarray(self.evaluator.node_energies)
 
-        pair_forces = np.fromiter(self.evaluator.node_forces, dtype=self.dtype).reshape((-1, 3))
+        # for some reason seems to faster than putting self.evaluator.node_forces as arg to fromiter
+        pair_forces_l = self.evaluator.node_forces
+        pair_forces = np.fromiter(pair_forces_l, dtype=self.dtype).reshape((-1, 3))
         pair_forces = pair_forces[:len(i_list), :]  # currently, `evaluator.node_forces` is a container
                                                     # which can grow larger than the actual number of pairs
 


### PR DESCRIPTION
Avoid needlessly slow operations
- replace `list.index()` calls for `node_types` and `neigh_types` with pure numpy array syntax
- replace `pair_forces` `np.asarray` with faster `np.fromiter(..., dtype=...)` [maybe not faster?]

TODO
- add skin mechanism for recalculating neighbor lists less frequently, as in https://github.com/CheukHinHoJerry/torch-dftd or https://github.com/vicvaleeva/FourierD3/tree/main/src/fourierd3
- other things?

closes #92